### PR TITLE
docs: point workflows-disabled readme at tracking issue

### DIFF
--- a/.github/workflows-disabled/README.md
+++ b/.github/workflows-disabled/README.md
@@ -32,5 +32,4 @@ The only currently-live workflow is `.github/workflows/docker-dev.yml`,
 which guards out-of-the-box buildability of the dev Docker image. See
 issue #584 for context.
 
-Tracking issue for restoring (or deleting) the workflows in this folder:
-**see the fork's issue tracker.**
+Tracking issue for restoring (or deleting) the workflows in this folder: #586.


### PR DESCRIPTION
## Summary

- Replaces the placeholder line in `.github/workflows-disabled/README.md` with the actual tracking issue reference (#586).

In #585 I staged the README before opening the tracking issue, then edited the issue number in afterwards — but the edit never made it into the staged diff, so the placeholder shipped on `4.x`. This is the trivial follow-up.

## Test plan

- [ ] Confirm rendered README on `4.x` shows `Tracking issue ... #586.` and the line is a live link in the GitHub UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
