### PR TITLE
chore: verify node 20 migration and align stale references

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 php 8.1.0
-nodejs 16.15.0
+nodejs 20.19.6
 yarn 1.22.19

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -57,7 +57,7 @@ php composer-setup.php --install-dir=/usr/local/bin/ --filename=composer
 php -r "unlink('composer-setup.php');"
 ```
 
-**Node.js:** Install node.js 16+ minimum
+**Node.js:** Install Node.js 20 (matches the version declared in `package.json` and used by the Docker image and CI)
 
 
 **Yarn:** Install yarn using npm


### PR DESCRIPTION
## Summary

- Aligns the two stale Node 18-era declarations that PR #561 left behind so a fresh clone tells operators the same Node version no matter where they look (`package.json` / Docker / CI / `.tool-versions` / install docs).
- Documents a full Node 20 verification pass across the install, build, lint, and Cypress paths so issue #582 can close.

## Changes

- `.tool-versions`: `nodejs 16.15.0` → `nodejs 20.19.6` (asdf users were getting a Node 4 versions behind what `package.json` and the dev Docker image declare).
- `docs/installation/providers/generic.md`: "Install node.js 16+ minimum" → "Install Node.js 20" with the rationale that this matches `package.json`, the Docker image, and CI.

Nothing else needed updating — every other Node version entry point (`package.json` engines, the now-disabled GitHub workflows, the Dockerfile, related repo docs) was already on 20 after PR #561 and the workflow reset (#585).

## Verification (Node 20.19.6 / Yarn 1.22.19)

| Path | Result |
| --- | --- |
| `yarn run inst` | clean in 34.66s — peer-dep warnings present but identical to pre-bump baseline |
| `yarn run dev` | clean in 9.60s (Mix compile 5.32s) |
| `yarn run prod` | clean in 19.84s (Mix compile 16.96s); no tracked-file drift after build |
| `yarn run lint` | clean |
| `yarn run lint:cypress` | clean |
| `yarn run cy:verify` | clean — Cypress 7.7.0 verifies under host Node 20 |
| `cypress run` (auth specs, electron, against live Laravel) | both specs pass — see below |

Notes on the toolchain concerns called out in #582:

- **Cypress 7.x:** package declares 7.2.0 but yarn already resolves 7.7.0 (last 7.x). It bundles its own Node 14.15.1 for spec execution, so the host Node version only affects the CLI wrapper. `cy:verify` confirms the wrapper works on Node 20; the live spec run below confirms the bundled runtime works end-to-end against a real Laravel app.
- **ESLint 7-era tooling:** both `lint` and `lint:cypress` run clean on Node 20.19.6, which is well within ESLint 7.32.0's supported range.
- **Laravel Mix 6 / webpack 5 production minification:** prod build completes and emits the expected manifest — no terser/uglify breakage under Node 20.
- **`fsevents` on macOS:** install resolved natively, no rebuild prompts or skipped optional deps.

## Cypress live-app smoke

Local setup used for the smoke (kept out of tree — `.env` and screenshots removed):

- Dedicated MySQL 8.0 container on host port `:3308` (isolated from any other Compose stacks running on `:3306` / `:3307`).
- `php artisan migrate` + `php artisan db:seed` against that DB.
- `php artisan serve --host=127.0.0.1 --port=8001`.
- `npx cypress run --spec 'tests/cypress/integration/auth/**/*' --config baseUrl=http://127.0.0.1:8001,video=false --browser electron`.

Results:

| Spec | Result |
| --- | --- |
| `auth/signup_spec.js` — "should block registration if email is already used" | ✔ pass (8.4s) — exercises the Vue+Laravel registration form end-to-end with two real DB writes |
| `auth/login_spec.js` — "should not let user sign in with a non-existing account" | ✔ pass (2.1s) — exercises bad-credentials validation and `.alert` rendering |

The login spec initially failed on an unseeded DB because `cy.visit('/')` redirects to the first-install `/register` page when no users exist; after `php artisan db:seed`, the spec passes cleanly. This is a test-fixture quirk, not a Node 20 issue. (CI's own workflow seeds the DB before Cypress, so it would never have hit this state.)

### Broader specs (contacts / journal / settings) deliberately not run

These specs all open with `cy.login()`, which shells out via `cy.exec('php artisan setup:frontendtestuser')` and uses the resulting stdout as a Dusk login token. Under PHP 8.4 (the only PHP currently available on this machine), `php artisan` emits a stream of `Deprecated:` warnings to stdout *alongside* the token, so `cy.exec().stdout` returns garbage and the `/_dusk/login/<token>/` URL 404s.

That is a PHP 8.4 compat issue (rung 1 of the modernization ladder, tracked separately), **not** a Node 20 issue — it would block the same specs under Node 18 or any other Node version. Fixing it is out of scope for this PR; once PHP 8.1 / 8.2 is running again (whether via the dev Docker image, Sail, or asdf), the broader Cypress surface should run unchanged.

## Deliberately out of scope

- Re-enabling the Cypress CI workflow — separate follow-up tracked in #587.
- Fixing PHP 8.4 deprecation noise leaking into `cy.exec` stdout — separate concern on rung 1 of the modernization ladder.
- Sass deprecation warnings about `/`-division in `node_modules/font-awesome` — pre-existing, not Node-version-related, and the vendored stylesheet isn't in scope for this fork's modernization ladder.

## Test plan

- [x] `yarn run inst` clean under Node 20.19.6
- [x] `yarn run dev` succeeds and emits expected dev bundle
- [x] `yarn run prod` succeeds, prod bundle smaller than dev (as expected), no tracked-file drift
- [x] `yarn run lint` clean
- [x] `yarn run lint:cypress` clean
- [x] `yarn run cy:verify` clean
- [x] `cypress run` against live Laravel (auth specs) — both pass
- [ ] CI: defer until inherited workflows are re-enabled per #587 (and PHP 8.4 compat is addressed for the broader spec surface)

Closes #582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
