### PR TITLE
test(cypress): parse cy.login token defensively for PHP 8.4 stdout noise

### DIFF
--- a/tests/cypress/support/helpers/app.js
+++ b/tests/cypress/support/helpers/app.js
@@ -1,6 +1,10 @@
 Cypress.Commands.add('login', () => {
   cy.exec('php artisan setup:frontendtestuser').then((result) => {
-    cy.visit('/_dusk/login/'+result.stdout+'/');
+    // PHP versions with display_errors=on interleave deprecation
+    // warnings with the artisan command's stdout; the user id is
+    // always the last line emitted. See brycehans/monica#592.
+    const token = result.stdout.trim().split(/\r?\n/).pop().trim();
+    cy.visit('/_dusk/login/'+token+'/');
   });
 });
 


### PR DESCRIPTION
## Summary

- Implements option 1 from #592: parse the artisan token defensively in `cy.login()` so PHP 8.4 deprecation noise on stdout doesn't corrupt the constructed Dusk login URL.
- One-line behavioural change (plus a comment pointing at the issue). No artisan-side changes, no test-fixture changes, no environment changes.

## Change

```diff
 Cypress.Commands.add('login', () => {
   cy.exec('php artisan setup:frontendtestuser').then((result) => {
-    cy.visit('/_dusk/login/'+result.stdout+'/');
+    // PHP versions with display_errors=on interleave deprecation
+    // warnings with the artisan command's stdout; the user id is
+    // always the last line emitted. See brycehans/monica#592.
+    const token = result.stdout.trim().split(/\r?\n/).pop().trim();
+    cy.visit('/_dusk/login/'+token+'/');
   });
 });
```

The artisan command's contract is "the id is emitted last" (`$this->info($user->getKey())` in `app/Console/Commands/Tests/SetupFrontEndTestUser.php`), so taking the last non-empty line of stdout is correct under any PHP version — with or without deprecation noise.

## Verification

Local stack: PHP 8.4.12 + Laravel 9.52.16 + MySQL 8.0 (`monica-cy-mysql` container on `:3308`) + `php artisan serve --port=8001`, Cypress 7.7.0 / electron, Node 20.19.6.

| Scenario | URL `cy.visit()` saw | Result |
| --- | --- | --- |
| `4.x` HEAD before fix | `/_dusk/login/Deprecated: voku\helper\ASCII::… 4/` | 404 — login() fails on every spec |
| this branch (display_errors on, default) | `/_dusk/login/6/` | login() resolves, navigation reaches `/people` |
| this branch (display_errors off via `php -d display_errors=Off artisan serve`) | `/_dusk/login/6/` | same — token parse is decoupled from PHP error reporting |

End-to-end on the contacts spec, the first test ("lets you add a contact") now authenticates successfully and reaches `/people`. It then fails on `#button-add-contact` not being visible — that's an unrelated downstream issue (PHP 8.4 + PHP's built-in single-threaded webserver + asset serving), separate from the token-parse problem this PR is scoped to.

## What this does NOT fix

Two downstream issues that became visible once login was no longer corrupted:

- **PHP 8.4 deprecation output corrupting HTTP responses on the Dusk auth route.** When `display_errors=on`, deprecation lines can land in the response body and trip Cypress's bundled Node 14 strict HTTP parser ("Parse Error: Expected HTTP/"). Workaround: run the host server with `php -d display_errors=Off artisan serve`. Proper fix lives on the PHP 8.4 compat rung (META #1).
- **Vue assets / `#button-add-contact` not rendering on `/people` under `php artisan serve`.** Probably `php artisan serve` not serving the SPA bundle the way Apache does in the Docker image. Separate concern; not test-infra.

Neither of those is in scope here. This PR's job is to make `cy.login()` *robust* against stdout noise, not to make every spec pass on a host-PHP-8.4 setup that nobody normally runs against.

## Test plan

- [x] Diff is a one-liner + comment in `tests/cypress/support/helpers/app.js`
- [x] Token parse extracts the bare id under PHP 8.4 with deprecation noise on stdout
- [x] First contact spec authenticates through `cy.login()` end-to-end (URL is clean, Dusk bridge resolves, `/people` loads)
- [ ] CI: defer until inherited Cypress workflow is re-enabled per #586 (CI uses PHP 8.2, which doesn't emit these specific deprecations, so the fix is a no-op there but doesn't regress)

Closes #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
