### PR TITLE
fix(docker-dev): pin mysql to 8.0 and lock remaining image tags

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
       - ./routes:/var/www/html/routes
 
   mysql:
-    image: mysql:8
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_ROOT_PASSWORD=sekret_root_password
@@ -37,7 +37,7 @@ services:
       - /var/lib/mysql
 
   phpmyadmin:
-    image: phpmyadmin
+    image: phpmyadmin:5.2
     depends_on:
       - mysql
     environment:
@@ -52,7 +52,7 @@ services:
 
   mail:
     container_name: fake_mail
-    image: mailhog/mailhog
+    image: mailhog/mailhog:v1.0.1
     ports:
       - 8025:8025
       - 1025:1025


### PR DESCRIPTION
## Summary

- Pins `mysql:8` → `mysql:8.0` so the dev stack no longer breaks when `mysql:8` resolves to 8.4 (which removed `--default-authentication-plugin`)
- Pins `phpmyadmin` → `phpmyadmin:5.2` for repeatability
- Pins `mailhog/mailhog` → `mailhog/mailhog:v1.0.1` for repeatability

Closes #596

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml up -d` on a fresh image pull brings up all four containers cleanly
- [ ] `docker logs <mysql-container>` shows no `unknown variable` errors
- [ ] App container reaches Apache-serving state and returns 302 from `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
