### PR TITLE
fix(docker-dev): add dev build stage so composer dev deps are present in monica:dev image

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: .
       dockerfile: scripts/docker/Dockerfile
+      target: dev
     image: monica:dev
     depends_on:
       - mysql

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -6,7 +6,7 @@
 ### This file is based off of the `apache` variant in the above mentioned repo
 ###
 
-FROM php:8.1-apache
+FROM php:8.1-apache AS base
 
 # opencontainers annotations https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.authors="Alexis Saettler <alexis@saettler.org>" \
@@ -179,3 +179,14 @@ COPY scripts/docker/entrypoint.sh \
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["apache2-foreground"]
+
+###
+### Dev stage — extends base, adds Composer dev dependencies
+###
+FROM base AS dev
+
+RUN set -ex; \
+    \
+    composer install --no-interaction --no-progress; \
+    composer clear-cache; \
+    rm -rf .composer


### PR DESCRIPTION
## Summary

- Names the existing single `FROM php:8.1-apache` stage as `base` (production, `--no-dev`)
- Appends a `dev` stage that re-runs `composer install` without `--no-dev`, bringing in `laravel/legacy-factories`, `laravel/dusk`, `phpunit/phpunit`, etc.
- Adds `target: dev` to `docker-compose.dev.yml` so the dev stack builds the `dev` stage explicitly

## Why

`php artisan setup:frontendtestuser` (which `cy.login()` depends on) was failing inside the dev container:

```
Call to undefined function App\Console\Commands\Tests\factory()
```

Because the image was built with `composer install --no-dev`, the `factory()` helper from `laravel/legacy-factories` was absent.

## Test plan

- [x] `vendor/laravel/legacy-factories/`, `vendor/laravel/dusk/`, `vendor/phpunit/phpunit/` all present in `monica:dev` image
- [x] `php -r "require 'vendor/autoload.php'; var_dump(function_exists('factory'));"` → `bool(true)` inside dev container
- [x] `--target base` image is free of dev deps (`vendor/laravel/legacy-factories/` absent)
- [ ] `docker exec monica-dev-app-1 php artisan setup:frontendtestuser` succeeds against a running dev stack
- [ ] `yarn run e2e` passes with `cy.login()` working against the dev stack

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
