### PR TITLE
test: fix cypress suite against docker stack

### DIFF
--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -59,6 +59,13 @@ between runs. See `docker-compose.yml` for examples.
 CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 yarn run e2e
 ```
 
+The project expects Node 20 for frontend tooling. If your shell is on another
+Node version, run Cypress through your Node version manager, for example:
+
+```sh
+CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 fnm exec --using=20 yarn run e2e
+```
+
 The container name defaults to `monica-app-1` (Docker Compose's default when
 the working directory is named `monica`). Override it if your setup differs:
 

--- a/tests/cypress/integration/auth/login_spec.js
+++ b/tests/cypress/integration/auth/login_spec.js
@@ -4,7 +4,7 @@ describe('Login', function () {
 
     cy.get('input[name=email]').type('impossibru@test.com');
     cy.get('input[name=password]').type('testtest');
-    cy.get('button[type=submit]').click();
+    cy.get('button.btn-primary[type=submit]').click();
 
     cy.get('.alert').should('exist');
   });

--- a/tests/cypress/integration/contacts/calls_spec.js
+++ b/tests/cypress/integration/contacts/calls_spec.js
@@ -9,7 +9,7 @@ describe('Calls', function () {
   it('lets you manage a call', function () {
     cy.url().should('include', '/people/h:');
     cy.get('[cy-name=calls-blank-state]').should('exist');
-    cy.get('[cy-name=log-call-form]').should('not.be.visible');
+    cy.get('[cy-name=log-call-form]').should('not.exist');
     cy.get('[cy-name=last-talked-to]').should('contain', 'unknown');
 
     // add a call

--- a/tests/cypress/integration/contacts/contacts_spec.js
+++ b/tests/cypress/integration/contacts/contacts_spec.js
@@ -76,7 +76,7 @@ describe('Contacts', function () {
     // tests if the favorite button can be toggled
     cy.get('[cy-name=set-favorite]').should('be.visible');
     cy.get('[cy-name=set-favorite]').click();
-    cy.get('[cy-name=set-favorite]').should('not.be.visible');
+    cy.get('[cy-name=set-favorite]').should('not.exist');
     cy.get('[cy-name=unset-favorite]').should('be.visible');
     cy.get('[cy-name=unset-favorite]').click();
     cy.get('[cy-name=set-favorite]').should('be.visible');

--- a/tests/cypress/integration/contacts/conversations_spec.js
+++ b/tests/cypress/integration/contacts/conversations_spec.js
@@ -22,6 +22,6 @@ describe('Conversations', function () {
     cy.get('[cy-name=save-conversation-button]').click();
 
     cy.url().should('include', '/people/h:');
-    cy.get('[cy-name=conversation-blank-state]').should('not.be.visible');
+    cy.get('[cy-name=conversation-blank-state]').should('not.exist');
   });
 });

--- a/tests/cypress/integration/contacts/debts_spec.js
+++ b/tests/cypress/integration/contacts/debts_spec.js
@@ -17,7 +17,7 @@ describe('Debts', function () {
     cy.get('[cy-name=save-debt-button]').click();
 
     cy.url().should('include', '/people/h:');
-    cy.get('[cy-name=debt-blank-state]').should('not.be.visible');
+    cy.get('[cy-name=debt-blank-state]').should('not.exist');
 
     cy.get('[cy-name=debts-body]').should('be.visible')
       .invoke('attr', 'cy-items').then(function (item) {

--- a/tests/cypress/integration/contacts/introductions_spec.js
+++ b/tests/cypress/integration/contacts/introductions_spec.js
@@ -27,7 +27,7 @@ describe('Introduction', function () {
     cy.url().should('include', '/introductions/edit');
 
     cy.get('textarea[name=first_met_additional_info]').type('Lorem ipsum');
-    cy.get('#metThrough > .v-select input').click();
+    cy.get('#metThrough input[type=search]').click();
     cy.get('#metThrough ul[role="listbox"]').contains('John Doe');
     cy.get('#metThrough ul[role="listbox"]').contains('Jane Doe');
     cy.get('#metThrough ul[role="listbox"]').contains('Joe Shmoe');

--- a/tests/cypress/integration/contacts/notes_spec.js
+++ b/tests/cypress/integration/contacts/notes_spec.js
@@ -6,7 +6,7 @@ describe('Notes', function () {
 
   it('lets you manage a note', function () {
     cy.url().should('include', '/people/h:');
-    cy.get('[cy-name=add-note-button]').should('not.be.visible');
+    cy.get('[cy-name=add-note-button]').should('not.exist');
 
     // add a note
     cy.get('[cy-name=add-note-textarea]').click();

--- a/tests/cypress/integration/journal/entries_spec.js
+++ b/tests/cypress/integration/journal/entries_spec.js
@@ -17,7 +17,7 @@ describe('Journal entries', function () {
     cy.get('[cy-name=save-entry-button]').click();
 
     cy.url().should('include', '/journal');
-    cy.get('[cy-name=journal-blank-state]').should('not.be.visible');
+    cy.get('[cy-name=journal-blank-state]').should('not.exist');
 
     cy.get('[cy-name=journal-entries-body]').should('be.visible')
       .invoke('attr', 'cy-items').then(function (item) {
@@ -29,6 +29,7 @@ describe('Journal entries', function () {
 
             // delete a journal entry
             cy.get('[cy-name=entry-delete-button-'+objItem+']').click();
+            cy.get('[cy-name=confirm-]:visible').click();
             cy.url().should('include', '/journal');
             cy.get('[cy-name=entry-body-'+item+']').should('not.exist');
           });
@@ -40,7 +41,7 @@ describe('Journal entries', function () {
 
     cy.visit('/journal');
 
-    cy.get('[cy-name=journal-blank-state]').should('not.be.visible');
+    cy.get('[cy-name=journal-blank-state]').should('not.exist');
 
     cy.get('[cy-name=journal-entries-body]').should('be.visible').then((entries) => {
       let item = entries[0].getAttribute('cy-items');

--- a/tests/cypress/integration/settings/activity_types_spec.js
+++ b/tests/cypress/integration/settings/activity_types_spec.js
@@ -1,11 +1,16 @@
 var _ = require('lodash');
 
 describe('Settings: activity types', function () {
+  afterEach(function () {
+    cy.clearCachedConfig();
+  });
+
   it('doesn\'t let you manage activity types if user is not premium', function () {
+    cy.setRequiresSubscription(true);
     cy.login();
     cy.visit('/settings/personalization');
     cy.get('[cy-name=activity-type-premium-message]').should('be.visible');
-    cy.get('[cy-name=activity-type-edit-button]').should('not.exist');
+    cy.get('[cy-name=add-activity-type-category-button]').should('not.exist');
   });
 
   it('lets you manage an activity type category and activity type', function () {
@@ -19,13 +24,13 @@ describe('Settings: activity types', function () {
 
     // make sure that going premium removes restrictions
     cy.visit('/settings/personalization');
-    cy.get('[cy-name=activity-type-premium-message]').should('not.be.visible');
+    cy.get('[cy-name=activity-type-premium-message]').should('not.exist');
     cy.get('[cy-name=activity-types]').should('contain', 'played a sport together');
 
     // add an activity type category
     cy.get('[cy-name=add-activity-type-category-button]').click();
     cy.get('.sweet-modal-overlay').should('be.visible');
-    cy.get('[name=add-category-name]').type('This is an activity type category');
+    cy.get('[name=add-category-name]:visible').type('This is an activity type category');
     cy.get('[cy-name=add-activity-type-category-save-button]').click();
     cy.wait(10);
 
@@ -36,15 +41,15 @@ describe('Settings: activity types', function () {
       // edit an activity type category
       cy.get('[cy-name=activity-type-category-edit-button-'+item+']').click();
       cy.get('.sweet-modal-overlay').should('be.visible');
-      cy.get('[name=update-category-name]').clear();
-      cy.get('[name=update-category-name]').type('This is still an activity type category');
+      cy.get('[name=update-category-name]:visible').clear();
+      cy.get('[name=update-category-name]:visible').type('This is still an activity type category');
       cy.get('[cy-name=update-activity-type-category-button]').click();
       cy.get('[cy-name=activity-types]').should('contain', 'This is still an activity type category');
 
       // add an activity type
       cy.get('[cy-name=add-activity-type-button-for-category-'+item+']').click();
       cy.get('.sweet-modal-overlay').should('be.visible');
-      cy.get('[name=add-type-name]').type('This is activity type 1');
+      cy.get('[name=add-type-name]:visible').type('This is activity type 1');
       cy.get('[cy-name=add-type-button]').click();
       cy.get('[cy-name=activity-types]').should('contain', 'This is activity type 1');
 
@@ -54,8 +59,8 @@ describe('Settings: activity types', function () {
 
         cy.get('[cy-name=activity-type-edit-button-'+aitem+']').click();
         cy.get('.sweet-modal-overlay').should('be.visible');
-        cy.get('[name=update-type-name]').clear();
-        cy.get('[name=update-type-name]').type('This is modified activity type 1');
+        cy.get('[name=update-type-name]:visible').clear();
+        cy.get('[name=update-type-name]:visible').type('This is modified activity type 1');
         cy.get('[cy-name=update-type-button]').click();
         cy.wait(10);
         cy.get('[cy-name=activity-types]').should('contain', 'This is modified activity type 1');
@@ -64,7 +69,7 @@ describe('Settings: activity types', function () {
       // delete an activity type
       cy.get('[cy-name=add-activity-type-button-for-category-'+item+']').click();
       cy.get('.sweet-modal-overlay').should('be.visible');
-      cy.get('[name=add-type-name]').type('This is activity type 2');
+      cy.get('[name=add-type-name]:visible').type('This is activity type 2');
       cy.get('[cy-name=add-type-button]').click();
       cy.get('[cy-name=activity-types]').should('contain', 'This is activity type 2');
 
@@ -96,13 +101,13 @@ describe('Settings: activity types', function () {
 
     // make sure that going premium removes restrictions
     cy.visit('/settings/personalization');
-    cy.get('[cy-name=activity-type-premium-message]').should('not.be.visible');
+    cy.get('[cy-name=activity-type-premium-message]').should('not.exist');
     cy.get('[cy-name=activity-types]').should('contain', 'played a sport together');
 
     // add an activity type category
     cy.get('[cy-name=add-activity-type-category-button]').click();
     cy.get('.sweet-modal-overlay').should('be.visible');
-    cy.get('[name=add-category-name]').type('This is an activity type category');
+    cy.get('[name=add-category-name]:visible').type('This is an activity type category');
     cy.get('[cy-name=add-activity-type-category-save-button]').click();
 
     cy.get('[cy-name=activity-types]').should('contain', 'This is an activity type category');
@@ -112,15 +117,15 @@ describe('Settings: activity types', function () {
       // edit an activity type category
       cy.get('[cy-name=activity-type-category-edit-button-'+item+']').click();
       cy.get('.sweet-modal-overlay').should('be.visible');
-      cy.get('[name=update-category-name]').clear();
-      cy.get('[name=update-category-name]').type('This is still an activity type category');
+      cy.get('[name=update-category-name]:visible').clear();
+      cy.get('[name=update-category-name]:visible').type('This is still an activity type category');
       cy.get('[cy-name=update-activity-type-category-button]').click();
       cy.get('[cy-name=activity-types]').should('contain', 'This is still an activity type category');
 
       // add an activity type
       cy.get('[cy-name=add-activity-type-button-for-category-'+item+']').click();
       cy.get('.sweet-modal-overlay').should('be.visible');
-      cy.get('[name=add-type-name]').type('This is activity type 1');
+      cy.get('[name=add-type-name]:visible').type('This is activity type 1');
       cy.get('[cy-name=add-type-button]').click();
       cy.get('[cy-name=activity-types]').should('contain', 'This is activity type 1');
 

--- a/tests/cypress/support/helpers/app.js
+++ b/tests/cypress/support/helpers/app.js
@@ -26,6 +26,16 @@ Cypress.Commands.add('setPremium', (accountId) => {
   cy.exec(artisan('php artisan account:setpremium ' + accountId));
 });
 
+Cypress.Commands.add('setRequiresSubscription', (requiresSubscription) => {
+  const value = requiresSubscription ? 'true' : 'false';
+
+  cy.exec(artisan('sh -lc "REQUIRES_SUBSCRIPTION=' + value + ' php artisan config:cache"'));
+});
+
+Cypress.Commands.add('clearCachedConfig', () => {
+  cy.exec(artisan('php artisan config:clear'));
+});
+
 Cypress.Commands.add('register', (firstName, lastName, password, email, policy) => {
   cy.visit('/register');
 
@@ -38,5 +48,5 @@ Cypress.Commands.add('register', (firstName, lastName, password, email, policy) 
   if (policy) {
     cy.get('input[name=policy]').click();
   }
-  cy.get('button[type=submit]').click();
+  cy.get('button.btn-primary[type=submit]').click();
 });

--- a/tests/cypress/support/helpers/contacts.js
+++ b/tests/cypress/support/helpers/contacts.js
@@ -23,7 +23,7 @@ Cypress.Commands.add('createActivity', () => {
   cy.get('[cy-name=save-activity-button]').click();
 
   cy.url().should('include', '/people/h:');
-  cy.get('[cy-name=activities-blank-state]').should('not.be.visible');
+  cy.get('[cy-name=activities-blank-state]').should('not.exist');
 
   cy.get('[cy-name=activities-body]').should('be.visible').then((activities) => {
     let item = activities[0].getAttribute('cy-items');


### PR DESCRIPTION
## Summary
- Fix Cypress assertions that expected hidden elements when the app removes them with `v-if` or Blade conditionals.
- Tighten stale selectors for auth submit buttons, vue-select, SweetModal fields, and journal deletion confirmation.
- Keep the activity-types non-premium branch covered by temporarily enabling subscription-required config for that spec.

Fixes #602.

## Verification
- `fnm exec --using=20 yarn run lint:cypress`
- `CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 fnm exec --using=20 yarn run e2e`
