### PR TITLE
ci: skip docker build for docs and tests

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -27,9 +27,19 @@ on:
     branches:
       - 4.x
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'docs/**'
+      - 'tests/**'
+      - '*.md'
+      - '.migration/**'
   push:
     branches:
       - 4.x
+    paths-ignore:
+      - 'docs/**'
+      - 'tests/**'
+      - '*.md'
+      - '.migration/**'
 
 concurrency:
   group: OOTB Docker build ${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to the OOTB Docker build workflow.
- Skip the Docker image build for PRs and pushes that only touch `docs/**` or `tests/**`.
- Keep the workflow broad for any mixed change that includes build-relevant files.

## Verification
- Inspected `.github/workflows/docker-dev.yml` trigger syntax.
