### PR TITLE
fix: disable display_errors for http requests in public/index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -9,6 +9,8 @@
 
 define('LARAVEL_START', microtime(true));
 
+ini_set('display_errors', 'Off');
+
 /*
 |--------------------------------------------------------------------------
 | Register The Auto Loader


### PR DESCRIPTION
## Summary

- Add `ini_set('display_errors', 'Off')` at the top of `public/index.php`, before the autoloader.

Laravel routes all errors through its own exception handler (Ignition in dev, JSON for API routes). PHP's `display_errors` operates below the framework and writes raw deprecation/warning text directly to stdout before headers are sent — corrupting the HTTP response envelope. This is a best-practice Laravel hardening that is correct regardless of PHP version, and also closes the PHP 8.4 response-corruption issue tracked in #594.

Errors still reach `storage/logs/laravel.log` via `log_errors`.

## Test plan

- [x] `php artisan serve` + visit app locally — Ignition error pages still render, no regression
- [x] `yarn run test` passes (PHP 8.1)
- [x] Under PHP 8.4: response bodies are no longer prefixed with `Deprecated:` lines

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
