### PR TITLE
test: fix phpunit suite against docker stack

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -15,6 +15,12 @@ DB_USERNAME=homestead
 DB_PASSWORD=secret
 DB_PREFIX=
 
+DB_TEST_HOST=mysql
+DB_TEST_PORT=3306
+DB_TEST_DATABASE=monica_test
+DB_TEST_USERNAME=homestead
+DB_TEST_PASSWORD=secret
+
 # Mail credentials used to send emails from the application.
 MAIL_MAILER=smtp
 MAIL_HOST=fake_mail

--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -49,6 +49,36 @@ restart the container. Map a volume to
 `/var/www/monica/storage/app/public` if you want that data to persist
 between runs. See `docker-compose.yml` for examples.
 
+## Running PHPUnit inside the Docker dev stack
+
+The dev stack runs tests directly inside the `app` container:
+
+```sh
+docker exec monica-app-1 yarn run migrate     # migrate + seed the testing DB
+docker exec monica-app-1 vendor/bin/phpunit   # run the suite
+```
+
+`yarn run migrate` runs `php artisan migrate:fresh --seed` with `DB_CONNECTION=testing`, which reads the `DB_TEST_*` block from `.env.dev`. The default `.env.dev` points those at `mysql` (the Docker service name) and the `monica_test` database, both of which must exist:
+
+```sh
+docker exec monica-mysql-1 mysql -u root -psekret_root_password \
+  -e "CREATE DATABASE IF NOT EXISTS monica_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; \
+      GRANT ALL ON monica_test.* TO 'homestead'@'%';"
+```
+
+### Why `phpunit.xml` uses `force="true"` and a custom bootstrap
+
+PHPUnit's `<env>` directive normally only writes to `putenv()` and `$_ENV`. It does **not** touch `$_SERVER`. When `docker compose` loads `env_file: .env.dev`, the container's `APP_ENV=local` lands in `$_SERVER`, and Laravel's `Env::get()` reads `$_SERVER` first — so `config('app.env')` returns `local` even when `phpunit.xml` says `testing`.
+
+Symptoms when this is broken: feature tests get 302 redirects to `/` on every POST. CSRF middleware's `runningUnitTests()` check fails because `APP_ENV !== 'testing'`, `TokenMismatchException` fires, and the app's custom exception handler turns it into a redirect to `loginRedirect`.
+
+Two pieces keep this working:
+
+1. **`force="true"` on the critical `<env>` overrides in `phpunit.xml`** — `APP_ENV`, `APP_KEY`, `BCRYPT_ROUNDS`, `DB_CONNECTION`. Without it, PHPUnit's `<env>` is a no-op when the same name already exists in the process environment (which it does in Docker).
+2. **`tests/bootstrap.php`** — runs after PHPUnit applies its `<env>` block and copies `$_ENV` over `$_SERVER` so Laravel's `Env::get()` sees the testing values.
+
+If you ever see a wave of feature-test 302s after touching test config or the Docker stack, check `$_SERVER['APP_ENV']` inside a middleware before chasing it through the auth stack.
+
 ## Running Cypress against the Docker dev stack
 
 `cy.exec()` always runs on the host shell, not inside the container. Set

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
   backupGlobals="false"
   backupStaticAttributes="false"
-  bootstrap="vendor/autoload.php"
+  bootstrap="tests/bootstrap.php"
   colors="true"
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
@@ -53,10 +53,10 @@
   </testsuites>
 
   <php>
-    <env name="APP_ENV" value="testing"/>
-    <env name="APP_KEY" value="base64:NTrXToqFZJlv48dgPc+kNpc3SBt333TfDnF1mDShsBg="/>
-    <env name="BCRYPT_ROUNDS" value="4"/>
-    <env name="DB_CONNECTION" value="testing"/>
+    <env name="APP_ENV" value="testing" force="true"/>
+    <env name="APP_KEY" value="base64:NTrXToqFZJlv48dgPc+kNpc3SBt333TfDnF1mDShsBg=" force="true"/>
+    <env name="BCRYPT_ROUNDS" value="4" force="true"/>
+    <env name="DB_CONNECTION" value="testing" force="true"/>
     <env name="CACHE_DRIVER" value="array"/>
     <env name="CHECK_VERSION" value="false"/>
     <env name="MAIL_MAILER" value="array"/>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+
+foreach ($_ENV as $key => $value) {
+    if (! array_key_exists($key, $_SERVER) || $_SERVER[$key] !== $value) {
+        $_SERVER[$key] = $value;
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes the 149 phpunit failures and CSRF-driven 302 redirects on every authenticated POST when running `vendor/bin/phpunit` inside the docker dev stack (issue #606).
- Root cause: `docker compose`'s `env_file` puts variables in `$_SERVER`, and Laravel's `Env::get()` reads `$_SERVER` before `$_ENV`. PHPUnit's `<env>` directive only writes to `putenv()`/`$_ENV`, so `APP_ENV=local` from `.env.dev` leaked into the test environment, CSRF middleware's `runningUnitTests()` check returned false, and the custom exception handler converted `TokenMismatchException` into a redirect to `loginRedirect` — looking exactly like a generic auth failure.
- Fix has three pieces: a `tests/bootstrap.php` shim that copies `$_ENV` into `$_SERVER` after PHPUnit applies its env block, `force="true"` on the critical phpunit.xml overrides (`APP_ENV`, `APP_KEY`, `BCRYPT_ROUNDS`, `DB_CONNECTION`), and a `DB_TEST_*` block in `.env.dev` pointing at the `mysql` service and `monica_test` database.

`docs/contribute/docker.md` gets a new section documenting the pitfall and how the three pieces interact, so the next person sees this trap before they spend an hour chasing 302s through the middleware stack.

## Test plan

- [ ] One-time setup: `docker exec monica-mysql-1 mysql -u root -psekret_root_password -e "CREATE DATABASE IF NOT EXISTS monica_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; GRANT ALL ON monica_test.* TO 'homestead'@'%';"`
- [ ] Recreate the app container so it picks up the new `.env.dev` vars: `docker compose -f docker-compose.dev.yml up -d --force-recreate app`
- [ ] `docker exec monica-app-1 yarn run migrate` — fresh + seed the testing DB
- [ ] `docker exec monica-app-1 vendor/bin/phpunit` — full suite should pass with only the pre-existing 12 skips (locally: 1668 tests, 0 failures)
- [ ] phpstan errors documented in #606 are unrelated to this PR and are still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)
