### PR TITLE
fix: correct $fillable/$with PHPDoc types in models

### DIFF
--- a/app/Models/Account/Account.php
+++ b/app/Models/Account/Account.php
@@ -66,7 +66,7 @@ class Account extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'number_of_invitations_sent',

--- a/app/Models/Account/Activity.php
+++ b/app/Models/Account/Activity.php
@@ -45,7 +45,7 @@ class Activity extends Model implements IsJournalableInterface
     /**
      * The relations to eager load on every query.
      *
-     * @var array
+     * @var array<int, string>
      */
     protected $with = [
         'account',

--- a/app/Models/Account/ActivityStatistic.php
+++ b/app/Models/Account/ActivityStatistic.php
@@ -12,7 +12,7 @@ class ActivityStatistic extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Account/ActivityType.php
+++ b/app/Models/Account/ActivityType.php
@@ -16,7 +16,7 @@ class ActivityType extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Account/ActivityTypeCategory.php
+++ b/app/Models/Account/ActivityTypeCategory.php
@@ -18,7 +18,7 @@ class ActivityTypeCategory extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Account/AddressBook.php
+++ b/app/Models/Account/AddressBook.php
@@ -19,7 +19,7 @@ class AddressBook extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Account/AddressBookSubscription.php
+++ b/app/Models/Account/AddressBookSubscription.php
@@ -21,7 +21,7 @@ class AddressBookSubscription extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',
@@ -70,7 +70,7 @@ class AddressBookSubscription extends Model
     /**
      * Eager load account with every contact.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $with = [
         'user',

--- a/app/Models/Account/Company.php
+++ b/app/Models/Account/Company.php
@@ -14,7 +14,7 @@ class Company extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'weather_json',

--- a/app/Models/Account/ExportJob.php
+++ b/app/Models/Account/ExportJob.php
@@ -35,7 +35,7 @@ class ExportJob extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'uuid',

--- a/app/Models/Account/Weather.php
+++ b/app/Models/Account/Weather.php
@@ -16,7 +16,7 @@ class Weather extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -101,7 +101,7 @@ class Contact extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'uuid',
@@ -138,7 +138,7 @@ class Contact extends Model
     /**
      * Eager load account with every contact.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $with = [
         'account',

--- a/app/Models/Contact/Gender.php
+++ b/app/Models/Contact/Gender.php
@@ -22,7 +22,7 @@ class Gender extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Contact/LifeEvent.php
+++ b/app/Models/Contact/LifeEvent.php
@@ -23,7 +23,7 @@ class LifeEvent extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Contact/LifeEventCategory.php
+++ b/app/Models/Contact/LifeEventCategory.php
@@ -17,7 +17,7 @@ class LifeEventCategory extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Contact/LifeEventType.php
+++ b/app/Models/Contact/LifeEventType.php
@@ -17,7 +17,7 @@ class LifeEventType extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Contact/Note.php
+++ b/app/Models/Contact/Note.php
@@ -44,7 +44,7 @@ class Note extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Contact/Occupation.php
+++ b/app/Models/Contact/Occupation.php
@@ -14,7 +14,7 @@ class Occupation extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Contact/Tag.php
+++ b/app/Models/Contact/Tag.php
@@ -18,7 +18,7 @@ class Tag extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'name',

--- a/app/Models/Instance/AuditLog.php
+++ b/app/Models/Instance/AuditLog.php
@@ -16,7 +16,7 @@ class AuditLog extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Instance/Cron.php
+++ b/app/Models/Instance/Cron.php
@@ -9,7 +9,7 @@ class Cron extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'command',

--- a/app/Models/Instance/SpecialDate.php
+++ b/app/Models/Instance/SpecialDate.php
@@ -60,7 +60,7 @@ class SpecialDate extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'contact_id',

--- a/app/Models/Journal/Entry.php
+++ b/app/Models/Journal/Entry.php
@@ -29,7 +29,7 @@ class Entry extends Model implements IsJournalableInterface
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/Relationship/Relationship.php
+++ b/app/Models/Relationship/Relationship.php
@@ -28,7 +28,7 @@ class Relationship extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/User/RecoveryCode.php
+++ b/app/Models/User/RecoveryCode.php
@@ -12,7 +12,7 @@ class RecoveryCode extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/User/SyncToken.php
+++ b/app/Models/User/SyncToken.php
@@ -18,7 +18,7 @@ class SyncToken extends Model
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'account_id',

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -35,7 +35,7 @@ class User extends Authenticatable implements MustVerifyEmail, HasLocalePreferen
     /**
      * The attributes that are mass assignable.
      *
-     * @var array<string>
+     * @var array<int, string>
      */
     protected $fillable = [
         'first_name',


### PR DESCRIPTION
## Summary

- Resolves the 28 phpstan errors documented in #606. All were the same shape: `@var array<string>` (or one bare `@var array`) on `$fillable`/`$with` properties, which Eloquent's base `Model` declares as `array<int, string>`. PHPStan correctly flagged the covariance mismatch.
- Mechanical PHPDoc-only fix — no behaviour change. Each offending `@var` becomes `@var array<int, string>`. 26 files, 28 lines.
- Chose to fix the docs rather than add a `phpstan-baseline.neon` so future drift on these properties keeps being caught.

## Test plan

- [x] `docker exec monica-app-1 vendor/bin/phpstan analyse` — clean (locally: 0 errors)
- [x] `docker exec monica-app-1 vendor/bin/phpunit` — still green (locally: 1668 pass, 12 skip, 0 fail)
- [x] Psalm is still pre-existing dirty (4 errors in `app/Console/Commands/SetupTest.php`) — not in scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
