### PR TITLE
fix: silence remaining psalm errors in console commands

### DIFF
--- a/app/Console/Commands/ImportAccounts.php
+++ b/app/Console/Commands/ImportAccounts.php
@@ -79,6 +79,7 @@ class ImportAccounts extends Command
 
             return;
         }
+        /** @psalm-suppress UndefinedConstant */
         if (! ldap_set_option($ldap_conn, LDAP_OPT_PROTOCOL_VERSION, 3)) {
             $this->error('Could not set LDAP protocol v3');
 

--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -97,9 +97,9 @@ class SetupTest extends Command
             return;
         }
 
-        $this->artisan('✓ Performing migrations', 'migrate:fresh');
+        $this->runArtisan('✓ Performing migrations', 'migrate:fresh');
 
-        $this->artisan('✓ Symlink the storage folder', 'storage:link');
+        $this->runArtisan('✓ Symlink the storage folder', 'storage:link');
 
         if (! $this->option('skipSeed')) {
             $this->numberOfContacts = $this->ask('How many contacts would you like to have in this test account?');
@@ -122,7 +122,7 @@ class SetupTest extends Command
         $this->info('Setup is done. Have fun.');
     }
 
-    public function exec($message, $command)
+    public function runExec($message, $command)
     {
         $this->info($message);
         $this->line($command);
@@ -131,7 +131,7 @@ class SetupTest extends Command
         $this->line('');
     }
 
-    public function artisan($message, $command, array $arguments = [])
+    public function runArtisan($message, $command, array $arguments = [])
     {
         $this->info($message);
         $this->line(Application::formatCommandString($command));


### PR DESCRIPTION
## Summary

- Closes the last 4 static-analysis errors flagged in #606 — all in `app/Console/Commands/`.
- 3 of 4 came from psalm misidentifying `SetupTest::exec()` and `SetupTest::artisan()` as overrides of methods on `Illuminate\Console\Command`. Reflection confirms the parent has neither method, so the rename to `runExec()` / `runArtisan()` makes them unambiguous local helpers. Both callers (lines 100, 102 in the same file) are updated.
- The 4th was `LDAP_OPT_PROTOCOL_VERSION` flagged as undefined in `ImportAccounts.php`. Psalm doesn't ship LDAP-extension stubs and the constant only exists when ext-ldap is loaded. Used a targeted `@psalm-suppress UndefinedConstant` rather than a `defined()` guard so runtime behaviour is unchanged.

## Out of scope

`app/Console/Commands/Update.php` calls `$this->exec(...)` and `$this->artisan(...)` but doesn't define them and doesn't inherit them from anywhere — confirmed via `ReflectionClass`. That's a pre-existing latent `BadMethodCallException` if `php artisan monica:update` is ever invoked. Filed as #610.

## Test plan

- [ ] `docker exec monica-app-1 vendor/bin/psalm` — no errors (locally: clean)
- [ ] `docker exec monica-app-1 vendor/bin/phpstan analyse` — no errors (locally: clean)
- [ ] `docker exec monica-app-1 vendor/bin/phpunit` — still green (locally: 1668 pass / 12 skip / 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
