### PR TITLE
fix: extract runExec/runArtisan helpers into shared trait

### DIFF
--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use function Safe\exec;
 use App\Models\User\User;
 use App\Helpers\DateHelper;
 use Illuminate\Support\Carbon;
@@ -12,7 +11,7 @@ use Illuminate\Console\Command;
 use App\Helpers\CountriesHelper;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Console\Application;
+use App\Console\Concerns\RunsLoggedSteps;
 use App\Models\Contact\LifeEventType;
 use App\Models\Contact\ContactFieldType;
 use App\Services\Contact\Gift\CreateGift;
@@ -34,7 +33,7 @@ use App\Services\Account\Activity\Activity\AttachContactToActivity;
 
 class SetupTest extends Command
 {
-    use WithFaker;
+    use WithFaker, RunsLoggedSteps;
 
     /**
      * The name and signature of the console command.
@@ -120,23 +119,6 @@ class SetupTest extends Command
         $this->line('-----------------------------');
 
         $this->info('Setup is done. Have fun.');
-    }
-
-    public function runExec($message, $command)
-    {
-        $this->info($message);
-        $this->line($command);
-        exec($command, $output);
-        $this->line(implode('\n', $output));
-        $this->line('');
-    }
-
-    public function runArtisan($message, $command, array $arguments = [])
-    {
-        $this->info($message);
-        $this->line(Application::formatCommandString($command));
-        $this->callSilent($command, $arguments);
-        $this->line('');
     }
 
     /**

--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -7,10 +7,11 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Console\ConfirmableTrait;
+use App\Console\Concerns\RunsLoggedSteps;
 
 class Update extends Command
 {
-    use ConfirmableTrait;
+    use ConfirmableTrait, RunsLoggedSteps;
 
     /**
      * The name and signature of the console command.
@@ -39,54 +40,54 @@ class Update extends Command
     {
         if ($this->confirmToProceed()) {
             try {
-                $this->artisan('✓ Maintenance mode: on', 'down', [
+                $this->runArtisan('✓ Maintenance mode: on', 'down', [
                     '--retry' => '10',
                 ]);
 
                 // Clear or rebuild all cache
                 if (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table'))) {
-                    $this->artisan('✓ Resetting application cache', 'cache:clear');
+                    $this->runArtisan('✓ Resetting application cache', 'cache:clear');
                 }
 
                 if ($this->getLaravel()->environment() == 'production') {
-                    $this->artisan('✓ Clear config cache', 'config:clear');
-                    $this->artisan('✓ Resetting route cache', 'route:cache');
+                    $this->runArtisan('✓ Clear config cache', 'config:clear');
+                    $this->runArtisan('✓ Resetting route cache', 'route:cache');
                     if ($this->getLaravel()->version() > '5.6') {
-                        $this->artisan('✓ Resetting view cache', 'view:cache');
+                        $this->runArtisan('✓ Resetting view cache', 'view:cache');
                     } else {
-                        $this->artisan('✓ Resetting view cache', 'view:clear');
+                        $this->runArtisan('✓ Resetting view cache', 'view:clear');
                     }
                 } else {
-                    $this->artisan('✓ Clear config cache', 'config:clear');
-                    $this->artisan('✓ Clear route cache', 'route:clear');
-                    $this->artisan('✓ Clear view cache', 'view:clear');
+                    $this->runArtisan('✓ Clear config cache', 'config:clear');
+                    $this->runArtisan('✓ Clear route cache', 'route:clear');
+                    $this->runArtisan('✓ Clear view cache', 'view:clear');
                 }
 
                 if ($this->option('composer-install') === true) {
-                    $this->exec('✓ Updating composer dependencies', 'composer install --no-interaction'.($this->option('dev') === false ? ' --no-dev' : ''));
+                    $this->runExec('✓ Updating composer dependencies', 'composer install --no-interaction'.($this->option('dev') === false ? ' --no-dev' : ''));
                 }
 
                 if ($this->option('skip-storage-link') !== true && $this->getLaravel()->environment() != 'testing' && ! file_exists(public_path('storage'))) {
-                    $this->artisan('✓ Symlink the storage folder', 'storage:link');
+                    $this->runArtisan('✓ Symlink the storage folder', 'storage:link');
                 }
 
                 if ($this->migrateCollationTest()) {
-                    $this->artisan('✓ Performing collation migrations', 'migrate:collation', ['--force']);
+                    $this->runArtisan('✓ Performing collation migrations', 'migrate:collation', ['--force']);
                 }
 
-                $this->artisan('✓ Performing migrations', 'migrate', ['--force']);
+                $this->runArtisan('✓ Performing migrations', 'migrate', ['--force']);
 
-                $this->artisan('✓ Check for encryption keys', 'monica:passport', ['--force']);
+                $this->runArtisan('✓ Check for encryption keys', 'monica:passport', ['--force']);
 
-                $this->artisan('✓ Ping for new version', 'monica:ping', ['--force']);
+                $this->runArtisan('✓ Ping for new version', 'monica:ping', ['--force']);
 
                 // Cache config
                 if ($this->getLaravel()->environment() == 'production'
                     && (config('cache.default') != 'database' || Schema::hasTable(config('cache.stores.database.table')))) {
-                    $this->artisan('✓ Cache configuraton', 'config:cache');
+                    $this->runArtisan('✓ Cache configuraton', 'config:cache');
                 }
             } finally {
-                $this->artisan('✓ Maintenance mode: off', 'up');
+                $this->runArtisan('✓ Maintenance mode: off', 'up');
             }
 
             $this->line('Monica v'.config('monica.app_version').' is set up, enjoy.');

--- a/app/Console/Concerns/RunsLoggedSteps.php
+++ b/app/Console/Concerns/RunsLoggedSteps.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Concerns;
+
+use function Safe\exec;
+use Illuminate\Console\Application;
+
+/**
+ * Helpers for console commands that want to print a "step" banner before
+ * delegating to either a shell command or another artisan command.
+ *
+ * Expects the consuming class to be an `Illuminate\Console\Command` (so that
+ * `info()`, `line()`, and `callSilent()` are available).
+ */
+trait RunsLoggedSteps
+{
+    public function runExec(string $message, string $command): void
+    {
+        $this->info($message);
+        $this->line($command);
+        exec($command, $output);
+        $this->line(implode('\n', $output));
+        $this->line('');
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $arguments
+     */
+    public function runArtisan(string $message, string $command, array $arguments = []): void
+    {
+        $this->info($message);
+        $this->line(Application::formatCommandString($command));
+        $this->callSilent($command, $arguments);
+        $this->line('');
+    }
+}


### PR DESCRIPTION
## Summary

Closes #610. `monica:update` was unrunnable — `Update.php` called `$this->exec(...)` and `$this->artisan(...)` on 16 lines, but those methods existed only on `SetupTest` (and were renamed to `runExec`/`runArtisan` in #609). Calling the command would have thrown `BadMethodCallException`.

- Extract the helpers into a new trait `App\Console\Concerns\RunsLoggedSteps`.
- `SetupTest` and `Update` both `use` the trait.
- `Update.php`'s call sites mechanically retargeted: `->exec(` → `->runExec(`, `->artisan(` → `->runArtisan(`. No behaviour change there beyond making them resolvable.

Body of the helpers is preserved verbatim from the SetupTest versions (including the legacy `implode('\n', $output)` — literal backslash-n, almost certainly a bug, but out of scope here).

## Test plan

- [ ] `docker exec monica-app-1 vendor/bin/phpunit` — green (1668 pass / 12 skip / 0 fail)
- [ ] `docker exec monica-app-1 vendor/bin/phpstan analyse` — clean
- [ ] `docker exec monica-app-1 vendor/bin/psalm` — clean
- [ ] `docker exec monica-app-1 php -r "require '/var/www/html/vendor/autoload.php'; \$r = new ReflectionClass(\\App\\Console\\Commands\\Update::class); foreach (['runExec','runArtisan'] as \$n) echo \$n . ': ' . (\$r->hasMethod(\$n) ? 'YES' : 'no') . PHP_EOL;"` — both `YES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
