### PR TITLE
chore(docker): expose php memory/upload + apache body limits via env

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -98,6 +98,13 @@ ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
     PHP_OPCACHE_MAX_ACCELERATED_FILES="20000" \
     PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+
+# Limits — operator-tunable PHP memory + upload caps. Defaults match the
+# previous hardcoded memory_limit; upload/post widen from php.ini defaults
+# (~2 MB) to match upstream monicahq/docker. Replaces the old memory-limit.ini
+# with limits.ini for parity with upstream PR monicahq/monica#6966.
+ENV PHP_MEMORY_LIMIT="512M" \
+    PHP_UPLOAD_LIMIT="512M"
 RUN set -ex; \
     \
     docker-php-ext-enable opcache; \
@@ -115,7 +122,12 @@ RUN set -ex; \
     \
     echo 'apc.enable_cli=1' >> $PHP_INI_DIR/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > $PHP_INI_DIR/conf.d/memory-limit.ini
+    { \
+        echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
+        echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
+        echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+    } > $PHP_INI_DIR/conf.d/limits.ini; \
+    rm -f $PHP_INI_DIR/conf.d/memory-limit.ini
 
 RUN set -ex; \
     \
@@ -127,6 +139,17 @@ RUN set -ex; \
         echo RemoteIPTrustedProxy 192.168.0.0/16; \
     } > $APACHE_CONFDIR/conf-available/remoteip.conf; \
     a2enconf remoteip
+
+# Apache request body limit — pairs with PHP_UPLOAD_LIMIT above. Defaults to
+# 1 GiB to match upstream monicahq/docker; widens Apache's default cap so
+# operators don't silently 413 on large uploads.
+ENV APACHE_BODY_LIMIT 1073741824
+RUN set -ex; \
+    \
+    { \
+        echo 'LimitRequestBody ${APACHE_BODY_LIMIT}'; \
+    } > $APACHE_CONFDIR/conf-available/apache-limits.conf; \
+    a2enconf apache-limits
 
 RUN set -ex; \
     APACHE_DOCUMENT_ROOT=/var/www/html/public; \


### PR DESCRIPTION
## Summary

Backport of upstream PR `monicahq/monica#6966` (Oct 2023) — exposes PHP memory/upload and Apache request-body limits as operator-tunable env vars on `scripts/docker/Dockerfile`. Closes #589.

- `PHP_MEMORY_LIMIT` (default `512M`, unchanged) and `PHP_UPLOAD_LIMIT` (default `512M`) now drive a new `conf.d/limits.ini` covering `memory_limit`, `upload_max_filesize`, and `post_max_size`. Replaces the old hardcoded `memory-limit.ini`.
- `APACHE_BODY_LIMIT` (default `1073741824` / 1 GiB) drives a new `conf-available/apache-limits.conf` with `LimitRequestBody`, enabled via `a2enconf`.
- `ENV` declarations live in the `base` stage so the `dev` stage (added by #599) inherits them transparently — `docker-compose.dev.yml` builds `target: dev` and still ends up with the right ini values.

## Risk

- `memory_limit` default is unchanged. `upload_max_filesize` / `post_max_size` / `LimitRequestBody` widen from very small defaults (~2 MB on the PHP side; Apache's default) to 512 MB / 1 GiB — matching the canonical `monicahq/docker` image so this fork stops being the odd one out.
- The PHP ini file is renamed from `memory-limit.ini` to `limits.ini`. The Dockerfile explicitly `rm -f`s the old name so a diff against a cached older layer makes the rename obvious. Self-hosters bind-mounting a custom `memory-limit.ini` to override us will still have that file load (PHP loads `conf.d/*.ini` alphabetically — their override applies after our `limits.ini`), so operator intent is preserved.
- Optional fold-in from upstream `#6733` (adding `unzip`) was deliberately skipped to keep scope minimal; v4 builds work fine without it.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml build app` succeeds locally
- [x] `docker run --rm --entrypoint php monica:dev -r '...'` reports `memory_limit=512M`, `upload_max_filesize=512M`, `post_max_size=512M`
- [x] `apache2ctl -t` returns `Syntax OK` inside the image
- [x] `/etc/apache2/conf-enabled/apache-limits.conf` is symlinked into the enabled set
- [x] No stray `memory-limit.ini` in `conf.d/`
- [ ] OOTB Docker build workflow passes on this PR (validates fresh-clone build path)

## Refs

- Issue: #589
- Audit: #583
- Cherry-pick precedent: #561
- Postmortem: discussion #581
- Upstream: `monicahq/monica#6966`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
