### PR TITLE
test(cypress): inject --user www-data into docker exec helper

### DIFF
--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -103,6 +103,16 @@ the working directory is named `monica`). Override it if your setup differs:
 CYPRESS_USE_DOCKER=true CYPRESS_DOCKER_CONTAINER=myproject-app-1 CYPRESS_BASE_URL=http://localhost:8082 yarn run e2e
 ```
 
+The helper also passes `--user www-data` so artisan runs as the same uid as
+apache inside the container; without it, `storage/logs/laravel.log` gets
+chowned to root and subsequent web requests 500 (see #629). Override via
+`CYPRESS_DOCKER_USER` if your container uses a different user, or set it to
+an empty string to run as root:
+
+```sh
+CYPRESS_USE_DOCKER=true CYPRESS_DOCKER_USER=appuser CYPRESS_BASE_URL=http://localhost:8082 yarn run e2e
+```
+
 ## Other documents to read
 
 [Connecting to MySQL inside of a Docker container](/docs/installation/docker-mysql.md)

--- a/tests/cypress/support/helpers/app.js
+++ b/tests/cypress/support/helpers/app.js
@@ -1,10 +1,19 @@
 // When running Cypress against the Docker dev stack (CYPRESS_USE_DOCKER=true),
 // cy.exec runs on the host which has no .env or DB connection. Prefix artisan
 // commands with docker exec so they run inside the app container instead.
+//
+// docker exec defaults to root; running artisan as root chowns
+// storage/logs/laravel.log to root, after which any web request that logs
+// (i.e. most of them) 500s under the apache www-data user. Inject
+// --user www-data by default so the helper matches apache's uid. Override
+// via CYPRESS_DOCKER_USER (set to empty string to run as root).
 function artisan(cmd) {
   if (Cypress.env('USE_DOCKER')) {
     const container = Cypress.env('DOCKER_CONTAINER') || 'monica-app-1';
-    return 'docker exec ' + container + ' ' + cmd;
+    const userEnv = Cypress.env('DOCKER_USER');
+    const user = userEnv === undefined ? 'www-data' : userEnv;
+    const userFlag = user ? '--user ' + user + ' ' : '';
+    return 'docker exec ' + userFlag + container + ' ' + cmd;
   }
   return cmd;
 }


### PR DESCRIPTION
## Summary

- `tests/cypress/support/helpers/app.js` now injects `--user www-data` into the `docker exec` command by default, configurable via `CYPRESS_DOCKER_USER` (set to empty string to run as root). Fixes the brittle `CYPRESS_DOCKER_CONTAINER='--user www-data monica-app-1'` workaround PR-D used to dodge #629.
- `docs/contribute/docker.md` documents the new override.

## Why

`docker exec` defaults to root. Every `cy.login()` calls `setup:frontendtestuser` through the helper, which (before this PR) ran as root and chowned `storage/logs/laravel.log` to root. The next www-data web request then 500s on log append; the 500 handler tries to log the 500, and you get the recursive cascade described in #629. The helper now matches apache's uid by default.

## Test plan

- [x] Run cypress against the dev compose rig WITHOUT the `CYPRESS_DOCKER_CONTAINER` workaround:
  ```sh
  CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 node_modules/.bin/cypress run --spec tests/cypress/e2e/contacts/notes.cy.js,tests/cypress/e2e/journal/entries.cy.js,tests/cypress/e2e/contacts/conversations.cy.js,tests/cypress/e2e/auth/login.cy.js
  ```
  5/5 passing locally.
- [x] Confirm `storage/logs/laravel.log` ownership remained `www-data:www-data` after the run.
- [ ] (Follow-up) Anyone restoring the cypress workflow under #586 should now be able to drop the env-var hack from CI.

Closes #637.
Refs #629, #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
