### PR TITLE
fix(dev): honour --no-interaction in setup:test

### DIFF
--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -41,7 +41,8 @@ class SetupTest extends Command
      * @var string
      */
     protected $signature = 'setup:test
-                            {--skipSeed : Skip the populate database with fake data.}';
+                            {--skipSeed : Skip the populate database with fake data.}
+                            {--contacts=20 : Number of contacts to seed when populating the database.}';
 
     /**
      * The console command description.
@@ -92,8 +93,11 @@ class SetupTest extends Command
      */
     public function handle()
     {
-        if (! $this->confirm('Are you sure you want to proceed? This will delete ALL data in your environment.')) {
-            return;
+        if (! $this->option('no-interaction')
+            && ! $this->confirm('Are you sure you want to proceed? This will delete ALL data in your environment.')) {
+            $this->warn('Command cancelled.');
+
+            return self::FAILURE;
         }
 
         $this->runArtisan('✓ Performing migrations', 'migrate:fresh');
@@ -101,7 +105,10 @@ class SetupTest extends Command
         $this->runArtisan('✓ Symlink the storage folder', 'storage:link');
 
         if (! $this->option('skipSeed')) {
-            $this->numberOfContacts = $this->ask('How many contacts would you like to have in this test account?');
+            $this->numberOfContacts = (int) $this->ask(
+                'How many contacts would you like to have in this test account?',
+                $this->option('contacts')
+            );
             $this->info('✓ Filling database with fake data');
             $this->seed();
         }

--- a/tests/Commands/Tests/SetupTestCommandTest.php
+++ b/tests/Commands/Tests/SetupTestCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Commands\Tests;
+
+use Tests\TestCase;
+use App\Console\Commands\Helpers\Command;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class SetupTestCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_completes_non_interactively_with_skip_seed()
+    {
+        /** @var \Tests\Helpers\CommandCallerFake */
+        $fake = Command::fake();
+
+        $this->artisan('setup:test', [
+            '--skipSeed' => true,
+            '--no-interaction' => true,
+        ])->assertSuccessful()->run();
+
+        $fake->assertContainsMessage('✓ Performing migrations');
+        $fake->assertContainsMessage('✓ Symlink the storage folder');
+    }
+
+    /** @test */
+    public function it_accepts_contacts_option_to_set_seed_count()
+    {
+        /** @var \Tests\Helpers\CommandCallerFake */
+        $fake = Command::fake();
+
+        $this->artisan('setup:test', [
+            '--skipSeed' => true,
+            '--contacts' => 5,
+            '--no-interaction' => true,
+        ])->assertSuccessful()->run();
+
+        $fake->assertContainsMessage('✓ Performing migrations');
+    }
+
+    /** @test */
+    public function it_prompts_for_confirmation_when_interactive()
+    {
+        /** @var \Tests\Helpers\CommandCallerFake */
+        $fake = Command::fake();
+
+        $this->artisan('setup:test', ['--skipSeed' => true])
+            ->expectsConfirmation(
+                'Are you sure you want to proceed? This will delete ALL data in your environment.',
+                'yes'
+            )
+            ->assertSuccessful()
+            ->run();
+
+        $fake->assertContainsMessage('✓ Performing migrations');
+    }
+
+    /** @test */
+    public function it_fails_when_user_declines_confirmation()
+    {
+        /** @var \Tests\Helpers\CommandCallerFake */
+        $fake = Command::fake();
+
+        $this->artisan('setup:test', ['--skipSeed' => true])
+            ->expectsConfirmation(
+                'Are you sure you want to proceed? This will delete ALL data in your environment.',
+                'no'
+            )
+            ->assertFailed()
+            ->run();
+
+        $this->assertCount(0, $fake->buffer);
+    }
+}


### PR DESCRIPTION
Closes #638.

## Summary
- `setup:test --no-interaction` now seeds successfully instead of exiting 0 silently. The destructive-action confirmation is skipped under `--no-interaction`; user-decline interactively returns `self::FAILURE` (was silent success).
- New `--contacts=20` option is honoured under `--no-interaction` and is used as the default for the interactive prompt.
- Test coverage for both code paths added.

## Root cause
`$this->confirm()` returned `false` (the prompt's default) under `--no-interaction`, so the command bailed before running migrations or seeding. Same shape on `$this->ask()` for the contact count — returned `null`, which left the `for ($i = 0; $i < $this->numberOfContacts; $i++)` loop bound at zero. Either alone is enough to produce the "exits 0, no contacts" symptom.

## Test plan
- [x] `vendor/bin/phpunit tests/Commands/Tests/SetupTestCommandTest.php` — 4 new tests pass (11 assertions)
- [x] `vendor/bin/phpunit --testsuite Commands-Scheduling` — 25/25 pass (no regressions in the suite that owns this test file)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/psalm` — no errors (cache-dir workaround `HOME=/tmp` needed inside the dev container, unrelated to this change)
- [x] Live repro in dev container: `docker compose -f docker-compose.dev.yml exec -T --user www-data app php artisan setup:test --no-interaction --contacts=2` → 2 contacts + `admin@admin.com` user landed in DB (verified via direct `mysql` query against `monica-mysql-1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
