### PR TITLE
test(cypress): migrate Cypress.env() to Cypress.expose()

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,6 +11,12 @@ module.exports = defineConfig({
     toConsole: true,
   },
   projectId: 'q8h6k9',
+  allowCypressEnv: false,
+  expose: {
+    USE_DOCKER: process.env.CYPRESS_USE_DOCKER,
+    DOCKER_CONTAINER: process.env.CYPRESS_DOCKER_CONTAINER,
+    DOCKER_USER: process.env.CYPRESS_DOCKER_USER,
+  },
   e2e: {
     baseUrl: 'http://localhost:8000',
     supportFile: 'tests/cypress/support/e2e.js',

--- a/tests/cypress/support/helpers/app.js
+++ b/tests/cypress/support/helpers/app.js
@@ -8,9 +8,9 @@
 // --user www-data by default so the helper matches apache's uid. Override
 // via CYPRESS_DOCKER_USER (set to empty string to run as root).
 function artisan(cmd) {
-  if (Cypress.env('USE_DOCKER')) {
-    const container = Cypress.env('DOCKER_CONTAINER') || 'monica-app-1';
-    const userEnv = Cypress.env('DOCKER_USER');
+  if (Cypress.expose('USE_DOCKER')) {
+    const container = Cypress.expose('DOCKER_CONTAINER') || 'monica-app-1';
+    const userEnv = Cypress.expose('DOCKER_USER');
     const user = userEnv === undefined ? 'www-data' : userEnv;
     const userFlag = user ? '--user ' + user + ' ' : '';
     return 'docker exec ' + userFlag + container + ' ' + cmd;


### PR DESCRIPTION
## Summary

Closes #639. Cypress 15 prints a startup banner whenever `allowCypressEnv` is left at the default `true`:

```
Warning: The allowCypressEnv configuration option is enabled. This allows
any browser code to read values from Cypress.env(). This is insecure and
will be removed in a future major version.

1. Replace Cypress.env() calls with cy.env() (for sensitive values) or
   Cypress.expose() (for public configuration)
2. Set allowCypressEnv: false in your Cypress configuration to disable
   Cypress.env()

Learn more: https://on.cypress.io/cypress-env-migration
```

The three call sites in `tests/cypress/support/helpers/app.js` read non-sensitive docker-routing flags (`USE_DOCKER` / `DOCKER_CONTAINER` / `DOCKER_USER`), so the correct replacement is `Cypress.expose()` rather than `cy.env()`.

## Changes

- `cypress.config.js`: add `allowCypressEnv: false` and an `expose:` block that sources `CYPRESS_USE_DOCKER` / `CYPRESS_DOCKER_CONTAINER` / `CYPRESS_DOCKER_USER` from `process.env` (the `CYPRESS_*` auto-mapping only feeds `env`, so this has to be explicit for `expose`).
- `tests/cypress/support/helpers/app.js`: flip three `Cypress.env(...)` calls to `Cypress.expose(...)`. Public env-var names (`CYPRESS_USE_DOCKER` etc.) are unchanged — only the in-runtime read path moves.

## Verification

**Before** — banner present:

```
$ CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 yarn run e2e --spec tests/cypress/e2e/auth/login.cy.js
…
$ cypress run --spec tests/cypress/e2e/auth/login.cy.js
Warning: The allowCypressEnv configuration option is enabled. …
```

**After** — banner gone, same invocation:

```
$ CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 yarn run e2e --spec tests/cypress/e2e/auth/login.cy.js
…
$ cypress run --spec tests/cypress/e2e/auth/login.cy.js

================================================================================

  (Run Starting)
…
```

## Test plan

- [x] `auth/login.cy.js` — 1/1 passing, no banner.
- [x] `contacts/notes.cy.js` — 1/1 passing. Exercises `cy.login()` → `artisan()` → `Cypress.expose('USE_DOCKER')` end-to-end through docker; would have failed if `expose()` returned `undefined`.
- [x] `journal/entries.cy.js` — 3/3 passing.
- [x] `contacts/conversations.cy.js` — 1/1 passing.
- [x] `npx eslint cypress.config.js tests/cypress/support/helpers/app.js` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
