### PR TITLE
fix(dev): run app service as www-data in docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,7 @@ services:
       dockerfile: scripts/docker/Dockerfile
       target: dev
     image: monica:dev
+    user: www-data
     depends_on:
       - mysql
     ports:


### PR DESCRIPTION
## Summary

- Adds `user: www-data` to the `app` service in `docker-compose.dev.yml` so any `docker compose exec app …` runs as the uid that owns `storage/*`, not as root.
- Closes #629.

## Why

`docker compose exec` defaults to the container's default user, which on `php:8.1-apache` is root. Console invocations (`setup:test`, `cache:clear`, migrations) therefore create root-owned files under `storage/`, after which `www-data` Apache workers can no longer append to e.g. `storage/logs/laravel.log` and authenticated web requests start returning 500s.

## Concerns considered

I worried `user: www-data` on the service would break two things, but both held:

1. **Apache binding to privileged port 80** — Docker grants `CAP_NET_BIND_SERVICE` to containers by default, so `apache2 -DFOREGROUND` can listen on 80 as www-data without extra config. Confirmed: container starts cleanly, Apache logs `AH00094: Command line: 'apache2 -D FOREGROUND'` and serves HTTP 200 on `:8082`.
2. **`entrypoint.sh:17` doing `chown -R www-data:www-data ${STORAGE}`** — storage is already www-data-owned in this dev image, so chown is a no-op when the entrypoint itself runs as www-data; entrypoint completed normally (`Monica v is set up, enjoy.`).

## Verification

Container recreated via `docker compose -f docker-compose.dev.yml up -d --force-recreate app` against this branch's compose file.

### Container effective user

```
$ docker exec monica-app-1 id
uid=33(www-data) gid=33(www-data) groups=33(www-data)

$ docker exec monica-app-1 ps -ef | head -3
UID        PID  PPID  C STIME TTY          TIME CMD
www-data     1     0  0 12:01 ?        00:00:00 apache2 -DFOREGROUND
www-data    56     1  0 12:01 ?        00:00:00 apache2 -DFOREGROUND
```

(Pre-fix the same command showed `uid=0(root)`.)

### App still responsive

```
$ xh GET http://localhost:8082/
HTTP/1.1 200 OK
Server: Apache/2.4.65 (Debian)
X-Powered-By: PHP/8.1.34
```

### Before / after ownership of files written via `exec`

`--user root` simulates the pre-fix default. The default (post-fix) is www-data:

```
$ docker compose -f docker-compose.dev.yml exec -T --user root app touch /var/www/html/storage/logs/before-fix.log
$ docker compose -f docker-compose.dev.yml exec -T              app touch /var/www/html/storage/logs/after-fix.log
$ docker compose -f docker-compose.dev.yml exec -T app ls -la /var/www/html/storage/logs/
-rw-r--r-- 1 www-data www-data     0 May 22 12:03 after-fix.log
-rw-r--r-- 1 root     root         0 May 22 12:03 before-fix.log
```

### Real-world artisan invocation works

```
$ docker compose -f docker-compose.dev.yml exec -T app php artisan cache:clear
   INFO  Application cache cleared successfully.
```

No `Permission denied` on `storage/framework/cache/*`, which would have been the prior failure mode.

## Test plan

- [x] Container starts as www-data (`docker exec monica-app-1 id`)
- [x] Apache binds port 80 (HTTP 200 on `:8082`)
- [x] `exec` default user is www-data (touch test)
- [x] `--user root` simulation still shows root-owned files (confirms the fix is what's driving the new default)
- [x] `php artisan cache:clear` succeeds via default `exec`
- [ ] Reviewer rebuilds via `docker compose -f docker-compose.dev.yml up -d --force-recreate app` and reproduces the touch test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
