### PR TITLE
test(ci): add authenticated-route smoke test (#656)

### DIFF
--- a/tests/Feature/SmokeRoutesTest.php
+++ b/tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Contact\Contact;
+use App\Models\Contact\Gender;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Tests\FeatureTestCase;
+
+/**
+ * Smoke coverage for the request lifecycle on primary authenticated routes.
+ *
+ * Catches regressions that bypass model/unit tests but fire when the framework
+ * hydrates a User from DB and runs a real request through middleware + Blade
+ * — e.g. Laravel 11's stricter Encrypter rejecting `decrypt('')` from an
+ * empty-string column default that L10 silently tolerated (PR #652, fix
+ * commit d16d40283).
+ *
+ * Asserts no 500s and no Ignition error-page markers in the response body.
+ *
+ * Filed: #656.
+ */
+class SmokeRoutesTest extends FeatureTestCase
+{
+    private const ERROR_PAGE_MARKERS = [
+        'The payload is invalid',
+        'Whoops, looks like something went wrong',
+        'Ignition\\',
+        'Symfony\\Component\\HttpKernel\\Exception\\',
+    ];
+
+    public function test_guest_can_load_login_or_register_page(): void
+    {
+        $response = $this->followingRedirects()->get('/');
+
+        $response->assertStatus(200);
+        $this->assertNotAnErrorPage($response, '/');
+    }
+
+    public function test_authenticated_user_can_load_dashboard(): void
+    {
+        $this->signIn();
+
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+        $this->assertNotAnErrorPage($response, '/dashboard');
+    }
+
+    /**
+     * @dataProvider authenticatedGetRoutes
+     */
+    public function test_authenticated_user_can_load_route(string $url): void
+    {
+        $this->signIn();
+
+        $response = $this->get($url);
+
+        $this->assertSame(200, $response->getStatusCode(), "GET {$url} did not return 200");
+        $this->assertNotAnErrorPage($response, $url);
+    }
+
+    public static function authenticatedGetRoutes(): array
+    {
+        return [
+            'people index' => ['/people'],
+            'people add form' => ['/people/add'],
+            'settings' => ['/settings'],
+            'journal' => ['/journal'],
+        ];
+    }
+
+    public function test_authenticated_user_can_view_a_contact_detail_page(): void
+    {
+        $user = $this->signIn();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->get('/people/'.$contact->hashID());
+
+        $response->assertStatus(200);
+        $this->assertNotAnErrorPage($response, '/people/{contact}');
+    }
+
+    /**
+     * Regression: PR #652 / commit d16d40283. Older installs end up with
+     * `google2fa_secret = ''` (empty string) in the DB rather than NULL; the
+     * Laravel 11 Encrypter rejects `decrypt('')` with DecryptException where
+     * L10 silently returned null. The User accessor must short-circuit on
+     * blank values without invoking the encrypter.
+     */
+    public function test_dashboard_loads_for_user_with_empty_google2fa_secret(): void
+    {
+        $user = $this->signIn();
+
+        DB::table('users')
+            ->where('id', $user->id)
+            ->update(['google2fa_secret' => '']);
+        $user->refresh();
+        $this->be($user);
+
+        $response = $this->get('/dashboard');
+
+        $response->assertStatus(200);
+        $this->assertNotAnErrorPage($response, '/dashboard (empty google2fa_secret)');
+    }
+
+    public function test_authenticated_user_can_create_a_contact(): void
+    {
+        $user = $this->signIn();
+        $gender = factory(Gender::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->post('/people', [
+            'first_name' => 'Smoke',
+            'last_name' => 'Test',
+            'gender' => $gender->id,
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertSessionHasNoErrors();
+        $this->assertDatabaseHas('contacts', [
+            'account_id' => $user->account_id,
+            'first_name' => 'Smoke',
+            'last_name' => 'Test',
+        ]);
+    }
+
+    private function assertNotAnErrorPage(TestResponse $response, string $url): void
+    {
+        $body = (string) $response->getContent();
+
+        foreach (self::ERROR_PAGE_MARKERS as $marker) {
+            $this->assertStringNotContainsString(
+                $marker,
+                $body,
+                "Route {$url} returned an error-page marker: {$marker}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `tests/Feature/SmokeRoutesTest.php` — a fast (~0.8s) request-lifecycle gate to catch the class of regression that bypassed PR #652's 1673-test phpunit suite.

The triggering bug: Laravel 11's stricter `Encrypter::getJsonPayload()` rejects `decrypt('')` (where L10 silently returned `null`), causing a 500 on every authenticated request that touched the `User::google2fa_secret` accessor on accounts with an empty-string column value. Fixed in commit `d16d40283`; this PR locks the fix in with a targeted regression test and adds broader smoke coverage around it.

### What's covered

- `GET /` (guest, follows redirect to login-or-register)
- `GET /dashboard`, `/people`, `/people/add`, `/settings`, `/journal`
- `GET /people/{contact}` (with a factory-created contact in the user's account)
- `POST /people` (write path — asserts 302 redirect, no session errors, contact persisted)
- **Targeted regression case**: signs in, sets `google2fa_secret = ''` directly in DB, refreshes the in-memory model, and asserts `/dashboard` returns 200. Verified to fail with `"The payload is invalid"` if `User::getGoogle2faSecretAttribute()` is reverted to the pre-fix `is_null()` check.

### Assertion strategy

Each route asserts:
- HTTP 200 (302 for the write path)
- Body contains none of: `The payload is invalid`, `Whoops, looks like something went wrong`, `Ignition\`, `Symfony\Component\HttpKernel\Exception\`

### CI wiring

No `.github/workflows/tests.yml` change needed — the file lives under `tests/Feature/` and is picked up automatically by the existing `Feature` testsuite in the matrix.

### Performance

~0.8s for the whole class (9 cases, 43 assertions). Issue's budget was <30s.

Closes #656.

## Test plan

- [x] `vendor/bin/phpunit --filter SmokeRoutesTest` passes locally (9/9)
- [x] `vendor/bin/phpstan analyse tests/Feature/SmokeRoutesTest.php` clean
- [x] Full `--testsuite Feature` run still green (162 tests, 12 skipped, no failures)
- [x] Targeted google2fa case verified to catch the d16d40283 regression — reverted the accessor, ran the test, confirmed failure with `"The payload is invalid"` in the body; restored the fix, confirmed pass
- [ ] CI matrix green on all PHP versions / testsuites

🤖 Generated with [Claude Code](https://claude.com/claude-code)
