### PR TITLE
chore(static-analysis): clear 3 baseline entries surfaced by ide-helper

### DIFF
--- a/app/Models/Account/Account.php
+++ b/app/Models/Account/Account.php
@@ -471,9 +471,9 @@ class Account extends Model
     /**
      * Get the Reminder Rules records associated with the account.
      *
-     * @return HasMany
+     * @return HasMany<ReminderRule, $this>
      */
-    public function reminderRules()
+    public function reminderRules(): HasMany
     {
         return $this->hasMany(ReminderRule::class);
     }

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -353,19 +353,15 @@ class Contact extends Model
     /**
      * Get the list of contacts from the same address book as this contact.
      *
-     * @return HasMany<self>|null
+     * @return HasMany<self>
      */
-    public function siblingContacts(): ?HasMany
+    public function siblingContacts(): HasMany
     {
-        if ($this->account) {
-            if ($this->addressBook) {
-                return $this->account->contacts($this->addressBook->name);
-            }
-
-            return $this->account->contacts();
+        if ($this->addressBook) {
+            return $this->account->contacts($this->addressBook->name);
         }
 
-        return null;
+        return $this->account->contacts();
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -547,12 +547,6 @@ parameters:
 			path: app/Models/Contact/Contact.php
 
 		-
-			message: '#^If condition is always true\.$#'
-			identifier: if.alwaysTrue
-			count: 1
-			path: app/Models/Contact/Contact.php
-
-		-
 			message: '#^Method App\\Models\\Contact\\Contact\:\:getAgeAtDeath\(\) should return int\|null but returns float\.$#'
 			identifier: return.type
 			count: 1
@@ -573,12 +567,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$address of static method App\\Helpers\\WeatherHelper\:\:getWeatherForAddress\(\) expects App\\Models\\Contact\\Address\|null, Illuminate\\Database\\Eloquent\\Model\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: app/Models/Contact/Contact.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
 			count: 1
 			path: app/Models/Contact/Contact.php
 
@@ -635,12 +623,6 @@ parameters:
 			identifier: property.phpDocType
 			count: 1
 			path: app/Models/Contact/Occupation.php
-
-		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$number_of_days_before\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Models/Contact/Reminder.php
 
 		-
 			message: '#^PHPDoc type array\<int, string\> of property App\\Models\\Contact\\Tag\:\:\$fillable is not covariant with PHPDoc type list\<string\> of overridden property Illuminate\\Database\\Eloquent\\Model\:\:\$fillable\.$#'


### PR DESCRIPTION
## Summary

- Clear the 3 phpstan baseline entries surfaced (not introduced) by `ide-helper:models` in PR #660 — at the source, not the baseline.
- Baseline shrinks 139 → 136 entries. Verified clean subset (−3 targeted, 0 added) via (path, identifier, message) tuple diff.
- Companion test-coverage issue filed as #661 for the path this touched.

## Changes

**`app/Models/Account/Account.php`** — `reminderRules()` gets larastan v3 generics: `@return HasMany<ReminderRule, $this>` + `: HasMany` return type. Closes two `Reminder.php` `Eloquent\Model::$number_of_days_before` entries (count: 2) at `Reminder::scheduleNotifications()`:219,231 where `$this->account->reminderRules()->where(...)->get()` was inferring `Collection<int, Model>` instead of `Collection<int, ReminderRule>`.

**`app/Models/Contact/Contact.php`** — `siblingContacts()` drops the unreachable `if ($this->account)` wrapper and tightens the return type from `?HasMany<self>` to `HasMany<self>`. Closes `if.alwaysTrue` + `deadCode.unreachable` entries.

Why safe: the `@property-read Account $account` is non-nullable (per ide-helper output + the NOT NULL multi-tenancy FK), and the only caller `IntroductionsController::edit` chains `->real()->active()->orderByUserPreference()->paginate(20)` on the result with **no null guard** — the `null` branch was unreachable in practice.

**`phpstan-baseline.neon`** — regenerated. 139 → 136 entries, count-sum 171 → 167.

## Why now

PR #660 just shrank the baseline 307 → 139 (the issue #658 line). PR-D (Laravel 11 → 12) is next on the ladder and wants a credible "no new baseline entries" guarantee. Clearing the three entries that surfaced under PR #660 makes that guarantee sharper — every entry left in the baseline now is a pre-existing smell, not noise from the static-analysis tooling itself.

## Test plan

- [x] `vendor/bin/phpstan analyse --memory-limit=1G` → 0 errors against the new baseline (host).
- [x] Full `phpunit` (container): 1682 tests, 0 failures, 12 skipped, 13205 assertions.
- [x] (path, identifier, message) tuple diff of `phpstan-baseline.neon` before vs after: exactly 3 entries removed (`Contact.php#if.alwaysTrue`, `Contact.php#deadCode.unreachable`, `Reminder.php#property.notFound`), 0 added.
- [ ] CI: composer install, full phpstan, all 6 phpunit testsuites, asset build, dev docker build, migration smoke.

## Not in scope

- Test coverage for `Contact::siblingContacts()` and `IntroductionsController::edit` — both have 0% coverage today, surfaced during this cleanup. Tracked separately in #661 so PR-D's diff stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
