### PR TITLE
style(tests): import FQN attribute names across 275 test files

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,4 +11,10 @@ return RectorConfig::configure()
     ])
     ->withSets([
         PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES,
-    ]);
+    ])
+    ->withImportNames(
+        importNames: true,
+        importDocBlockNames: false,
+        importShortClasses: false,
+        removeUnusedImports: false,
+    );

--- a/tests/Api/Account/Activity/ApiActivityTypeCategoryControllerTest.php
+++ b/tests/Api/Account/Activity/ApiActivityTypeCategoryControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\ActivityTypeCategory;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -21,7 +22,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_activity_type_categories()
     {
         $user = $this->signin();
@@ -39,7 +40,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_limit_parameter()
     {
         $user = $this->signin();
@@ -67,7 +68,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_activity_type_category()
     {
         $user = $this->signin();
@@ -87,7 +88,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_activity_type_category()
     {
         $user = $this->signin();
@@ -111,7 +112,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_update_if_custom_field_not_found()
     {
         $user = $this->signin();
@@ -127,7 +128,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_activity_type_category()
     {
         $user = $this->signin();
@@ -151,7 +152,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_delete_the_custom_field_if_not_found()
     {
         $user = $this->signin();
@@ -165,7 +166,7 @@ class ApiActivityTypeCategoryControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_single_activity_type_category()
     {
         $user = $this->signin();

--- a/tests/Api/Account/Activity/ApiActivityTypeControllerTest.php
+++ b/tests/Api/Account/Activity/ApiActivityTypeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\Activity;
 use App\Models\Account\ActivityType;
@@ -34,7 +35,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_activity_types()
     {
         $user = $this->signin();
@@ -52,7 +53,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_limit_parameter()
     {
         $user = $this->signin();
@@ -80,7 +81,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_activity_type()
     {
         $user = $this->signin();
@@ -106,7 +107,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_store_an_activity_type_if_query_not_valid()
     {
         $user = $this->signin();
@@ -118,7 +119,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_activity_type()
     {
         $user = $this->signin();
@@ -148,7 +149,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_update_if_activity_type_not_found()
     {
         $user = $this->signin();
@@ -162,7 +163,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_an_activity_type()
     {
         $user = $this->signin();
@@ -193,7 +194,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_delete_the_activity_type_if_not_found()
     {
         $user = $this->signin();
@@ -205,7 +206,7 @@ class ApiActivityTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_single_activity_type()
     {
         $user = $this->signin();

--- a/tests/Api/Account/ApiCompanyControllerTest.php
+++ b/tests/Api/Account/ApiCompanyControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Account;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -24,7 +25,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_companies()
     {
         $user = $this->signin();
@@ -41,7 +42,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -69,7 +70,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_company()
     {
         $user = $this->signin();
@@ -90,7 +91,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_call_with_unexistent_id()
     {
         $user = $this->signin();
@@ -100,7 +101,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_company()
     {
         $user = $this->signin();
@@ -129,7 +130,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_company()
     {
         $user = $this->signin();
@@ -166,7 +167,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_company_if_account_is_not_linked_to_company()
     {
         $user = $this->signin();
@@ -183,7 +184,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_company()
     {
         $user = $this->signin();
@@ -202,7 +203,7 @@ class ApiCompanyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_company_if_company_doesnt_exist()
     {
         $user = $this->signin();

--- a/tests/Api/Account/ApiGenderControllerTest.php
+++ b/tests/Api/Account/ApiGenderControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Account;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
@@ -23,7 +24,7 @@ class ApiGenderControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_genders()
     {
         $user = $this->signin();
@@ -40,7 +41,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -68,7 +69,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_gender()
     {
         $user = $this->signin();
@@ -89,7 +90,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_gender_with_unexistent_id()
     {
         $user = $this->signin();
@@ -99,7 +100,7 @@ class ApiGenderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_gender()
     {
         $user = $this->signin();
@@ -129,7 +130,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_gender()
     {
         $user = $this->signin();
@@ -166,7 +167,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_gender_if_account_is_not_linked_to_gender()
     {
         $user = $this->signin();
@@ -184,7 +185,7 @@ class ApiGenderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_gender_if_account_is_not_linked_to_gender2()
     {
         $user = $this->signin();
@@ -203,7 +204,7 @@ class ApiGenderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_gender()
     {
         $user = $this->signin();
@@ -222,7 +223,7 @@ class ApiGenderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_gender_if_gender_doesnt_exist()
     {
         $user = $this->signin();

--- a/tests/Api/Account/ApiUserControllerTest.php
+++ b/tests/Api/Account/ApiUserControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Account;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Settings\Term;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -27,7 +28,7 @@ class ApiUserControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_authenticated_user()
     {
         $user = $this->signIn();
@@ -46,7 +47,7 @@ class ApiUserControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tells_if_the_user_has_signed_a_given_policy()
     {
         $user = $this->signIn();
@@ -72,7 +73,7 @@ class ApiUserControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_method_not_found_if_no_policy_is_found()
     {
         $user = $this->signIn();
@@ -87,7 +88,7 @@ class ApiUserControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_compliances_signed_by_user()
     {
         $user = $this->signIn();
@@ -104,7 +105,7 @@ class ApiUserControllerTest extends ApiTestCase
         $response->assertJsonCount(2, 'data');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_no_compliances_signed_by_user()
     {
         $user = $this->signIn();
@@ -114,7 +115,7 @@ class ApiUserControllerTest extends ApiTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tries_to_sign_lapolicy()
     {
         $user = $this->signIn();
@@ -126,7 +127,7 @@ class ApiUserControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_signs_lapolicy()
     {
         $user = $this->signIn();

--- a/tests/Api/ApiActivitiesTest.php
+++ b/tests/Api/ApiActivitiesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use App\Models\Account\Activity;
@@ -97,7 +98,7 @@ class ApiActivitiesTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_all()
     {
         $user = $this->signin();
@@ -124,7 +125,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_contact_all()
     {
         $user = $this->signin();
@@ -160,7 +161,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_contact_all_error()
     {
         $this->signin();
@@ -170,7 +171,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_contact_all_error_wrong_account()
     {
         $this->signin();
@@ -181,7 +182,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_one()
     {
         $user = $this->signin();
@@ -208,7 +209,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_one_error()
     {
         $this->signin();
@@ -218,7 +219,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_get_one_error_wrong_account()
     {
         $this->signin();
@@ -229,7 +230,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create()
     {
         $user = $this->signin();
@@ -273,7 +274,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_wrong_parameter()
     {
         $user = $this->signin();
@@ -291,7 +292,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_bad_account()
     {
         $this->signin();
@@ -308,7 +309,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_bad_account2()
     {
         $user = $this->signin();
@@ -329,7 +330,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update()
     {
         $user = $this->signin();
@@ -372,7 +373,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_category()
     {
         $user = $this->signin();
@@ -427,7 +428,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_existing()
     {
         $user = $this->signin();
@@ -494,7 +495,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_parameter()
     {
         $user = $this->signin();
@@ -510,7 +511,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_account_for_activity()
     {
         $user = $this->signin();
@@ -530,7 +531,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_account_for_contacts()
     {
         $user = $this->signin();
@@ -550,7 +551,7 @@ class ApiActivitiesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete()
     {
         $user = $this->signin();
@@ -570,7 +571,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete_error()
     {
         $this->signin();
@@ -582,7 +583,7 @@ class ApiActivitiesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete_with_wrong_account()
     {
         $this->signin();

--- a/tests/Api/ApiControllerTest.php
+++ b/tests/Api/ApiControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Http\Controllers\Api\ApiController;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class ApiControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_http_status_code_returns_the_status_code()
     {
         $apiController = new ApiController;
@@ -28,7 +29,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_error_code_returns_the_error_code()
     {
         $apiController = new ApiController;
@@ -45,7 +46,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_with_parameter_returns_the_parameter()
     {
         $apiController = new ApiController;
@@ -62,7 +63,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_limit_per_page_code_returns_the_limit_per_page()
     {
         $apiController = new ApiController;
@@ -80,7 +81,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_sort_criteria()
     {
         $apiController = new ApiController;
@@ -98,7 +99,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_only_accepts_some_sorting_parameters()
     {
         $apiController = new ApiController;
@@ -118,7 +119,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function calling_api_with_insane_limit_number_raises_an_error()
     {
         $user = $this->signin();
@@ -135,7 +136,7 @@ class ApiControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function calling_api_with_a_wrong_sort_parameter_raises_an_error()
     {
         $user = $this->signin();
@@ -152,7 +153,7 @@ class ApiControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_the_order_by_parameters()
     {
         $apiController = new ApiController;
@@ -182,7 +183,7 @@ class ApiControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function root_api()
     {
         $user = $this->signin();

--- a/tests/Api/ApiCountriesTest.php
+++ b/tests/Api/ApiCountriesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -16,7 +17,7 @@ class ApiCountriesTest extends ApiTestCase
         'object',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_countries()
     {
         $user = $this->signin();
@@ -37,7 +38,7 @@ class ApiCountriesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_country_in_a_specific_locale()
     {
         $user = $this->signin();

--- a/tests/Api/ApiDebtsTest.php
+++ b/tests/Api/ApiDebtsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Debt;
 use App\Models\Account\Account;
@@ -31,7 +32,7 @@ class ApiDebtsTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_debts()
     {
         $user = $this->signin();
@@ -66,7 +67,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_debts_for_a_given_contact()
     {
         $user = $this->signin();
@@ -101,7 +102,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_debts_from_an_invalid_contact()
     {
         $user = $this->signin();
@@ -111,7 +112,7 @@ class ApiDebtsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_debt()
     {
         $user = $this->signin();
@@ -143,7 +144,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_debt_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -153,7 +154,7 @@ class ApiDebtsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_debt()
     {
         $user = $this->signin();
@@ -204,7 +205,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_debt_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -223,7 +224,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_debt_with_a_bad_account()
     {
         $user = $this->signin();
@@ -244,7 +245,7 @@ class ApiDebtsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_debt()
     {
         $user = $this->signin();
@@ -294,7 +295,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_debt_with_missing_parameters()
     {
         $user = $this->signin();
@@ -313,7 +314,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_debt_with_a_wrong_account()
     {
         $user = $this->signin();
@@ -338,7 +339,7 @@ class ApiDebtsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_debt()
     {
         $user = $this->signin();
@@ -365,7 +366,7 @@ class ApiDebtsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_debt_with_an_invalid_id()
     {
         $user = $this->signin();

--- a/tests/Api/ApiGiftsTest.php
+++ b/tests/Api/ApiGiftsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Gift;
 use App\Models\Account\Account;
@@ -32,7 +33,7 @@ class ApiGiftsTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_gifts()
     {
         $user = $this->signin();
@@ -67,7 +68,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_gifts_of_a_contact()
     {
         $user = $this->signin();
@@ -102,7 +103,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_all_the_gifts_of_an_invalid_contact()
     {
         $user = $this->signin();
@@ -112,7 +113,7 @@ class ApiGiftsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_gift()
     {
         $user = $this->signin();
@@ -144,7 +145,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_gift_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -154,7 +155,7 @@ class ApiGiftsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_a_gift()
     {
         $user = $this->signin();
@@ -187,7 +188,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_create_is_for()
     {
         $user = $this->signin();
@@ -225,7 +226,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_create_is_for_bad_account()
     {
         $user = $this->signin();
@@ -248,7 +249,7 @@ class ApiGiftsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_create_error()
     {
         $user = $this->signin();
@@ -266,7 +267,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_create_error_bad_account()
     {
         $user = $this->signin();
@@ -285,7 +286,7 @@ class ApiGiftsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_update()
     {
         $user = $this->signin();
@@ -325,7 +326,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_update_is_for()
     {
         $user = $this->signin();
@@ -370,7 +371,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_update_error()
     {
         $user = $this->signin();
@@ -388,7 +389,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_update_error_bad_account()
     {
         $user = $this->signin();
@@ -412,7 +413,7 @@ class ApiGiftsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_delete()
     {
         $user = $this->signin();
@@ -444,7 +445,7 @@ class ApiGiftsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_delete_error()
     {
         $user = $this->signin();
@@ -454,7 +455,7 @@ class ApiGiftsTest extends ApiTestCase
         $response->assertStatus(422);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gifts_delete_wrong_account()
     {
         $user = $this->signin();

--- a/tests/Api/ApiJournalTest.php
+++ b/tests/Api/ApiJournalTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Journal\Entry;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -22,7 +23,7 @@ class ApiJournalTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_journal_entries()
     {
         $user = $this->signin();
@@ -49,7 +50,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_journal_entry()
     {
         $user = $this->signin();
@@ -76,7 +77,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_journal_entry_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -86,7 +87,7 @@ class ApiJournalTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_journal_entry()
     {
         $user = $this->signin();
@@ -117,7 +118,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_journal_entry_with_missing_parameters()
     {
         $user = $this->signin();
@@ -130,7 +131,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_journal_entry()
     {
         $user = $this->signin();
@@ -166,7 +167,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_journal_entry_with_missing_parameters()
     {
         $user = $this->signin();
@@ -182,7 +183,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_journal_entry()
     {
         $user = $this->signin();
@@ -203,7 +204,7 @@ class ApiJournalTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_journal_entry_with_an_invalid_id()
     {
         $user = $this->signin();

--- a/tests/Api/ApiNotesTest.php
+++ b/tests/Api/ApiNotesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use App\Models\Contact\Note;
@@ -29,7 +30,7 @@ class ApiNotesTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_notes()
     {
         $user = $this->signin();
@@ -64,7 +65,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_notes_of_a_given_contact()
     {
         $user = $this->signin();
@@ -99,7 +100,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_notes_from_a_contact_with_invalid_id()
     {
         $user = $this->signin();
@@ -109,7 +110,7 @@ class ApiNotesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_note()
     {
         $user = $this->signin();
@@ -141,7 +142,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_note_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -151,7 +152,7 @@ class ApiNotesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_note()
     {
         $user = $this->signin();
@@ -187,7 +188,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_note_and_marks_as_favorite()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -227,7 +228,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_note_with_missing_parameters()
     {
         $user = $this->signin();
@@ -244,7 +245,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_note_with_an_invalid_account()
     {
         $user = $this->signin();
@@ -263,7 +264,7 @@ class ApiNotesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_note()
     {
         $user = $this->signin();
@@ -304,7 +305,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_note_and_marks_it_as_favorite()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -349,7 +350,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_note_with_missing_parameters()
     {
         $user = $this->signin();
@@ -366,7 +367,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_note_with_an_invalid_account()
     {
         $user = $this->signin();
@@ -389,7 +390,7 @@ class ApiNotesTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_note()
     {
         $user = $this->signin();
@@ -416,7 +417,7 @@ class ApiNotesTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_note_with_an_invalid_id()
     {
         $user = $this->signin();

--- a/tests/Api/ApiPetsTest.php
+++ b/tests/Api/ApiPetsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Pet;
 use App\Models\Account\Account;
@@ -33,7 +34,7 @@ class ApiPetsTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_get_all()
     {
         $user = $this->signin();
@@ -68,7 +69,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_get_contact_all()
     {
         $user = $this->signin();
@@ -103,7 +104,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_get_contact_all_error()
     {
         $user = $this->signin();
@@ -113,7 +114,7 @@ class ApiPetsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_get_one()
     {
         $user = $this->signin();
@@ -145,7 +146,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_get_one_error()
     {
         $user = $this->signin();
@@ -155,7 +156,7 @@ class ApiPetsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_create()
     {
         $user = $this->signin();
@@ -191,7 +192,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_create_error()
     {
         $user = $this->signin();
@@ -208,7 +209,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_create_error_bad_account()
     {
         $user = $this->signin();
@@ -227,7 +228,7 @@ class ApiPetsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_update()
     {
         $user = $this->signin();
@@ -268,7 +269,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_update_error()
     {
         $user = $this->signin();
@@ -285,7 +286,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_update_error_bad_account()
     {
         $user = $this->signin();
@@ -308,7 +309,7 @@ class ApiPetsTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_delete()
     {
         $user = $this->signin();
@@ -335,7 +336,7 @@ class ApiPetsTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function pets_delete_error()
     {
         $user = $this->signin();

--- a/tests/Api/ApiRelationshipControllerTest.php
+++ b/tests/Api/ApiRelationshipControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use App\Models\Relationship\Relationship;
@@ -12,7 +13,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_the_api_call_if_parameters_are_not_right()
     {
         $user = $this->signin();
@@ -54,7 +55,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectDataError($response, ['The of contact must be an integer.']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_relationship_type_id_is_invalid()
     {
         $user = $this->signin();
@@ -75,7 +76,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_id_is_invalid()
     {
         $user = $this->signin();
@@ -96,7 +97,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_of_contact_id_is_invalid()
     {
         $user = $this->signin();
@@ -117,7 +118,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_new_resource()
     {
         $user = $this->signin();
@@ -158,7 +159,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_displays_a_relationship()
     {
         $user = $this->signin();
@@ -192,7 +193,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
                     ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_relationship()
     {
         $user = $this->signin();
@@ -241,7 +242,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_the_delete_api_call_if_parameters_are_not_right()
     {
         $user = $this->signin();
@@ -260,7 +261,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_the_update_api_call_if_parameters_are_not_right()
     {
         $user = $this->signin();
@@ -277,7 +278,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_rejects_the_update_api_call_if_parameters_are_not_right2()
     {
         $user = $this->signin();
@@ -293,7 +294,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectDataError($response, ['The relationship type id must be an integer.']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_the_update_if_relationship_type_id_is_invalid()
     {
         $user = $this->signin();
@@ -309,7 +310,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_relationship()
     {
         $user = $this->signin();
@@ -350,7 +351,7 @@ class ApiRelationshipControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_displays_all_relationships_of_a_contact()
     {
         $user = $this->signin();

--- a/tests/Api/ApiRelationshipTypeControllerTest.php
+++ b/tests/Api/ApiRelationshipTypeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Relationship\RelationshipType;
 use App\Models\Relationship\RelationshipTypeGroup;
@@ -11,7 +12,7 @@ class ApiRelationshipTypeControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_right_number_of_relationship_types()
     {
         $user = $this->signin();
@@ -31,7 +32,7 @@ class ApiRelationshipTypeControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_relationship_types()
     {
         $user = $this->signin();
@@ -67,7 +68,7 @@ class ApiRelationshipTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_relationship_type_group()
     {
         $user = $this->signin();

--- a/tests/Api/ApiRelationshipTypeGroupControllerTest.php
+++ b/tests/Api/ApiRelationshipTypeGroupControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Relationship\RelationshipTypeGroup;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class ApiRelationshipTypeGroupControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_right_number_of_relationship_type_groups()
     {
         $user = $this->signin();
@@ -30,7 +31,7 @@ class ApiRelationshipTypeGroupControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_relationship_type_groups()
     {
         $user = $this->signin();
@@ -58,7 +59,7 @@ class ApiRelationshipTypeGroupControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_relationship_type_group()
     {
         $user = $this->signin();

--- a/tests/Api/ApiReminderControllerTest.php
+++ b/tests/Api/ApiReminderControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use App\Models\Account\Account;
@@ -32,7 +33,7 @@ class ApiReminderControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_reminders()
     {
         $user = $this->signin();
@@ -70,7 +71,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_reminders_of_a_contact()
     {
         $user = $this->signin();
@@ -105,7 +106,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_reminder_of_a_contact_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -115,7 +116,7 @@ class ApiReminderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_reminder()
     {
         $user = $this->signin();
@@ -147,7 +148,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_reminder_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -157,7 +158,7 @@ class ApiReminderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_reminder()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -198,7 +199,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_reminders_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -218,7 +219,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function reminders_create_error_bad_account()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -242,7 +243,7 @@ class ApiReminderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_reminder()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -291,7 +292,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_reminder_generates_an_error()
     {
         $user = $this->signin();
@@ -310,7 +311,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function reminders_update_error_bad_account()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -334,7 +335,7 @@ class ApiReminderControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_reminder()
     {
         $user = $this->signin();
@@ -356,7 +357,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function reminders_delete_error()
     {
         $user = $this->signin();
@@ -368,7 +369,7 @@ class ApiReminderControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_upcoming_reminders()
     {
         $user = $this->signin();

--- a/tests/Api/ApiStatisticsControllerTest.php
+++ b/tests/Api/ApiStatisticsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -18,7 +19,7 @@ class ApiStatisticsControllerTest extends ApiTestCase
         'number_of_new_users_last_week',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_right_structure_of_the_public_statistics()
     {
         config(['monica.allow_statistics_through_public_api_access' => true]);
@@ -34,7 +35,7 @@ class ApiStatisticsControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_error_if_public_statistics_are_not_available()
     {
         config(['monica.allow_statistics_through_public_api_access' => false]);

--- a/tests/Api/ApiTagControllerTest.php
+++ b/tests/Api/ApiTagControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Tag;
 use App\Models\Contact\Contact;
@@ -135,7 +136,7 @@ class ApiTagControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_all_tags()
     {
         $user = $this->signin();
@@ -166,7 +167,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_tag()
     {
         $user = $this->signin();
@@ -188,7 +189,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_triggers_error_if_tag_unknown()
     {
         $user = $this->signin();
@@ -198,7 +199,7 @@ class ApiTagControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_tag()
     {
         $user = $this->signin();
@@ -226,7 +227,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_tag()
     {
         $user = $this->signin();
@@ -260,7 +261,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_tag()
     {
         $user = $this->signin();
@@ -282,7 +283,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_tag_associated()
     {
         $user = $this->signin();
@@ -330,7 +331,7 @@ class ApiTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_contacts_for_a_given_tag()
     {
         $user = $this->signin();
@@ -366,7 +367,7 @@ class ApiTagControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_contacts_for_a_given_tag_and_applies_pagination()
     {
         $user = $this->signin();

--- a/tests/Api/ApiTaskControllerTest.php
+++ b/tests/Api/ApiTaskControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
@@ -29,7 +30,7 @@ class ApiTaskControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_tasks()
     {
         $user = $this->signin();
@@ -64,7 +65,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_tasks_of_a_contact()
     {
         $user = $this->signin();
@@ -99,7 +100,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_the_tasks_of_a_contact_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -109,7 +110,7 @@ class ApiTaskControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_task()
     {
         $user = $this->signin();
@@ -141,7 +142,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_a_task_with_an_invalid_id()
     {
         $user = $this->signin();
@@ -151,7 +152,7 @@ class ApiTaskControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_a_task_associated_to_a_contact()
     {
         $user = $this->signin();
@@ -186,7 +187,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_a_task_not_associated_to_a_contact()
     {
         $user = $this->signin();
@@ -221,7 +222,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function creating_a_task_triggers_invalid_parameter_error()
     {
         $user = $this->signin();
@@ -238,7 +239,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function creating_a_task_with_a_wrong_account_id_triggers_an_error()
     {
         $user = $this->signin();
@@ -257,7 +258,7 @@ class ApiTaskControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_task()
     {
         $user = $this->signin();
@@ -296,7 +297,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_a_task_with_missing_parameters_triggers_an_error()
     {
         $user = $this->signin();
@@ -314,7 +315,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_a_task_with_wrong_account_triggers_an_error()
     {
         $user = $this->signin();
@@ -334,7 +335,7 @@ class ApiTaskControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_task()
     {
         $user = $this->signin();
@@ -357,7 +358,7 @@ class ApiTaskControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_task_if_wrong_task_id()
     {
         $user = $this->signin();

--- a/tests/Api/Authentication/ApiAuthenticateTest.php
+++ b/tests/Api/Authentication/ApiAuthenticateTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Api\Authentication;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 
 class ApiAuthenticateTest extends ApiTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function guest_is_rejected()
     {
         $response = $this->json('GET', '/api/contacts');

--- a/tests/Api/Contact/ApiAdressesControllerTest.php
+++ b/tests/Api/Contact/ApiAdressesControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
@@ -33,7 +34,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_addresses()
     {
         $user = $this->signin();
@@ -62,7 +63,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -96,7 +97,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_addresses_for_a_specific_contact()
     {
         $user = $this->signin();
@@ -117,7 +118,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function calling_addresses_gets_an_error_if_contact_doesnt_exist()
     {
         $user = $this->signin();
@@ -127,7 +128,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_specific_address()
     {
         $user = $this->signin();
@@ -153,7 +154,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_an_address()
     {
         $user = $this->signin();
@@ -192,7 +193,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         $this->assertGreaterThan(0, $addressId);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_addresses_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -206,7 +207,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_addresses_gets_an_error_if_contact_is_not_linked_to_user()
     {
         $user = $this->signin();
@@ -227,7 +228,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_address()
     {
         $user = $this->signin();
@@ -268,7 +269,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_address_generates_an_error()
     {
         $user = $this->signin();
@@ -283,7 +284,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_an_address_if_account_is_not_linked_to_address()
     {
         $user = $this->signin();
@@ -300,7 +301,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_an_address()
     {
         $user = $this->signin();
@@ -326,7 +327,7 @@ class ApiAdressesControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function address_delete_error()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiAuditLogControllerTest.php
+++ b/tests/Api/Contact/ApiAuditLogControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use App\Models\Instance\AuditLog;
@@ -24,7 +25,7 @@ class ApiAuditLogControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_audit_logs()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiAvatarControllerTest.php
+++ b/tests/Api/Contact/ApiAvatarControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Http\UploadedFile;
@@ -29,7 +30,7 @@ class ApiAvatarControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_photo_avatar()
     {
         Storage::fake();
@@ -74,7 +75,7 @@ class ApiAvatarControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_gravatar_avatar()
     {
         $user = $this->signin();
@@ -99,7 +100,7 @@ class ApiAvatarControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_default_avatar()
     {
         $user = $this->signin();
@@ -123,7 +124,7 @@ class ApiAvatarControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function avatar_update_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -140,7 +141,7 @@ class ApiAvatarControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function avatar_update_gets_an_error_if_contact_is_not_linked_to_user()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiCallControllerTest.php
+++ b/tests/Api/Contact/ApiCallControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Call;
 use App\Models\Account\Account;
@@ -27,7 +28,7 @@ class ApiCallControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_calls()
     {
         $user = $this->signin();
@@ -62,7 +63,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_calls_of_a_contact()
     {
         $user = $this->signin();
@@ -97,7 +98,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function calling_calls_get_error()
     {
         $user = $this->signin();
@@ -107,7 +108,7 @@ class ApiCallControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_call()
     {
         $user = $this->signin();
@@ -139,7 +140,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function calling_one_call_gets_an_error()
     {
         $user = $this->signin();
@@ -149,7 +150,7 @@ class ApiCallControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_call()
     {
         $user = $this->signin();
@@ -183,7 +184,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_calls_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -200,7 +201,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_create_a_call_if_account_is_wrong()
     {
         $user = $this->signin();
@@ -219,7 +220,7 @@ class ApiCallControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_call()
     {
         $user = $this->signin();
@@ -258,7 +259,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_call_generates_an_error()
     {
         $user = $this->signin();
@@ -279,7 +280,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_a_call_if_account_is_not_linked_to_call()
     {
         $user = $this->signin();
@@ -298,7 +299,7 @@ class ApiCallControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_call()
     {
         $user = $this->signin();
@@ -325,7 +326,7 @@ class ApiCallControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_call_if_call_doesnt_exist()
     {
         $user = $this->signin();
@@ -335,7 +336,7 @@ class ApiCallControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_delete_a_call_if_account_is_not_linked()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiContactControllerTest.php
+++ b/tests/Api/Contact/ApiContactControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use App\Models\Contact\Gender;
@@ -221,7 +222,7 @@ class ApiContactControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_contacts()
     {
         $user = $this->signin();
@@ -243,7 +244,7 @@ class ApiContactControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_contacts_without_gender()
     {
         $user = $this->signin();
@@ -265,7 +266,7 @@ class ApiContactControllerTest extends ApiTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_contains_pagination_when_fetching_contacts()
     {
         $user = $this->signin();
@@ -287,7 +288,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -323,7 +324,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_is_possible_to_search_contacts_with_query()
     {
         $user = $this->signin();
@@ -353,7 +354,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_is_possible_to_search_contacts_and_limit_query()
     {
         $user = $this->signin();
@@ -385,7 +386,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_is_possible_to_search_contacts_and_limit_query_and_paginate()
     {
         $user = $this->signin();
@@ -417,7 +418,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_contact()
     {
         $user = $this->signin();
@@ -440,7 +441,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_a_contact_matches_a_specific_json_structure()
     {
         $user = $this->signin();
@@ -459,7 +460,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_a_partial_contact_matches_a_specific_json_structure()
     {
         $user = $this->signin();
@@ -479,7 +480,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_a_contact_with_the_parameter_with_matches_a_specific_json_structure()
     {
         $user = $this->signin();
@@ -515,7 +516,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_list_of_contacts_with_parameter_and_limit_and_page()
     {
         $user = $this->signin();
@@ -571,7 +572,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prevents_a_contact_query_injection()
     {
         $firstuser = $this->signin();
@@ -597,7 +598,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_contact_with_the_contact_fields()
     {
         $user = $this->signin();
@@ -641,7 +642,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_query_all_account()
     {
         $firstuser = $this->signin();
@@ -684,7 +685,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_query_internationalphone()
     {
         $user = $this->signin();
@@ -717,7 +718,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_contact()
     {
         $user = $this->signin();
@@ -763,7 +764,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function creating_contact_is_not_possible_if_parameters_are_missing()
     {
         $user = $this->signin();
@@ -780,7 +781,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_birthdate()
     {
         $user = $this->signin();
@@ -835,7 +836,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_create_birthdate_year_unknown()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -891,7 +892,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_create_birthdate_age_based()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -948,7 +949,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_create_deceased_date()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1003,7 +1004,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_create_deceased_date_year_unknown()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1058,7 +1059,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_contact()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1116,7 +1117,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_update_bad_account()
     {
         $user = $this->signin();
@@ -1148,7 +1149,7 @@ class ApiContactControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_update_the_contact_if_parameters_are_missing()
     {
         $user = $this->signin();
@@ -1167,7 +1168,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_update_birthdate()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1217,7 +1218,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_update_birthdate_year_unknown()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1267,7 +1268,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_update_birthdate_age_based()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1318,7 +1319,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_update_deceased_date()
     {
         Carbon::setTestNow(Carbon::create(2018, 1, 1, 7, 0, 0));
@@ -1367,7 +1368,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_a_contact()
     {
         $user = $this->signin();
@@ -1385,7 +1386,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_me_contact()
     {
         $user = $this->signin();
@@ -1409,7 +1410,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_career()
     {
         $user = $this->signin();
@@ -1458,7 +1459,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_career_with_wrong_params()
     {
         $user = $this->signin();
@@ -1471,7 +1472,7 @@ class ApiContactControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_career_on_partial_contact()
     {
         $user = $this->signin();
@@ -1487,7 +1488,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_food_preferences()
     {
         $user = $this->signin();
@@ -1526,7 +1527,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_food_preferences_with_wrong_params()
     {
         $user = $this->signin();
@@ -1536,7 +1537,7 @@ class ApiContactControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_food_preferences_on_partial_contact()
     {
         $user = $this->signin();
@@ -1552,7 +1553,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_first_met()
     {
         $user = $this->signin();
@@ -1587,7 +1588,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_first_met_age()
     {
         Carbon::setTestNow(Carbon::create(2019, 12, 1, 7, 0, 0));
@@ -1622,7 +1623,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_first_met_reminder()
     {
         $user = $this->signin();
@@ -1655,7 +1656,7 @@ class ApiContactControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_first_met_with_wrong_params()
     {
         $user = $this->signin();
@@ -1671,7 +1672,7 @@ class ApiContactControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_an_error_when_set_first_met_on_partial_contact()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiContactTagControllerTest.php
+++ b/tests/Api/Contact/ApiContactTagControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Tag;
 use App\Models\Contact\Contact;
@@ -11,7 +12,7 @@ class ApiContactTagControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tags_are_required_to_associate_tags_to_a_contact()
     {
         $user = $this->signin();
@@ -25,7 +26,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         $this->expectDataError($response, ['The tags field is required.']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_associates_tags_to_a_contact()
     {
         $user = $this->signin();
@@ -67,7 +68,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tags_ignore_empty_tags()
     {
         $user = $this->signin();
@@ -113,7 +114,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function a_list_of_tags_are_required_to_remove_a_tag_from_a_contact()
     {
         $user = $this->signin();
@@ -127,7 +128,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         $this->expectDataError($response, ['The tags field is required.']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_one_tag_from_a_contact()
     {
         $user = $this->signin();
@@ -181,7 +182,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_multiple_tags_from_a_contact()
     {
         $user = $this->signin();
@@ -246,7 +247,7 @@ class ApiContactTagControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_all_tags_from_a_contact()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiConversationControllerTest.php
+++ b/tests/Api/Contact/ApiConversationControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -50,7 +51,7 @@ class ApiConversationControllerTest extends ApiTestCase
         return $conversation;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_conversations()
     {
         $user = $this->signin();
@@ -80,7 +81,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -108,7 +109,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_conversation()
     {
         $user = $this->signin();
@@ -124,7 +125,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_conversation_for_a_specific_contact()
     {
         $user = $this->signin();
@@ -142,7 +143,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_conversation()
     {
         $user = $this->signin();
@@ -167,7 +168,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_conversation()
     {
         $user = $this->signin();
@@ -189,7 +190,7 @@ class ApiConversationControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_conversation()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiDocumentControllerTest.php
+++ b/tests/Api/Contact/ApiDocumentControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -48,7 +49,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         return $document;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_documents()
     {
         $user = $this->signin();
@@ -78,7 +79,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -106,7 +107,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_document()
     {
         $user = $this->signin();
@@ -122,7 +123,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function document_show_gets_an_error_if_document_is_not_linked_to_account()
     {
         $user = $this->signin();
@@ -138,7 +139,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_document_for_a_specific_contact()
     {
         $user = $this->signin();
@@ -163,7 +164,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_store_a_document_for_a_specific_contact()
     {
         Storage::fake();
@@ -193,7 +194,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         Storage::disk('public')->assertExists($response->json('data.new_filename'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function document_store_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -206,7 +207,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function document_store_gets_an_error_if_contact_is_not_linked_to_user()
     {
         $user = $this->signin();
@@ -221,7 +222,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroy_a_document()
     {
         $user = $this->signin();
@@ -238,7 +239,7 @@ class ApiDocumentControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function document_destroy_gets_an_error_if_document_is_not_linked_to_user()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiLifeEventControllerTest.php
+++ b/tests/Api/Contact/ApiLifeEventControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -54,7 +55,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         return $lifeEvent;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_life_events()
     {
         $user = $this->signin();
@@ -84,7 +85,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -112,7 +113,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_life_event()
     {
         $user = $this->signin();
@@ -128,7 +129,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_a_life_event_doesnt_work_if_life_event_doesnt_exist()
     {
         $user = $this->signin();
@@ -138,7 +139,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_life_event()
     {
         $user = $this->signin();
@@ -168,7 +169,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function creating_a_life_event_doesnt_work_if_ids_are_not_found()
     {
         $user = $this->signin();
@@ -208,7 +209,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function creating_a_life_event_doesnt_work_if_parameters_are_not_right()
     {
         $user = $this->signin();
@@ -235,7 +236,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_life_event()
     {
         $user = $this->signin();
@@ -259,7 +260,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_a_life_event_doesnt_work_if_ids_are_not_found()
     {
         $user = $this->signin();
@@ -288,7 +289,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function updating_a_life_event_doesnt_work_if_parameters_are_not_right()
     {
         $user = $this->signin();
@@ -309,7 +310,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_life_event()
     {
         $user = $this->signin();
@@ -326,7 +327,7 @@ class ApiLifeEventControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function deleting_a_life_event_doesnt_work_if_ids_are_not_found()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiMeControllerTest.php
+++ b/tests/Api/Contact/ApiMeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class ApiMeControllerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_me_contact()
     {
         $user = $this->signin();
@@ -28,7 +29,7 @@ class ApiMeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_error_if_wrong_account_on_sets_me_contact()
     {
         $this->signin();
@@ -39,7 +40,7 @@ class ApiMeControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_error_if_account_not_exists_on_sets_me_contact()
     {
         $this->signin();
@@ -51,7 +52,7 @@ class ApiMeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_me_contact()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiMessageControllerTest.php
+++ b/tests/Api/Contact/ApiMessageControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -66,7 +67,7 @@ class ApiMessageControllerTest extends ApiTestCase
         return $message;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_a_message_to_a_conversation()
     {
         $user = $this->signin();
@@ -86,7 +87,7 @@ class ApiMessageControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_message()
     {
         $user = $this->signin();
@@ -107,7 +108,7 @@ class ApiMessageControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_message()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiPhotoControllerTest.php
+++ b/tests/Api/Contact/ApiPhotoControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\User\User;
 use App\Models\Account\Photo;
@@ -48,7 +49,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         return $photo;
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_photos()
     {
         $user = $this->signin();
@@ -78,7 +79,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_applies_the_limit_parameter_in_search()
     {
         $user = $this->signin();
@@ -106,7 +107,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_photo()
     {
         $user = $this->signin();
@@ -122,7 +123,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function photo_show_gets_an_error_if_photo_is_not_linked_to_account()
     {
         $user = $this->signin();
@@ -139,7 +140,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_photo_for_a_specific_contact()
     {
         $user = $this->signin();
@@ -164,7 +165,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_store_a_photo_for_a_specific_contact()
     {
         Storage::fake();
@@ -193,7 +194,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         Storage::disk('public')->assertExists($response->json('data.new_filename'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function photo_store_gets_an_error_if_fields_are_missing()
     {
         $user = $this->signin();
@@ -206,7 +207,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function photo_store_gets_an_error_if_contact_is_not_linked_to_user()
     {
         $user = $this->signin();
@@ -222,7 +223,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroy_a_photo()
     {
         $user = $this->signin();
@@ -244,7 +245,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function photo_destroy_gets_an_error_if_photo_is_not_linked_to_account()
     {
         $user = $this->signin();
@@ -261,7 +262,7 @@ class ApiPhotoControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_store_and_destroy_a_photo()
     {
         Storage::fake();

--- a/tests/Api/ContactField/ApiContactFieldControllerTest.php
+++ b/tests/Api/ContactField/ApiContactFieldControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\ContactField;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -26,7 +27,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_get_contact_all()
     {
         $user = $this->signin();
@@ -61,7 +62,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_get_contact_all_error()
     {
         $user = $this->signin();
@@ -71,7 +72,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_get_one()
     {
         $user = $this->signin();
@@ -103,7 +104,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_get_one_error()
     {
         $user = $this->signin();
@@ -113,7 +114,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_create()
     {
         $user = $this->signin();
@@ -150,7 +151,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_create_error()
     {
         $user = $this->signin();
@@ -168,7 +169,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_create_error_bad_account()
     {
         $user = $this->signin();
@@ -190,7 +191,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_update()
     {
         $user = $this->signin();
@@ -229,7 +230,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_update_error()
     {
         $user = $this->signin();
@@ -247,7 +248,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_update_error_bad_account()
     {
         $user = $this->signin();
@@ -270,7 +271,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_delete()
     {
         $user = $this->signin();
@@ -297,7 +298,7 @@ class ApiContactFieldControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_fields_delete_error()
     {
         $user = $this->signin();

--- a/tests/Api/ContactField/ApiContactFieldTypeControllerTest.php
+++ b/tests/Api/ContactField/ApiContactFieldTypeControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\ContactField;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\ContactFieldType;
@@ -25,7 +26,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_get_one()
     {
         $user = $this->signin();
@@ -52,7 +53,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_get_one_error()
     {
         $user = $this->signin();
@@ -62,7 +63,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_create()
     {
         $user = $this->signin();
@@ -93,7 +94,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_create_error()
     {
         $user = $this->signin();
@@ -106,7 +107,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_update()
     {
         $user = $this->signin();
@@ -141,7 +142,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_update_error()
     {
         $user = $this->signin();
@@ -156,7 +157,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_update_error_bad_account()
     {
         $user = $this->signin();
@@ -175,7 +176,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_delete()
     {
         $user = $this->signin();
@@ -196,7 +197,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_delete_error()
     {
         $user = $this->signin();
@@ -206,7 +207,7 @@ class ApiContactFieldTypeControllerTest extends ApiTestCase
         $this->expectNotFound($response);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function contact_field_type_delete_bad_account()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/CalDAVBirthdaysTest.php
+++ b/tests/Api/DAV/CalDAVBirthdaysTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use Illuminate\Support\Str;
@@ -13,7 +14,7 @@ class CalDAVBirthdaysTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_birthdays_propfind()
     {
         $user = $this->signin();
@@ -63,7 +64,7 @@ class CalDAVBirthdaysTest extends ApiTestCase
         '</d:multistatus', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_birthdays_propfind_one_birthday()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/CalDAVTasksTest.php
+++ b/tests/Api/DAV/CalDAVTasksTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use App\Models\Contact\Task;
@@ -13,7 +14,7 @@ class CalDAVTasksTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_tasks_propfind()
     {
         $user = $this->signin();
@@ -64,7 +65,7 @@ class CalDAVTasksTest extends ApiTestCase
         '</d:multistatus', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_tasks_propfind_one_task()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/CardDAVTest.php
+++ b/tests/Api/DAV/CardDAVTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use App\Models\User\SyncToken;
@@ -12,7 +13,7 @@ class CardDAVTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_addressbooks()
     {
         $user = $this->signin();
@@ -26,7 +27,7 @@ class CardDAVTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/addressbooks/{$user->email}/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_addressbooks_user()
     {
         $user = $this->signin();
@@ -40,7 +41,7 @@ class CardDAVTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/addressbooks/{$user->email}/contacts/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_contacts()
     {
         $user = $this->signin();
@@ -89,7 +90,7 @@ class CardDAVTest extends ApiTestCase
         '</d:multistatus', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_one_contact()
     {
         $user = $this->signin();
@@ -105,7 +106,7 @@ class CardDAVTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/addressbooks/{$user->email}/contacts/{$contact->uuid}.vcf</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_one_contact_without_extension()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/CardEtag.php
+++ b/tests/Api/DAV/CardEtag.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use Sabre\VObject\Version;
 use App\Models\Contact\Task;
 use App\Models\Contact\Contact;
 use App\Models\Instance\SpecialDate;
@@ -32,7 +33,7 @@ trait CardEtag
     {
         $contact = $contact->refresh();
         $url = route('people.show', $contact);
-        $sabreversion = \Sabre\VObject\Version::VERSION;
+        $sabreversion = Version::VERSION;
         $timestamp = $contact->updated_at->format('Ymd\THis\Z');
 
         $data = "BEGIN:VCARD
@@ -103,7 +104,7 @@ N:{$contact->last_name};{$contact->first_name};{$contact->middle_name};;
         $description1 = mb_substr($description, 0, 61);
         $description2 = mb_substr($description, 61);
 
-        $sabreversion = \Sabre\VObject\Version::VERSION;
+        $sabreversion = Version::VERSION;
         $timestamp = $specialDate->created_at->format('Ymd\THis\Z');
 
         $start = $specialDate->date->format('Ymd');
@@ -140,7 +141,7 @@ END:VCALENDAR
 
     protected function getVTodo(Task $task, bool $realFormat = false): string
     {
-        $sabreversion = \Sabre\VObject\Version::VERSION;
+        $sabreversion = Version::VERSION;
         $timestamp = $task->created_at->format('Ymd\THis\Z');
         $contact = $task->contact;
 

--- a/tests/Api/DAV/DAVServerTest.php
+++ b/tests/Api/DAV/DAVServerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
 use Tests\ApiTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -9,7 +10,7 @@ class DAVServerTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_propfind_base()
     {
         $user = $this->signin();
@@ -25,7 +26,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertSee('<d:response><d:href>/dav/calendars/</d:href>', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_propfind_principals()
     {
         $user = $this->signin();
@@ -39,7 +40,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/principals/{$user->email}/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_propfind_principals_user()
     {
         $user = $this->signin();
@@ -52,7 +53,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/principals/{$user->email}/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_ensure_browser_plugin_not_enabled()
     {
         $user = $this->signin();
@@ -64,7 +65,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertHeader('Location', route('settings.dav'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_propfind_groupmemberset()
     {
         $user = $this->signin();
@@ -104,7 +105,7 @@ class DAVServerTest extends ApiTestCase
         '</d:multistatus>', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_report_propertysearch()
     {
         $user = $this->signin();
@@ -143,7 +144,7 @@ class DAVServerTest extends ApiTestCase
         '</d:multistatus>', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_propfind()
     {
         $user = $this->signin();
@@ -157,7 +158,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/calendars/{$user->email}/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_propfind_calendars_user()
     {
         $user = $this->signin();
@@ -172,7 +173,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertSee("<d:response><d:href>/dav/calendars/{$user->email}/tasks/</d:href>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_limit_users_unauthorized()
     {
         $user = $this->signin();
@@ -184,7 +185,7 @@ class DAVServerTest extends ApiTestCase
         $response->assertStatus(403);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_dav_limit_users_authorized()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/VCardContactTest.php
+++ b/tests/Api/DAV/VCardContactTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
+use Sabre\DAV\Version;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use Illuminate\Support\Str;
 use App\Models\Account\Photo;
@@ -16,7 +19,7 @@ class VCardContactTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag, PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_get_one_contact()
     {
         $user = $this->signin();
@@ -34,7 +37,7 @@ class VCardContactTest extends ApiTestCase
         $this->assertVObjectEqualsVObject($this->getCard($contact, true), $response->getContent());
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_put_one_contact()
     {
         $user = $this->signin();
@@ -55,7 +58,7 @@ class VCardContactTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_put_one_contact_with_photo()
     {
         Storage::fake();
@@ -87,7 +90,7 @@ class VCardContactTest extends ApiTestCase
         Storage::disk('public')->assertExists($photo->new_filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_put_one_contact_with_photo_already_set()
     {
         $user = $this->signin();
@@ -121,7 +124,7 @@ class VCardContactTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_put_one_contact_with_photo_and_attributes()
     {
         Storage::fake();
@@ -153,7 +156,7 @@ class VCardContactTest extends ApiTestCase
         Storage::disk('public')->assertExists($photo->new_filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact()
     {
         $user = $this->signin();
@@ -177,7 +180,7 @@ class VCardContactTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact_if_modified()
     {
         $user = $this->signin();
@@ -205,7 +208,7 @@ class VCardContactTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact_if_modified_not_modified()
     {
         $user = $this->signin();
@@ -233,7 +236,7 @@ class VCardContactTest extends ApiTestCase
         $response->assertHeaderMissing('ETag');
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact_if_unmodified()
     {
         $user = $this->signin();
@@ -261,7 +264,7 @@ class VCardContactTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact_if_unmodified_error()
     {
         $user = $this->signin();
@@ -283,14 +286,14 @@ class VCardContactTest extends ApiTestCase
 
         $response->assertHeader('X-Sabre-Version');
 
-        $sabreversion = \Sabre\DAV\Version::VERSION;
+        $sabreversion = Version::VERSION;
         $response->assertSee("<d:error xmlns:d=\"DAV:\" xmlns:s=\"http://sabredav.org/ns\">
   <s:sabredav-version>{$sabreversion}</s:sabredav-version>
   <s:exception>Sabre\DAV\Exception\PreconditionFailed</s:exception>
   <s:message>An If-Unmodified-Since header was specified, but the entity has been changed since the specified date.</s:message>", false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_carddav_update_existing_contact_no_modify()
     {
         $user = $this->signin();
@@ -446,8 +449,8 @@ class VCardContactTest extends ApiTestCase
           '</d:multistatus>', false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Group('dav')]
+    #[Test]
     public function carddav_delete_one_contact()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/VEventBirthdayTest.php
+++ b/tests/Api/DAV/VEventBirthdayTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
 use Tests\ApiTestCase;
 use Illuminate\Support\Str;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class VEventBirthdayTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag, PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_get_one_birthday()
     {
         $user = $this->signin();

--- a/tests/Api/DAV/VTodoTaskTest.php
+++ b/tests/Api/DAV/VTodoTaskTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Api\DAV;
 
+use PHPUnit\Framework\Attributes\Group;
+use Sabre\VObject\Version;
 use Carbon\Carbon;
 use Tests\ApiTestCase;
 use Illuminate\Support\Str;
@@ -14,7 +16,7 @@ class VTodoTaskTest extends ApiTestCase
 {
     use DatabaseTransactions, CardEtag, PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_get_one_task()
     {
         $user = $this->signin();
@@ -33,7 +35,7 @@ class VTodoTaskTest extends ApiTestCase
         $this->assertVObjectEqualsVObject($this->getVTodo($task, true), $response->getContent() ?: $response->streamedContent());
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_put_one_task()
     {
         $user = $this->signin();
@@ -65,7 +67,7 @@ END:VCALENDAR
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_update_existing_task()
     {
         $user = $this->signin();
@@ -98,7 +100,7 @@ END:VCALENDAR
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('dav')]
+    #[Group('dav')]
     public function test_caldav_update_task_complete()
     {
         $user = $this->signin();
@@ -164,7 +166,7 @@ END:VCALENDAR
         $response->assertHeader('X-Sabre-Version');
 
         $peopleurl = route('people.show', $contact);
-        $sabreversion = \Sabre\VObject\Version::VERSION;
+        $sabreversion = Version::VERSION;
 
         $response->assertSee('<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/">'.
         '<d:response>'.

--- a/tests/Api/Settings/ApiAuditLogControllerTest.php
+++ b/tests/Api/Settings/ApiAuditLogControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Instance\AuditLog;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -23,7 +24,7 @@ class ApiAuditLogControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_audit_logs()
     {
         $user = $this->signin();
@@ -50,7 +51,7 @@ class ApiAuditLogControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_is_possible_to_get_audit_logs_and_limit_query_and_paginate()
     {
         $user = $this->signin();

--- a/tests/Api/Settings/ApiComplianceControllerTest.php
+++ b/tests/Api/Settings/ApiComplianceControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Settings\Term;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -21,7 +22,7 @@ class ApiComplianceControllerTest extends ApiTestCase
         'updated_at',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_terms()
     {
         $term = factory(Term::class, 10)->create([
@@ -52,7 +53,7 @@ class ApiComplianceControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_single_term()
     {
         $term = factory(Term::class)->create([
@@ -76,7 +77,7 @@ class ApiComplianceControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_get_a_single_term()
     {
         $response = $this->json('GET', '/api/compliance/3');

--- a/tests/Api/Settings/ApiCurrencyControllerTest.php
+++ b/tests/Api/Settings/ApiCurrencyControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Api\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Settings\Currency;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -18,7 +19,7 @@ class ApiCurrencyControllerTest extends ApiTestCase
         'symbol',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_currencies()
     {
         // in theory the currencies table is seeded by the initial script
@@ -41,7 +42,7 @@ class ApiCurrencyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_one_currency()
     {
         $currency = factory(Currency::class)->create([]);
@@ -60,7 +61,7 @@ class ApiCurrencyControllerTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_currency_that_is_invalid()
     {
         $response = $this->json('GET', '/api/currencies/0');

--- a/tests/Browser/Auth/AuthControllerTest.php
+++ b/tests/Browser/Auth/AuthControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Browser\Auth;
 
+use GuzzleHttp\Exception\RequestException;
 use Tests\TestCase;
 use GuzzleHttp\Client;
 use App\Models\User\User;
@@ -223,7 +224,7 @@ class AuthControllerTest extends TestCase
             $response = $http->post($path, [
                 'form_params' => $param,
             ]);
-        } catch (\GuzzleHttp\Exception\RequestException $e) {
+        } catch (RequestException $e) {
             $response = $e->getResponse();
         }
 

--- a/tests/Browser/Settings/MultiFAControllerTest.php
+++ b/tests/Browser/Settings/MultiFAControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Browser\Settings;
 
+use PHPUnit\Framework\Attributes\Group;
+use PragmaRX\Google2FA\Google2FA;
 use Zxing\QrReader;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
@@ -22,7 +24,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test if the user has 2fa Enable Link in Security Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testHasSettings2faEnableLink()
     {
         $this->browse(function (Browser $browser) {
@@ -35,7 +37,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test if the user has WebAuthn Enable Link in Security Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testHasSettingsWebAuthnEnableLink()
     {
         $this->browse(function (Browser $browser) {
@@ -48,7 +50,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the barcode generated in 2fa Enable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testHas2faEnableBarCode()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -67,8 +69,8 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the barcode generated in 2fa Enable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
-    #[\PHPUnit\Framework\Attributes\Group('multifabarcode')]
+    #[Group('multifa')]
+    #[Group('multifabarcode')]
     public function testBarCodeContent()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -117,7 +119,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the 2fa Enable Page with wrong code.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2faWrongCode()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -144,7 +146,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the 2fa Enable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2fa()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -166,7 +168,7 @@ class MultiFAControllerTest extends DuskTestCase
         $secretkey = $browser->waitFor('enableModal')
                              ->text('secretkey');
 
-        $google2fa = new \PragmaRX\Google2FA\Google2FA();
+        $google2fa = new Google2FA();
         $one_time_password = $google2fa->getCurrentOtp($secretkey);
         $browser->type('otpenable', $one_time_password);
 
@@ -190,7 +192,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the 2fa Enable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2faLoginWrongCode()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -225,7 +227,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test the 2fa Enable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2faLogin()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -241,7 +243,7 @@ class MultiFAControllerTest extends DuskTestCase
                     ->waitFor('enableModal');
 
             $secretkey = $this->enable2fa($browser);
-            $google2fa = new \PragmaRX\Google2FA\Google2FA();
+            $google2fa = new Google2FA();
             $one_time_password = $google2fa->getCurrentOtp($secretkey);
 
             $browser =
@@ -260,7 +262,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test 2fa Enable Page and Disable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2faDisable2fa()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');
@@ -274,7 +276,7 @@ class MultiFAControllerTest extends DuskTestCase
                     ->waitFor('enableModal');
 
             $secretkey = $this->enable2fa($browser);
-            $google2fa = new \PragmaRX\Google2FA\Google2FA();
+            $google2fa = new Google2FA();
             $one_time_password = $google2fa->getCurrentOtp($secretkey);
 
             $browser =
@@ -296,7 +298,7 @@ class MultiFAControllerTest extends DuskTestCase
     /**
      * Test 2fa Enable Page and Disable Page.
      */
-    #[\PHPUnit\Framework\Attributes\Group('multifa')]
+    #[Group('multifa')]
     public function testEnable2faDisable2faWrongCode()
     {
         $this->markTestIncomplete('Ignore 2fa tests for now.');

--- a/tests/Commands/OneTime/MoveAvatarsToPhotosDirectoryTest.php
+++ b/tests/Commands/OneTime/MoveAvatarsToPhotosDirectoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\OneTime;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Photo;
@@ -30,7 +31,7 @@ class MoveAvatarsToPhotosDirectoryTest extends TestCase
         return [$user, $contact];
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_move_avatars_to_photo_directory()
     {
         [$user, $contact] = $this->fetchUser();
@@ -66,7 +67,7 @@ class MoveAvatarsToPhotosDirectoryTest extends TestCase
         Storage::disk('public')->assertExists($photo->new_filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_handles_missing_avatar()
     {
         [$user, $contact] = $this->fetchUser();

--- a/tests/Commands/Other/CleanCommandTest.php
+++ b/tests/Commands/Other/CleanCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\User\SyncToken;
@@ -12,7 +13,7 @@ class CleanCommandTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clean_command_left_one_token()
     {
         $account = factory(Account::class)->create();
@@ -36,7 +37,7 @@ class CleanCommandTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clean_command_left_all_token()
     {
         $account = factory(Account::class)->create();
@@ -69,7 +70,7 @@ class CleanCommandTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function clean_command_dryrun()
     {
         $account = factory(Account::class)->create();

--- a/tests/Commands/Other/CreateAccountTest.php
+++ b/tests/Commands/Other/CreateAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Console\Commands\CreateAccount;
@@ -11,7 +12,7 @@ class CreateAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_account()
     {
         $email = 'user1@example.com';
@@ -22,7 +23,7 @@ class CreateAccountTest extends TestCase
         $this->assertNotEmpty($user);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_account_with_specified_name()
     {
         $email = 'user1@example.com';
@@ -39,7 +40,7 @@ class CreateAccountTest extends TestCase
         $this->assertNotEmpty($user);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_creation_without_email()
     {
         $this->artisan('account:create', ['--password' => 'astrongpassword'])
@@ -48,7 +49,7 @@ class CreateAccountTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_creation_without_password()
     {
         $email = 'user1@example.com';

--- a/tests/Commands/Other/CreateAddressBookSubscriptionTest.php
+++ b/tests/Commands/Other/CreateAddressBookSubscriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Mockery\MockInterface;
@@ -12,7 +13,7 @@ class CreateAddressBookSubscriptionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_add_addressbook()
     {
         $user = factory(User::class)->create();

--- a/tests/Commands/Other/ImportCSVTest.php
+++ b/tests/Commands/Other/ImportCSVTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class ImportCSVTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function csv_import_contacts()
     {
         Storage::fake('public');
@@ -50,7 +51,7 @@ class ImportCSVTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function csv_import_validates_user()
     {
         $path = base_path('tests/stubs/single_contact_stub.csv');
@@ -64,7 +65,7 @@ class ImportCSVTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function csv_import_validates_file()
     {
         $user = $this->getUser();

--- a/tests/Commands/Other/ImportVCardsTest.php
+++ b/tests/Commands/Other/ImportVCardsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class ImportVCardsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_user()
     {
         $path = base_path('tests/stubs/vcard_stub.vcf');
@@ -23,7 +24,7 @@ class ImportVCardsTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_file()
     {
         $user = $this->getUser();
@@ -34,7 +35,7 @@ class ImportVCardsTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_contacts()
     {
         Storage::fake('public');

--- a/tests/Commands/Other/UpdateCommandTest.php
+++ b/tests/Commands/Other/UpdateCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Console\Commands\Helpers\Command;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class UpdateCommandTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function update_command_default()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -30,7 +31,7 @@ class UpdateCommandTest extends TestCase
         $this->assertCommandContains($fake->buffer[8], 'Maintenance mode: off', 'php artisan up');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function update_command_composer()
     {
         /** @var \Tests\Helpers\CommandCallerFake */

--- a/tests/Commands/Other/WaitForDbTest.php
+++ b/tests/Commands/Other/WaitForDbTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Other;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -9,7 +10,7 @@ class WaitForDbTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_runs_wait_for_db_command()
     {
         $this->artisan('waitfordb')

--- a/tests/Commands/Scheduling/CalculateStatisticsTest.php
+++ b/tests/Commands/Scheduling/CalculateStatisticsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class CalculateStatisticsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function the_command_runs_well()
     {
         $runsWell = true;

--- a/tests/Commands/Scheduling/CronEventTest.php
+++ b/tests/Commands/Scheduling/CronEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Instance\Cron;
@@ -12,7 +13,7 @@ class CronEventTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_the_right_command()
     {
         $cron = factory(Cron::class)->create();
@@ -22,7 +23,7 @@ class CronEventTest extends TestCase
         $this->assertEquals($event->cron()->id, $cron->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function now_not_due()
     {
         $cron = factory(Cron::class)->create();
@@ -31,7 +32,7 @@ class CronEventTest extends TestCase
         $this->assertFalse($event->isDue());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function next_minute_is_due()
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
@@ -51,7 +52,7 @@ class CronEventTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function hourly_cron()
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));
@@ -85,7 +86,7 @@ class CronEventTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function daily_cron()
     {
         Carbon::setTestNow(Carbon::create(2019, 5, 1, 7, 0, 0));

--- a/tests/Commands/Scheduling/DavClientsUpdateTest.php
+++ b/tests/Commands/Scheduling/DavClientsUpdateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Jobs\SynchronizeAddressBooks;
 use Illuminate\Support\Facades\Queue;
@@ -12,7 +13,7 @@ class DavClientsUpdateTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_dispatch_subscription_update()
     {
         Queue::fake();

--- a/tests/Commands/Scheduling/PingVersionServerTest.php
+++ b/tests/Commands/Scheduling/PingVersionServerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Instance\Instance;
 use Illuminate\Support\Facades\Http;
@@ -11,7 +12,7 @@ class PingVersionServerTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_send_ping()
     {
         config(['monica.weekly_ping_server_url' => 'https://version.test/ping']);
@@ -43,7 +44,7 @@ class PingVersionServerTest extends TestCase
         $this->assertEquals(2, $instance->number_of_versions_since_current_version);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_clear_instance()
     {
         config(['monica.weekly_ping_server_url' => 'https://version.test/ping']);

--- a/tests/Commands/Scheduling/SendRemindersTest.php
+++ b/tests/Commands/Scheduling/SendRemindersTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -17,7 +18,7 @@ class SendRemindersTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_schedules_a_reminder_email_job()
     {
         Bus::fake();
@@ -45,7 +46,7 @@ class SendRemindersTest extends TestCase
         Bus::assertDispatched(NotifyUserAboutReminder::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_schedule_a_notification_if_it_is_not_the_right_time()
     {
         Bus::fake();

--- a/tests/Commands/Scheduling/SendStayInTouchTest.php
+++ b/tests/Commands/Scheduling/SendStayInTouchTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Scheduling;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class SendStayInTouchTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_schedules_a_stay_in_touch_job()
     {
         Bus::fake();
@@ -33,7 +34,7 @@ class SendStayInTouchTest extends TestCase
         Bus::assertDispatched(ScheduleStayInTouch::class);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_schedule_stay_in_touch_jobs_if_no_date_is_found()
     {
         Bus::fake();

--- a/tests/Commands/Tests/PassportCommandTest.php
+++ b/tests/Commands/Tests/PassportCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Console\Commands\Helpers\Command;
 use Laravel\Passport\PersonalAccessClient;
@@ -24,7 +25,7 @@ class PassportCommandTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function passport_command_create()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -36,7 +37,7 @@ class PassportCommandTest extends TestCase
         $this->assertCommandContains($fake->buffer[0], '✓ Creating personal access client', 'php artisan passport:client');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function passport_command_already_created()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -49,7 +50,7 @@ class PassportCommandTest extends TestCase
         $this->assertCount(0, $fake->buffer, $fake->buffer->implode(','));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function passport_command_env_config()
     {
         /** @var \Tests\Helpers\CommandCallerFake */

--- a/tests/Commands/Tests/SendTestEmailTest.php
+++ b/tests/Commands/Tests/SendTestEmailTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Commands\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Mail;
 
 class SendTestEmailTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function error_for_bad_email()
     {
         $exampleEmail = 'no.at.symbol';
@@ -18,7 +19,7 @@ class SendTestEmailTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function command_prompts_for_email()
     {
         $exampleEmail = 'no.at.symbol';
@@ -30,7 +31,7 @@ class SendTestEmailTest extends TestCase
             ->run();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function command_attempts_to_send_email()
     {
         $exampleEmail = 'test@example.org';

--- a/tests/Commands/Tests/SetupFrontEndTestUserTest.php
+++ b/tests/Commands/Tests/SetupFrontEndTestUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -11,7 +12,7 @@ class SetupFrontEndTestUserTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_a_test_user()
     {
         $accountCount = Account::count();

--- a/tests/Commands/Tests/SetupTestCommandTest.php
+++ b/tests/Commands/Tests/SetupTestCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands\Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Console\Commands\Helpers\Command;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class SetupTestCommandTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_completes_non_interactively_with_skip_seed()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -25,7 +26,7 @@ class SetupTestCommandTest extends TestCase
         $fake->assertContainsMessage('✓ Symlink the storage folder');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_contacts_option_to_set_seed_count()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -40,7 +41,7 @@ class SetupTestCommandTest extends TestCase
         $fake->assertContainsMessage('✓ Performing migrations');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prompts_for_confirmation_when_interactive()
     {
         /** @var \Tests\Helpers\CommandCallerFake */
@@ -57,7 +58,7 @@ class SetupTestCommandTest extends TestCase
         $fake->assertContainsMessage('✓ Performing migrations');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_when_user_declines_confirmation()
     {
         /** @var \Tests\Helpers\CommandCallerFake */

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\BeforeClass;
 use Tests\Traits\SignIn;
 use App\Models\User\User;
 use Laravel\Dusk\Browser;
@@ -30,7 +31,7 @@ abstract class DuskTestCase extends BaseTestCase
      *
      * @return void
      */
-    #[\PHPUnit\Framework\Attributes\BeforeClass]
+    #[BeforeClass]
     public static function prepare()
     {
         if (! static::runningInSail()) {

--- a/tests/Feature/AccountSubscriptionTest.php
+++ b/tests/Feature/AccountSubscriptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use Stripe\Exception\ApiErrorException;
+use App\Exceptions\StripeException;
 use Stripe\Plan;
 use Stripe\Stripe;
 use Stripe\Product;
@@ -117,7 +119,7 @@ class AccountSubscriptionTest extends FeatureTestCase
             if (method_exists($resource, 'delete')) {
                 $resource->delete();
             }
-        } catch (\Stripe\Exception\ApiErrorException $e) {
+        } catch (ApiErrorException $e) {
             //
         }
     }
@@ -128,7 +130,7 @@ class AccountSubscriptionTest extends FeatureTestCase
         $user->email = 'test_it_throw_an_error_on_subscribe@monica-test.com';
         $user->save();
 
-        $this->expectException(\App\Exceptions\StripeException::class);
+        $this->expectException(StripeException::class);
         $user->account->subscribe('xxx', 'annual');
     }
 
@@ -168,7 +170,7 @@ class AccountSubscriptionTest extends FeatureTestCase
             'quantity' => 1,
         ]);
 
-        $this->expectException(\App\Exceptions\StripeException::class);
+        $this->expectException(StripeException::class);
         $user->account->subscriptionCancel();
     }
 
@@ -250,7 +252,7 @@ class AccountSubscriptionTest extends FeatureTestCase
 
         try {
             $user->account->subscribe('pm_card_chargeDeclined', 'annual');
-        } catch (\App\Exceptions\StripeException $e) {
+        } catch (StripeException $e) {
             $this->assertEquals('Your card was declined. Decline message is: Your card was declined.', $e->getMessage());
 
             return;

--- a/tests/Feature/ActivityTest.php
+++ b/tests/Feature/ActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use App\Models\User\User;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
@@ -187,7 +188,7 @@ class ActivityTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create()
     {
         $user = $this->signin();
@@ -231,7 +232,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_wrong_parameter()
     {
         $user = $this->signin();
@@ -253,7 +254,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_bad_account()
     {
         $this->signin();
@@ -273,7 +274,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_create_error_bad_account2()
     {
         $user = $this->signin();
@@ -297,7 +298,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update()
     {
         $user = $this->signin();
@@ -340,7 +341,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_category()
     {
         $user = $this->signin();
@@ -395,7 +396,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_existing()
     {
         $user = $this->signin();
@@ -462,7 +463,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_parameter()
     {
         $user = $this->signin();
@@ -479,7 +480,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_account_for_activity()
     {
         $user = $this->signin();
@@ -502,7 +503,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_update_error_wrong_account_for_contacts()
     {
         $user = $this->signin();
@@ -525,7 +526,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete()
     {
         $user = $this->signin();
@@ -545,7 +546,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete_error()
     {
         $this->signin();
@@ -558,7 +559,7 @@ class ActivityTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function activities_delete_with_wrong_account()
     {
         $this->signin();

--- a/tests/Feature/CallsTest.php
+++ b/tests/Feature/CallsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\DateHelper;
 use App\Models\Contact\Call;
@@ -59,7 +60,7 @@ class CallsTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_last_talked_to()
     {
         $user = $this->signin();
@@ -87,7 +88,7 @@ class CallsTest extends FeatureTestCase
         $this->assertEquals($response->json('last_talked_to'), DateHelper::getShortDate($referenceDate));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_empty_last_talked_to()
     {
         $user = $this->signin();

--- a/tests/Feature/ContactTest.php
+++ b/tests/Feature/ContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\DateHelper;
 use App\Models\Contact\Tag;
@@ -685,7 +686,7 @@ class ContactTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_value()
     {
         $user = $this->signin();

--- a/tests/Feature/ContactsControllerTest.php
+++ b/tests/Feature/ContactsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\AccountHelper;
 use App\Models\Contact\Contact;
@@ -11,7 +12,7 @@ class ContactsControllerTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_unarchive_contact_if_limited_account()
     {
         config(['monica.requires_subscription' => true]);
@@ -33,7 +34,7 @@ class ContactsControllerTest extends FeatureTestCase
         $response->assertStatus(402);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stays_in_touch()
     {
         $user = $this->signin();

--- a/tests/Feature/ExportAccountTest.php
+++ b/tests/Feature/ExportAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use Illuminate\Support\Carbon;
 use App\Models\Account\ExportJob;
@@ -11,7 +12,7 @@ class ExportAccountTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_export_job_json()
     {
         config(['queue.default' => 'database']);
@@ -30,7 +31,7 @@ class ExportAccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_export_job_sql()
     {
         config(['queue.default' => 'database']);
@@ -49,7 +50,7 @@ class ExportAccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_delete_old_export()
     {
         config(['queue.default' => 'database']);

--- a/tests/Feature/MeTest.php
+++ b/tests/Feature/MeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class MeTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_me()
     {
         $user = $this->signin();
@@ -33,7 +34,7 @@ class MeTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_error_wrong_parameter()
     {
         $this->signin();
@@ -48,7 +49,7 @@ class MeTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_error_bad_account()
     {
         $this->signin();
@@ -65,7 +66,7 @@ class MeTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_me()
     {
         $user = $this->signin();

--- a/tests/Feature/ReminderRuleTest.php
+++ b/tests/Feature/ReminderRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\ReminderRule;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -25,7 +26,7 @@ class ReminderRuleTest extends FeatureTestCase
         return [$user, $reminderRule];
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function reminder_rule_index()
     {
         [$user, $reminderRule] = $this->fetchUser();
@@ -38,7 +39,7 @@ class ReminderRuleTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function reminder_rule_toggle()
     {
         [$user, $reminderRule] = $this->fetchUser();

--- a/tests/Feature/SmokeRoutesTest.php
+++ b/tests/Feature/SmokeRoutesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Gender;
 use Illuminate\Support\Facades\DB;
@@ -48,7 +49,7 @@ class SmokeRoutesTest extends FeatureTestCase
         $this->assertNotAnErrorPage($response, '/dashboard');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('authenticatedGetRoutes')]
+    #[DataProvider('authenticatedGetRoutes')]
     public function test_authenticated_user_can_load_route(string $url): void
     {
         $this->signIn();

--- a/tests/Feature/StorageControllerTest.php
+++ b/tests/Feature/StorageControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\FeatureTestCase;
 use App\Models\Account\Photo;
@@ -33,7 +34,7 @@ class StorageControllerTest extends FeatureTestCase
         return [$user, $contact];
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_photo_content()
     {
         config(['filesystems.default' => 'local']);
@@ -50,7 +51,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_avatar_content()
     {
         config(['filesystems.default' => 'local']);
@@ -67,7 +68,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_document_content()
     {
         config(['filesystems.default' => 'local']);
@@ -84,7 +85,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_if_avatar_not_exist()
     {
         config(['filesystems.default' => 'local']);
@@ -96,7 +97,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_404_if_folder_unknown()
     {
         config(['filesystems.default' => 'local']);
@@ -108,7 +109,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_200_if_modified_after_IfModifiedSince()
     {
         config(['filesystems.default' => 'local']);
@@ -127,7 +128,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_304_if_not_modified_since_IfModifiedSince()
     {
         config(['filesystems.default' => 'local']);
@@ -146,7 +147,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_200_if_not_modified_after_IfUnmodifiedSince()
     {
         config(['filesystems.default' => 'local']);
@@ -165,7 +166,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_412_if_modified_after_IfUnmodifiedSince()
     {
         config(['filesystems.default' => 'local']);
@@ -181,7 +182,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(412);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_file_not_found()
     {
         config(['filesystems.default' => 'local']);
@@ -193,7 +194,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_file_not_exist()
     {
         config(['filesystems.default' => 'local']);
@@ -215,7 +216,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_file_not_owned_by_user()
     {
         config(['filesystems.default' => 'local']);
@@ -233,7 +234,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertStatus(404);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_200_if_matching_IfMatch()
     {
         config(['filesystems.default' => 'local']);
@@ -252,7 +253,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_200_with_none_matching_IfNoneMatch()
     {
         config(['filesystems.default' => 'local']);
@@ -271,7 +272,7 @@ class StorageControllerTest extends FeatureTestCase
         $response->assertHeader('etag', '"'.sha1('/store/'.$file).'"');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_304_if_matching_IfNoneMatch()
     {
         config(['filesystems.default' => 'local']);

--- a/tests/Unit/Controllers/Account/LifeEvent/LifeEventCategoriesControllerTest.php
+++ b/tests/Unit/Controllers/Account/LifeEvent/LifeEventCategoriesControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Account\LifeEvent;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -9,7 +10,7 @@ class LifeEventCategoriesControllerTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_life_event_categories()
     {
         $user = $this->signin();

--- a/tests/Unit/Controllers/Auth/PasswordResetTest.php
+++ b/tests/Unit/Controllers/Auth/PasswordResetTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Auth;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Illuminate\Auth\Notifications\ResetPassword;
@@ -12,7 +13,7 @@ class PasswordResetTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_password_reset_email()
     {
         NotificationFacade::fake();

--- a/tests/Unit/Controllers/Contact/ContactAuditLogControllerTest.php
+++ b/tests/Unit/Controllers/Contact/ContactAuditLogControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class ContactAuditLogControllerTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_audit_logs_for_the_contact()
     {
         $user = $this->signin();

--- a/tests/Unit/Controllers/Contact/LifeEventsControllerTest.php
+++ b/tests/Unit/Controllers/Contact/LifeEventsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class LifeEventsControllerTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_life_events_for_the_contact()
     {
         $user = $this->signin();

--- a/tests/Unit/Controllers/Settings/AuditLogControllerTest.php
+++ b/tests/Unit/Controllers/Settings/AuditLogControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class AuditLogControllerTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_audit_logs_for_the_account()
     {
         $user = $this->signin();

--- a/tests/Unit/Controllers/Settings/GendersControllerTest.php
+++ b/tests/Unit/Controllers/Settings/GendersControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Controllers\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Gender;
 use App\Models\Contact\Contact;
@@ -24,7 +25,7 @@ class GendersControllerTest extends FeatureTestCase
         'name',
     ];
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_genders()
     {
         $user = $this->signin();
@@ -43,7 +44,7 @@ class GendersControllerTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_list_of_genderTypes()
     {
         $user = $this->signin();
@@ -62,7 +63,7 @@ class GendersControllerTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_new_gender()
     {
         $user = $this->signin();
@@ -82,7 +83,7 @@ class GendersControllerTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_new_default_gender()
     {
         $user = $this->signin();
@@ -98,7 +99,7 @@ class GendersControllerTest extends FeatureTestCase
         $this->assertEquals($response->getData()->id, $user->account->default_gender_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_gender()
     {
         $user = $this->signin();
@@ -120,7 +121,7 @@ class GendersControllerTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_replaces_a_gender()
     {
         $user = $this->signin();
@@ -149,7 +150,7 @@ class GendersControllerTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_replaces_a_gender_with_error()
     {
         $user = $this->signin();
@@ -166,7 +167,7 @@ class GendersControllerTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_gender()
     {
         $user = $this->signin();
@@ -183,7 +184,7 @@ class GendersControllerTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_default_gender()
     {
         $user = $this->signin();

--- a/tests/Unit/Events/Google2faEventListenerTest.php
+++ b/tests/Unit/Events/Google2faEventListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Events;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Events\RecoveryLogin;
 use Illuminate\Auth\AuthManager;
@@ -27,7 +28,7 @@ class Google2faEventListenerTest extends FeatureTestCase
         app('pragmarx.google2fa')->setStateless(false);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_listens_recovery_event()
     {
         $user = $this->signIn();
@@ -38,7 +39,7 @@ class Google2faEventListenerTest extends FeatureTestCase
         $this->assertTrue($this->app['session']->get('google2fa.auth_passed'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_listens_login_remember_event()
     {
         $user = $this->signIn();

--- a/tests/Unit/Helpers/AccountHelperTest.php
+++ b/tests/Unit/Helpers/AccountHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -19,7 +20,7 @@ class AccountHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_has_limitations_if_not_subscribed_or_exempted_of_subscriptions(): void
     {
         $account = factory(Account::class)->make([
@@ -38,7 +39,7 @@ class AccountHelperTest extends TestCase
         $this->assertFalse(AccountHelper::hasLimitations($account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function account_has_reached_contact_limit_on_free_plan(): void
     {
         $account = factory(Account::class)->create();
@@ -77,7 +78,7 @@ class AccountHelperTest extends TestCase
         $this->assertTrue(AccountHelper::isBelowContactLimit($account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_can_downgrade_with_only_one_user_and_no_pending_invitations_and_under_contact_limit(): void
     {
         config(['monica.number_of_allowed_contacts_free_account' => 1]);
@@ -90,7 +91,7 @@ class AccountHelperTest extends TestCase
         $this->assertTrue(AccountHelper::canDowngrade($contact->account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_cant_downgrade_with_two_users(): void
     {
         $contact = factory(Contact::class)->create();
@@ -102,7 +103,7 @@ class AccountHelperTest extends TestCase
         $this->assertFalse(AccountHelper::canDowngrade($contact->account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_cant_downgrade_with_pending_invitations(): void
     {
         $account = factory(Account::class)->create();
@@ -114,7 +115,7 @@ class AccountHelperTest extends TestCase
         $this->assertFalse(AccountHelper::canDowngrade($account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_cant_downgrade_with_too_many_contacts(): void
     {
         config(['monica.number_of_allowed_contacts_free_account' => 1]);
@@ -127,7 +128,7 @@ class AccountHelperTest extends TestCase
         $this->assertFalse(AccountHelper::canDowngrade($account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_default_gender_for_the_account(): void
     {
         $account = factory(Account::class)->create();
@@ -143,7 +144,7 @@ class AccountHelperTest extends TestCase
         $this->assertEquals($gender->type, AccountHelper::getDefaultGender($account));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_reminders_for_month_returns_no_reminders(): void
     {
         $account = factory(Account::class)->create();
@@ -160,7 +161,7 @@ class AccountHelperTest extends TestCase
         $this->actingAs($user)->assertCount(0, AccountHelper::getUpcomingRemindersForMonth($account, 3));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_reminders_for_month_returns_reminders_for_given_month(): void
     {
         $account = factory(Account::class)->create();
@@ -183,7 +184,7 @@ class AccountHelperTest extends TestCase
         $this->actingAs($user)->assertCount(3, AccountHelper::getUpcomingRemindersForMonth($account, 2));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_reminders_for_month_returns_reminders_for_current_user_only(): void
     {
         $account = factory(Account::class)->create();
@@ -210,7 +211,7 @@ class AccountHelperTest extends TestCase
         $this->actingAs($user1)->assertCount(3, AccountHelper::getUpcomingRemindersForMonth($account, 2));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_retrieves_yearly_activities_statistics(): void
     {
         $account = factory(Account::class)->create();
@@ -235,7 +236,7 @@ class AccountHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_retrieves_yearly_call_statistics(): void
     {
         $contact = factory(Contact::class)->create();

--- a/tests/Unit/Helpers/AuditLogHelperTest.php
+++ b/tests/Unit/Helpers/AuditLogHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Helpers\AuditLogHelper;
@@ -13,7 +14,7 @@ class AuditLogHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prepares_a_collection_of_audit_logs_for_the_settings_page()
     {
         $user = factory(User::class)->create([]);
@@ -38,7 +39,7 @@ class AuditLogHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prepares_a_collection_of_audit_logs_without_likns_for_the_settings_page()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Helpers/CollectionHelperTest.php
+++ b/tests/Unit/Helpers/CollectionHelperTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\CollectionHelper;
 use Illuminate\Support\Facades\App;
 
 class CollectionHelperTest extends FeatureTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sortByCollator_base()
     {
         $collection = collect([
@@ -28,7 +29,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sortByCollator_macro()
     {
         $collection = collect([
@@ -48,7 +49,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sortByCollator_callback()
     {
         $collection = collect([
@@ -70,7 +71,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sortByCollator_default_collation()
     {
         App::setLocale('en');
@@ -94,7 +95,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function sortByCollator_french_collation()
     {
         App::setLocale('fr');
@@ -118,7 +119,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getCollator_french_collation()
     {
         $collator = CollectionHelper::getCollator('fr');
@@ -127,7 +128,7 @@ class CollectionHelperTest extends FeatureTestCase
         $this->assertEquals($collator->getLocale(\Locale::VALID_LOCALE), 'fr');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function group_by_items_property()
     {
         $object1 = (object) ['name' => 'John'];
@@ -151,7 +152,7 @@ class CollectionHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_maps_uuid()
     {
         $collection = collect();

--- a/tests/Unit/Helpers/ComplianceHelperTest.php
+++ b/tests/Unit/Helpers/ComplianceHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Settings\Term;
@@ -12,7 +13,7 @@ class ComplianceHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_checks_if_the_user_has_signed_the_given_term()
     {
         $user = factory(User::class)->create([]);
@@ -25,7 +26,7 @@ class ComplianceHelperTest extends TestCase
         $this->assertTrue(ComplianceHelper::hasSignedGivenTerm($user, $term));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_checks_if_the_user_has_signed_the_latest_term()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Helpers/CountryHelperTest.php
+++ b/tests/Unit/Helpers/CountryHelperTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\CountriesHelper;
 
 class CountryHelperTest extends FeatureTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('countryDefaultCountryFromLocaleProvider')]
+    #[DataProvider('countryDefaultCountryFromLocaleProvider')]
     public function test_country_getDefaultCountryFromLocale($locale, $expect)
     {
         $reflection = new \ReflectionClass(CountriesHelper::class);
@@ -44,7 +46,7 @@ class CountryHelperTest extends FeatureTestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('countryCountryFromLocaleProvider')]
+    #[DataProvider('countryCountryFromLocaleProvider')]
     public function test_country_getCountryFromLocale($locale, $expect)
     {
         $country = CountriesHelper::getCountryFromLocale($locale);
@@ -82,8 +84,8 @@ class CountryHelperTest extends FeatureTestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('timezoneFromLocaleProvider')]
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[DataProvider('timezoneFromLocaleProvider')]
+    #[Test]
     public function it_get_default_timezone($locale, $expect)
     {
         $country = CountriesHelper::getCountryFromLocale($locale);

--- a/tests/Unit/Helpers/FormHelperTest.php
+++ b/tests/Unit/Helpers/FormHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Helpers\FormHelper;
@@ -11,7 +12,7 @@ class FormHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_name_order_for_a_form()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Helpers/GenderHelperTest.php
+++ b/tests/Unit/Helpers/GenderHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\GenderHelper;
 use App\Models\Contact\Gender;
@@ -10,7 +11,7 @@ use App\Models\Contact\Contact;
 
 class GenderHelperTest extends FeatureTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_all_the_gender_inputs()
     {
         $this->signIn();
@@ -24,7 +25,7 @@ class GenderHelperTest extends FeatureTestCase
         ], $genders[0]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_replaces_gender_with_another_gender()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Helpers/InstanceHelperTest.php
+++ b/tests/Unit/Helpers/InstanceHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Mockery;
 use Tests\TestCase;
 use function Safe\json_decode;
@@ -14,7 +15,7 @@ class InstanceHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_number_of_paid_subscribers()
     {
         factory(Account::class)->create(['stripe_id' => 'id292839']);
@@ -27,7 +28,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fetches_the_monthly_plan_information()
     {
         config(['monica.paid_plan_monthly_friendly_name' => 'Monthly']);
@@ -60,7 +61,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fetches_the_annually_plan_information()
     {
         config(['monica.paid_plan_annual_friendly_name' => 'Annual']);
@@ -93,7 +94,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fetches_subscription_information()
     {
         $stripeSubscription = (object) [
@@ -139,7 +140,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_when_fetching_an_unknown_plan_information()
     {
         $account = new Account;
@@ -149,7 +150,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_latest_changelog_entries()
     {
         $json = public_path('changelog.json');
@@ -167,7 +168,7 @@ class InstanceHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_checks_if_the_instance_has_at_least_one_account()
     {
         DB::table('accounts')->delete();

--- a/tests/Unit/Helpers/JournalHelperTest.php
+++ b/tests/Unit/Helpers/JournalHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Journal\Day;
@@ -13,7 +14,7 @@ class JournalHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function you_can_vote_if_you_havent_voted_yet_today()
     {
         $account = factory(Account::class)->create([]);
@@ -22,7 +23,7 @@ class JournalHelperTest extends TestCase
         $this->assertFalse(JournalHelper::hasAlreadyRatedToday($user));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function you_cant_vote_if_you_have_already_voted_today()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Helpers/LocaleHelperTest.php
+++ b/tests/Unit/Helpers/LocaleHelperTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\FeatureTestCase;
 use App\Helpers\LocaleHelper;
 use Illuminate\Support\Facades\App;
@@ -11,7 +13,7 @@ class LocaleHelperTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_locale_returns_english_by_default()
     {
         $this->assertEquals(
@@ -20,7 +22,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_locale_returns_right_locale_if_user_logged()
     {
         $user = $this->signIn();
@@ -33,7 +35,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_direction_default()
     {
         $this->assertEquals(
@@ -42,7 +44,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_direction_french()
     {
         App::setLocale('fr');
@@ -53,7 +55,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_direction_hebrew()
     {
         App::setLocale('he');
@@ -64,7 +66,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function format_telephone_by_iso()
     {
         $tel = LocaleHelper::formatTelephoneNumberByISO('202-555-0191', 'gb');
@@ -75,7 +77,7 @@ class LocaleHelperTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('localeHelperGetLangProvider')]
+    #[DataProvider('localeHelperGetLangProvider')]
     public function test_locale_get_lang($locale, $expect)
     {
         $lang = LocaleHelper::getLang($locale);
@@ -100,7 +102,7 @@ class LocaleHelperTest extends FeatureTestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('localeHelperGetCountryProvider')]
+    #[DataProvider('localeHelperGetCountryProvider')]
     public function test_locale_get_country($locale, $expect)
     {
         $country = LocaleHelper::getCountry($locale);
@@ -123,7 +125,7 @@ class LocaleHelperTest extends FeatureTestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('localeHelperExtractCountryProvider')]
+    #[DataProvider('localeHelperExtractCountryProvider')]
     public function test_locale_extract_country($locale, $expect)
     {
         $country = LocaleHelper::extractCountry($locale);

--- a/tests/Unit/Helpers/MoneyHelperTest.php
+++ b/tests/Unit/Helpers/MoneyHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Helpers\MoneyHelper;
@@ -13,7 +14,7 @@ class MoneyHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_amount_with_the_currency_symbol()
     {
         $currency = new Currency();
@@ -27,7 +28,7 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals(5038.29, MoneyHelper::exchangeValue(503829, $currency));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_amount_with_the_currency_symbol_in_the_right_locale()
     {
         App::setLocale('fr');
@@ -43,7 +44,7 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals(5038.29, MoneyHelper::exchangeValue(503829, $currency));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_amount_with_the_currency_symbol_with_the_right_punctuation()
     {
         $currency = new Currency();
@@ -57,7 +58,7 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals(5038, MoneyHelper::exchangeValue(5038, $currency));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_formats_the_currency_with_the_right_locale()
     {
         $currency = Currency::where('iso', 'GBP')->first();
@@ -74,20 +75,20 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals(2734.12, MoneyHelper::exchangeValue(273412, $currency));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_amount_without_the_currency_symbol_if_not_provided()
     {
         $this->assertEquals('500', MoneyHelper::format(500));
         $this->assertEquals('5,000', MoneyHelper::format(5000));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_zero_if_amount_is_null()
     {
         $this->assertEquals('0', MoneyHelper::format(null));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_covers_brazilian_currency()
     {
         $currency = Currency::where('iso', 'BRL')->first();
@@ -102,7 +103,7 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals(12345.67, MoneyHelper::exchangeValue(1234567, $currency));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_parse_an_input_value()
     {
         $currency = new Currency();

--- a/tests/Unit/Helpers/RequestHelperTest.php
+++ b/tests/Unit/Helpers/RequestHelperTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
+use Stevebauman\Location\Drivers\Driver;
+use Stevebauman\Location\Position;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Helpers\RequestHelper;
@@ -11,7 +14,7 @@ use Stevebauman\Location\Facades\Location;
 
 class RequestHelperTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_cf_ip()
     {
         Request::instance()->headers->set('Cf-Connecting-Ip', '1.2.3.4');
@@ -22,7 +25,7 @@ class RequestHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_server_ip()
     {
         Request::instance()->server->set('REMOTE_ADDR', '1.2.3.4');
@@ -33,7 +36,7 @@ class RequestHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_country_from_cf()
     {
         Request::instance()->headers->set('Cf-Ipcountry', 'XX');
@@ -44,13 +47,13 @@ class RequestHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_country_from_ip()
     {
-        $driver = $this->mock(\Stevebauman\Location\Drivers\Driver::class, function (MockInterface $mock) {
+        $driver = $this->mock(Driver::class, function (MockInterface $mock) {
             $mock->shouldReceive('get')
                 ->with(\Mockery::on(fn ($request) => $request instanceof \Stevebauman\Location\Request && $request->getIp() === '123.45.67.89'))
-                ->andReturn(tap(new \Stevebauman\Location\Position(), function ($position) {
+                ->andReturn(tap(new Position(), function ($position) {
                     $position->countryCode = 'TEST';
                 }));
         });
@@ -64,7 +67,7 @@ class RequestHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_infos_from_ip()
     {
         config(['location.ipdata.token' => 'test']);
@@ -84,7 +87,7 @@ class RequestHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_infos_from_ip_fail()
     {
         config(['location.ipdata.token' => 'test']);

--- a/tests/Unit/Helpers/SearchHelperTest.php
+++ b/tests/Unit/Helpers/SearchHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Note;
 use App\Helpers\SearchHelper;
@@ -12,7 +13,7 @@ class SearchHelperTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function searching_for_contacts_returns_a_collection_with_pagination()
     {
         $user = $this->signin();
@@ -63,7 +64,7 @@ class SearchHelperTest extends FeatureTestCase
         $this->assertCount(1, $searchResults);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function searching_with_wrong_search_field()
     {
         $user = $this->signin();

--- a/tests/Unit/Helpers/StorageHelperTest.php
+++ b/tests/Unit/Helpers/StorageHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Photo;
 use App\Helpers\StorageHelper;
@@ -13,7 +14,7 @@ class StorageHelperTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_the_account_storage_size(): void
     {
         $account = factory(Account::class)->create([]);
@@ -34,7 +35,7 @@ class StorageHelperTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tests_account_storage_limit(): void
     {
         config(['monica.requires_subscription' => true]);

--- a/tests/Unit/Helpers/VCardHelperTest.php
+++ b/tests/Unit/Helpers/VCardHelperTest.php
@@ -2,13 +2,14 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\VCardHelper;
 use Sabre\VObject\Component\VCard;
 
 class VCardHelperTest extends FeatureTestCase
 {
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_country_by_sabre_vcard()
     {
         $vcard = new VCard([

--- a/tests/Unit/Helpers/WeatherHelperTest.php
+++ b/tests/Unit/Helpers/WeatherHelperTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Helpers;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Helpers\WeatherHelper;
 use App\Jobs\GetGPSCoordinate;
@@ -16,14 +17,14 @@ class WeatherHelperTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_if_address_is_not_set()
     {
         $contact = factory(Contact::class)->create([]);
         $this->assertNull(WeatherHelper::getWeatherForAddress($contact->addresses()->first()));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_dispatch_batch_with_get_coordinates()
     {
         config(['monica.enable_geolocation' => true]);

--- a/tests/Unit/Jobs/CreateAvatarsForExistingContactsTest.php
+++ b/tests/Unit/Jobs/CreateAvatarsForExistingContactsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Support\Facades\Queue;
@@ -14,7 +15,7 @@ class CreateAvatarsForExistingContactsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_jobs_for_avatars_migration()
     {
         Queue::fake();

--- a/tests/Unit/Jobs/Dav/DeleteMultipleVCardTest.php
+++ b/tests/Unit/Jobs/Dav/DeleteMultipleVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Jobs\Dav\DeleteVCard;
@@ -16,7 +17,7 @@ class DeleteMultipleVCardTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_delete_cards()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Dav/DeleteVCardTest.php
+++ b/tests/Unit/Jobs/Dav/DeleteVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Jobs\Dav\DeleteVCard;
@@ -17,7 +18,7 @@ class DeleteVCardTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_delete_card()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Dav/GetMultipleVCardTest.php
+++ b/tests/Unit/Jobs/Dav/GetMultipleVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Mockery\MockInterface;
@@ -22,7 +23,7 @@ class GetMultipleVCardTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_cards()
     {
         $fake = Bus::fake();
@@ -98,7 +99,7 @@ class GetMultipleVCardTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_cards_mock_http()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Dav/GetVCardTest.php
+++ b/tests/Unit/Jobs/Dav/GetVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Jobs\Dav\GetVCard;
@@ -21,7 +22,7 @@ class GetVCardTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_card()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Dav/PushVCardTest.php
+++ b/tests/Unit/Jobs/Dav/PushVCardTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Jobs\Dav\PushVCard;
@@ -21,8 +23,8 @@ class PushVCardTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('modes')]
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[DataProvider('modes')]
+    #[Test]
     public function it_push_card($mode, $ifmatch)
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Dav/UpdateVCardTest.php
+++ b/tests/Unit/Jobs/Dav/UpdateVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Tests\Api\DAV\CardEtag;
@@ -19,7 +20,7 @@ class UpdateVCardTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_a_contact()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/GetWeatherInformationTest.php
+++ b/tests/Unit/Jobs/GetWeatherInformationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Models\Account\Place;
@@ -16,7 +17,7 @@ class GetWeatherInformationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_job_weather_information()
     {
         $fake = Bus::fake();

--- a/tests/Unit/Jobs/Reminder/NotifyUserAboutReminderTest.php
+++ b/tests/Unit/Jobs/Reminder/NotifyUserAboutReminderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs\Reminder;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -19,7 +20,7 @@ class NotifyUserAboutReminderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_a_reminder_to_a_user()
     {
         Notification::fake();
@@ -65,7 +66,7 @@ class NotifyUserAboutReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_a_notification_to_a_user()
     {
         Notification::fake();
@@ -111,7 +112,7 @@ class NotifyUserAboutReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_notify_a_user_if_he_is_on_the_free_plan()
     {
         Notification::fake();
@@ -148,7 +149,7 @@ class NotifyUserAboutReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_notify_a_user_if_contact_deleted()
     {
         Notification::fake();
@@ -186,7 +187,7 @@ class NotifyUserAboutReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_marks_the_one_time_reminder_has_inactive_once_it_is_sent()
     {
         Notification::fake();
@@ -226,7 +227,7 @@ class NotifyUserAboutReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_reschedule_a_recurring_reminder_once_it_is_sent()
     {
         Notification::fake();

--- a/tests/Unit/Jobs/ScheduleStayInTouchTest.php
+++ b/tests/Unit/Jobs/ScheduleStayInTouchTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -16,7 +17,7 @@ class ScheduleStayInTouchTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_dispatches_an_email()
     {
         NotificationFacade::fake();
@@ -57,7 +58,7 @@ class ScheduleStayInTouchTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_dispatches_an_email_if_free_account()
     {
         NotificationFacade::fake();
@@ -91,7 +92,7 @@ class ScheduleStayInTouchTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_reschedule_missed_stayintouch()
     {
         NotificationFacade::fake();

--- a/tests/Unit/Jobs/ServiceQueueTest.php
+++ b/tests/Unit/Jobs/ServiceQueueTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -9,7 +10,7 @@ class ServiceQueueTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_a_service_ok(): void
     {
         config(['queue.default' => 'sync']);
@@ -20,7 +21,7 @@ class ServiceQueueTest extends TestCase
         $this->assertFalse(ServiceQueueTester::$failed);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_a_service_sync(): void
     {
         ServiceQueueTester::dispatchSync();
@@ -29,7 +30,7 @@ class ServiceQueueTest extends TestCase
         $this->assertFalse(ServiceQueueTester::$failed);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_a_service_which_failed(): void
     {
         $this->expectException(\Exception::class);
@@ -41,7 +42,7 @@ class ServiceQueueTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function service_is_not_run_if_queue_set(): void
     {
         config(['queue.default' => 'database']);

--- a/tests/Unit/Jobs/SynchronizeAddressBooksTest.php
+++ b/tests/Unit/Jobs/SynchronizeAddressBooksTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Jobs\SynchronizeAddressBooks;
@@ -13,7 +14,7 @@ class SynchronizeAddressBooksTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_synchronize()
     {
         Carbon::setTestNow(Carbon::create(2021, 9, 1, 10, 0, 0));

--- a/tests/Unit/Jobs/UpdateAllGravatarsTest.php
+++ b/tests/Unit/Jobs/UpdateAllGravatarsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Jobs\Avatars\UpdateGravatar;
@@ -13,7 +14,7 @@ class UpdateAllGravatarsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_jobs_for_update_gravatars()
     {
         Queue::fake();

--- a/tests/Unit/Jobs/UpdateGravatarTest.php
+++ b/tests/Unit/Jobs/UpdateGravatarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\ContactField;
@@ -13,7 +14,7 @@ class UpdateGravatarTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_gravatar()
     {
         $contact = factory(Contact::class)->create();

--- a/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
+++ b/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Jobs;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class UpdateLastConsultedDateTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_last_consulted_at_field_for_the_given_contact()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 0, 0));

--- a/tests/Unit/Models/AccountTest.php
+++ b/tests/Unit/Models/AccountTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
+use Laravel\Cashier\Subscription;
+use Illuminate\Validation\ValidationException;
 use App\Models\User\User;
 use Tests\FeatureTestCase;
 use App\Models\User\Module;
@@ -33,7 +36,7 @@ class AccountTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_genders()
     {
         $account = factory(Account::class)->create();
@@ -49,7 +52,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->genders()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_relationship_types()
     {
         $account = factory(Account::class)->create();
@@ -63,7 +66,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->relationshipTypes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_relationship_type_groups()
     {
         $contact = factory(Contact::class)->create();
@@ -78,7 +81,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->relationshipTypeGroups()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_modules()
     {
         $contact = factory(Contact::class)->create();
@@ -93,7 +96,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->modules()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_activity_types()
     {
         $account = factory(Account::class)->create();
@@ -104,7 +107,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->activityTypes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_activity_type_categories()
     {
         $account = factory(Account::class)->create();
@@ -115,7 +118,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->activityTypeCategories()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_conversations()
     {
         $account = factory(Account::class)->create([]);
@@ -126,7 +129,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->conversations()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_messages()
     {
         $account = factory(Account::class)->create([]);
@@ -141,7 +144,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->messages()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_event_categories()
     {
         $account = factory(Account::class)->create([]);
@@ -152,14 +155,14 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->lifeEventCategories()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_reminder_outboxes()
     {
         $reminderOutbox = factory(ReminderOutbox::class)->create([]);
         $this->assertTrue($reminderOutbox->account->reminderOutboxes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_event_types()
     {
         $account = factory(Account::class)->create([]);
@@ -170,7 +173,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->lifeEventTypes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_events()
     {
         $account = factory(Account::class)->create([]);
@@ -181,7 +184,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->lifeEvents()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_documents()
     {
         $account = factory(Account::class)->create([]);
@@ -192,7 +195,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->documents()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_photos()
     {
         $account = factory(Account::class)->create([]);
@@ -202,14 +205,14 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->photos()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_weathers()
     {
         $weather = factory(Weather::class)->create([]);
         $this->assertTrue($weather->account->weathers()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_places()
     {
         $account = factory(Account::class)->create([]);
@@ -219,7 +222,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->places()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_addresses()
     {
         $account = factory(Account::class)->create([]);
@@ -229,7 +232,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->addresses()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_companies()
     {
         $account = factory(Account::class)->create([]);
@@ -239,7 +242,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->companies()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_occupations()
     {
         $account = factory(Account::class)->create([]);
@@ -249,7 +252,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->occupations()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_logs()
     {
         $account = factory(Account::class)->create([]);
@@ -259,7 +262,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->auditLogs()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_is_subscribed_if_user_can_access_to_paid_version_for_free()
     {
         $account = factory(Account::class)->make([
@@ -271,7 +274,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_is_subscribed_returns_false_if_not_subcribed()
     {
         $account = factory(Account::class)->make([
@@ -283,12 +286,12 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_is_subscribed_returns_true_if_monthly_plan_is_set()
     {
         $account = factory(Account::class)->create();
 
-        $plan = factory(\Laravel\Cashier\Subscription::class)->create([
+        $plan = factory(Subscription::class)->create([
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
@@ -302,12 +305,12 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_is_subscribed_returns_true_if_annual_plan_is_set()
     {
         $account = factory(Account::class)->create();
 
-        $plan = factory(\Laravel\Cashier\Subscription::class)->create([
+        $plan = factory(Subscription::class)->create([
             'account_id' => $account->id,
             'stripe_price' => 'chandler_annual',
             'stripe_id' => 'sub_C0R444pbxddhW7',
@@ -321,7 +324,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_is_subscribed_returns_false_if_no_plan_is_set()
     {
         $account = factory(Account::class)->create();
@@ -331,12 +334,12 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_invoices_returns_true_if_a_plan_exists()
     {
         $account = factory(Account::class)->create();
 
-        $plan = factory(\Laravel\Cashier\Subscription::class)->create([
+        $plan = factory(Subscription::class)->create([
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
@@ -346,7 +349,7 @@ class AccountTest extends FeatureTestCase
         $this->assertTrue($account->hasInvoices());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_invoices_returns_false_if_a_plan_does_not_exist()
     {
         $account = factory(Account::class)->create();
@@ -354,7 +357,7 @@ class AccountTest extends FeatureTestCase
         $this->assertFalse($account->hasInvoices());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_id_of_the_subscribed_plan()
     {
         config([
@@ -366,7 +369,7 @@ class AccountTest extends FeatureTestCase
 
         $account = $user->account;
 
-        $plan = factory(\Laravel\Cashier\Subscription::class)->create([
+        $plan = factory(Subscription::class)->create([
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
@@ -379,7 +382,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_friendly_name_of_the_subscribed_plan()
     {
         config([
@@ -391,7 +394,7 @@ class AccountTest extends FeatureTestCase
 
         $account = $user->account;
 
-        $plan = factory(\Laravel\Cashier\Subscription::class)->create([
+        $plan = factory(Subscription::class)->create([
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
@@ -404,7 +407,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_the_account_with_three_default_genders()
     {
         $account = factory(Account::class)->create();
@@ -416,7 +419,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_the_account_with_the_right_default_genders()
     {
         $account = factory(Account::class)->create();
@@ -438,7 +441,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_default_time_reminder_is_sent_attribute()
     {
         $account = factory(Account::class)->create(['default_time_reminder_is_sent' => '14:00']);
@@ -449,7 +452,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_default_time_reminder_is_sent_attribute()
     {
         $account = new Account;
@@ -461,7 +464,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_the_account_with_two_default_reminder_rules()
     {
         $account = factory(Account::class)->create();
@@ -473,7 +476,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_the_account_with_the_right_default_reminder_rules()
     {
         $account = factory(Account::class)->create();
@@ -490,7 +493,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_relationship_type_object_matching_a_given_name()
     {
         $account = factory(Account::class)->create();
@@ -502,7 +505,7 @@ class AccountTest extends FeatureTestCase
         $this->assertInstanceOf(RelationshipType::class, $account->getRelationshipTypeByType('partner'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_relationship_type_group_object_matching_a_given_name()
     {
         $account = factory(Account::class)->create();
@@ -514,7 +517,7 @@ class AccountTest extends FeatureTestCase
         $this->assertInstanceOf(RelationshipTypeGroup::class, $account->getRelationshipTypeGroupByType('love'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_default_relationship_type_groups_table_if_tables_havent_been_migrated_yet()
     {
         $account = factory(Account::class)->create();
@@ -531,7 +534,7 @@ class AccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_default_relationship_type_groups_table_for_types_already_migrated()
     {
         $account = factory(Account::class)->create();
@@ -547,7 +550,7 @@ class AccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_default_relationship_types_table_if_tables_havent_been_migrated_yet()
     {
         $account = factory(Account::class)->create();
@@ -568,7 +571,7 @@ class AccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_skips_default_relationship_types_table_for_types_already_migrated()
     {
         $account = factory(Account::class)->create();
@@ -590,7 +593,7 @@ class AccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_default_account()
     {
         $account = Account::createDefault('John', 'Doe', 'john@doe.com', 'password');
@@ -603,7 +606,7 @@ class AccountTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throw_an_exception_if_user_already_exist()
     {
         $account = Account::createDefault('John', 'Doe', 'john@doe.com', 'password');
@@ -615,11 +618,11 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
         ]);
 
-        $this->expectException(\Illuminate\Validation\ValidationException::class);
+        $this->expectException(ValidationException::class);
         $account = Account::createDefault('John', 'Doe', 'john@doe.com', 'password');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_first_user_locale()
     {
         $account = factory(Account::class)->create();
@@ -638,7 +641,7 @@ class AccountTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_first_locale_returns_null_if_user_doesnt_exist()
     {
         $account = factory(Account::class)->create();
@@ -646,7 +649,7 @@ class AccountTest extends FeatureTestCase
         $this->assertNull($account->getFirstLocale());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populates_default_life_event_tables_upon_creation()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Models/ActivityTest.php
+++ b/tests/Unit/Models/ActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Account\Activity;
@@ -12,7 +13,7 @@ class ActivityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_happened_at()
     {
         $activity = factory(Activity::class)->make();
@@ -23,7 +24,7 @@ class ActivityTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_title()
     {
         $type = factory(ActivityType::class)->create();
@@ -38,7 +39,7 @@ class ActivityTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_info_for_journal_entry()
     {
         $activity = factory(Activity::class)->create();

--- a/tests/Unit/Models/ActivityTypeCategoryTest.php
+++ b/tests/Unit/Models/ActivityTypeCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\ActivityType;
 use App\Models\Account\ActivityTypeCategory;
@@ -11,7 +12,7 @@ class ActivityTypeCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([]);
@@ -19,7 +20,7 @@ class ActivityTypeCategoryTest extends TestCase
         $this->assertTrue($activityTypeCategory->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_activity_types()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([]);
@@ -30,7 +31,7 @@ class ActivityTypeCategoryTest extends TestCase
         $this->assertTrue($activityTypeCategory->activityTypes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_name_attribute()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([

--- a/tests/Unit/Models/ActivityTypeTest.php
+++ b/tests/Unit/Models/ActivityTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Activity;
@@ -12,7 +13,7 @@ class ActivityTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $activityType = factory(ActivityType::class)->create([]);
@@ -20,7 +21,7 @@ class ActivityTypeTest extends TestCase
         $this->assertTrue($activityType->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_category()
     {
         $activityType = factory(ActivityType::class)->create([]);
@@ -28,7 +29,7 @@ class ActivityTypeTest extends TestCase
         $this->assertTrue($activityType->category()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_activities()
     {
         $account = factory(Account::class)->create();
@@ -43,7 +44,7 @@ class ActivityTypeTest extends TestCase
         $this->assertTrue($account->activities()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_name_attribute()
     {
         $activityType = factory(ActivityType::class)->create([
@@ -67,7 +68,7 @@ class ActivityTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resets_the_associated_activities()
     {
         $activityType = factory(ActivityType::class)->create([]);

--- a/tests/Unit/Models/AddressBookSubscriptionTest.php
+++ b/tests/Unit/Models/AddressBookSubscriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -13,7 +14,7 @@ class AddressBookSubscriptionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create();
@@ -26,7 +27,7 @@ class AddressBookSubscriptionTest extends TestCase
         $this->assertTrue($addressBookSubscription->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user()
     {
         $user = factory(User::class)->create();
@@ -37,7 +38,7 @@ class AddressBookSubscriptionTest extends TestCase
         $this->assertTrue($addressBookSubscription->user()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_addressbook()
     {
         $addressBook = AddressBook::factory()->create();
@@ -48,7 +49,7 @@ class AddressBookSubscriptionTest extends TestCase
         $this->assertTrue($addressBookSubscription->addressBook()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_saves_capabilities()
     {
         $addressBookSubscription = new AddressBookSubscription();
@@ -63,7 +64,7 @@ class AddressBookSubscriptionTest extends TestCase
         ], $addressBookSubscription->capabilities);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_saves_password()
     {
         $addressBookSubscription = new AddressBookSubscription();

--- a/tests/Unit/Models/AddressBookTest.php
+++ b/tests/Unit/Models/AddressBookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class AddressBookTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create();
@@ -25,7 +26,7 @@ class AddressBookTest extends TestCase
         $this->assertTrue($addressBook->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user()
     {
         $user = factory(User::class)->create();

--- a/tests/Unit/Models/AddressTest.php
+++ b/tests/Unit/Models/AddressTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Address;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,21 +11,21 @@ class AddressTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $address = factory(Address::class)->create([]);
         $this->assertTrue($address->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $address = factory(Address::class)->create([]);
         $this->assertTrue($address->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_place()
     {
         $address = factory(Address::class)->create([]);

--- a/tests/Unit/Models/AuditLogTest.php
+++ b/tests/Unit/Models/AuditLogTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\ApiTestCase;
 use App\Models\Contact\Contact;
 use App\Models\Instance\AuditLog;
@@ -11,21 +12,21 @@ class AuditLogTest extends ApiTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account(): void
     {
         $auditLog = factory(AuditLog::class)->create([]);
         $this->assertTrue($auditLog->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user(): void
     {
         $auditLog = factory(AuditLog::class)->create([]);
         $this->assertTrue($auditLog->author()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact(): void
     {
         $contact = factory(Contact::class)->create([]);
@@ -35,7 +36,7 @@ class AuditLogTest extends ApiTestCase
         $this->assertTrue($auditLog->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_object_attribute(): void
     {
         $auditLog = factory(AuditLog::class)->create([]);

--- a/tests/Unit/Models/CompanyTest.php
+++ b/tests/Unit/Models/CompanyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -12,7 +13,7 @@ class CompanyTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -23,7 +24,7 @@ class CompanyTest extends TestCase
         $this->assertTrue($company->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_occupations()
     {
         $company = factory(Company::class)->create([]);

--- a/tests/Unit/Models/ContactFieldTest.php
+++ b/tests/Unit/Models/ContactFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\ContactField;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class ContactFieldTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fetches_data_field()
     {
         $contactField = new ContactField;

--- a/tests/Unit/Models/ContactFieldTypeTest.php
+++ b/tests/Unit/Models/ContactFieldTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\FeatureTestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Conversation;
@@ -12,7 +13,7 @@ class ContactFieldTypeTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_conversations()
     {
         $contactFieldType = factory(ContactFieldType::class)->create([]);
@@ -24,7 +25,7 @@ class ContactFieldTypeTest extends FeatureTestCase
         $this->assertTrue($contactFieldType->conversations()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use App\Models\User\User;
 use Tests\FeatureTestCase;
@@ -32,7 +33,7 @@ class ContactTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_gender()
     {
         $account = factory(Account::class)->create([]);
@@ -45,7 +46,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->gender()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_relationships()
     {
         $account = factory(Account::class)->create([]);
@@ -58,7 +59,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->relationships()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_conversations()
     {
         $account = factory(Account::class)->create([]);
@@ -71,7 +72,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->conversations()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_messages()
     {
         $account = factory(Account::class)->create([]);
@@ -84,7 +85,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->messages()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_documents()
     {
         $account = factory(Account::class)->create([]);
@@ -97,7 +98,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->documents()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_photos()
     {
         $account = factory(Account::class)->create([]);
@@ -111,7 +112,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->photos()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_events()
     {
         $account = factory(Account::class)->create([]);
@@ -123,7 +124,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->lifeEvents()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_occupations()
     {
         $account = factory(Account::class)->create([]);
@@ -135,7 +136,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->occupations()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_logs()
     {
         $contact = factory(Contact::class)->create();
@@ -145,7 +146,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->logs()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_nickname()
     {
         $contact = new Contact;
@@ -157,7 +158,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_the_nickname()
     {
         $contact = new Contact;
@@ -169,7 +170,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function name_attribute_returns_name_in_the_right_order()
     {
         $contact = new Contact;
@@ -396,7 +397,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_initials()
     {
         $contact = new Contact;
@@ -440,7 +441,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_initials_returns_order_thanks_to_user_preferences()
     {
         $contact = new Contact;
@@ -455,7 +456,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_initials_with_special_chars()
     {
         $user = $this->signIn();
@@ -474,7 +475,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_last_activity_date_for_multiple_activities()
     {
         $contact = factory(Contact::class)->create();
@@ -503,7 +504,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_last_activity_date_for_one_activity()
     {
         $contact = factory(Contact::class)->create();
@@ -520,7 +521,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_last_activity_date_for_no_activity()
     {
         $contact = new Contact;
@@ -532,7 +533,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_default_avatar_color()
     {
         $contact = factory(Contact::class)->create([]);
@@ -544,7 +545,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_url_of_the_avatar()
     {
         // default
@@ -583,7 +584,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_indicates_that_it_has_not_debts()
     {
         $contact = new Contact;
@@ -593,7 +594,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function a_contact_is_owned_money()
     {
         /** @var Contact $contact */
@@ -609,7 +610,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->isOwedMoney());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function a_contact_is_not_owned_money()
     {
         /** @var Contact $contact */
@@ -625,7 +626,7 @@ class ContactTest extends FeatureTestCase
         $this->assertFalse($contact->isOwedMoney());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_amount_of_money_due()
     {
         /** @var Contact $contact */
@@ -656,7 +657,7 @@ class ContactTest extends FeatureTestCase
         $this->assertEquals(10000, $contact->totalOutstandingDebtAmount());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function set_special_date_with_age_creates_a_date_and_saves_the_id()
     {
         $contact = factory(Contact::class)->create();
@@ -669,7 +670,7 @@ class ContactTest extends FeatureTestCase
         $this->assertNotNull($contact->birthday_special_date_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_first_met_information_returns_false_if_no_information_is_present()
     {
         $contact = factory(Contact::class)->create();
@@ -677,7 +678,7 @@ class ContactTest extends FeatureTestCase
         $this->assertFalse($contact->hasFirstMetInformation());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_first_met_information_returns_true_if_at_least_one_info_is_present()
     {
         $contact = factory(Contact::class)->create();
@@ -686,7 +687,7 @@ class ContactTest extends FeatureTestCase
         $this->assertTrue($contact->hasFirstMetInformation());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_unknown_birthday_state()
     {
         $contact = factory(Contact::class)->create();
@@ -697,7 +698,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_approximate_birthday_state()
     {
         $contact = factory(Contact::class)->create();
@@ -716,7 +717,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_almost_birthday_state()
     {
         $contact = factory(Contact::class)->create();
@@ -736,7 +737,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_exact_birthday_state()
     {
         $contact = factory(Contact::class)->create();
@@ -753,7 +754,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function set_name_returns_false_if_given_an_empty_firstname()
     {
         $contact = factory(Contact::class)->create();
@@ -761,7 +762,7 @@ class ContactTest extends FeatureTestCase
         $this->assertFalse($contact->setName('', 'Test', 'Test'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function set_name_returns_true()
     {
         $contact = factory(Contact::class)->create();
@@ -778,7 +779,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_related_relationships_of_a_certain_relationshiptype_group_name()
     {
         $account = factory(Account::class)->create([]);
@@ -814,7 +815,7 @@ class ContactTest extends FeatureTestCase
         $this->assertNull($contact->getRelationshipsByRelationshipTypeGroup('love'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_right_number_of_birthdays_about_related_contacts()
     {
         $user = $this->signIn();
@@ -880,7 +881,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fetches_the_partial_contact_who_belongs_to_a_real_contact()
     {
         $user = $this->signIn();
@@ -914,7 +915,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_stay_in_touch_frequency()
     {
         $account = factory(Account::class)->create([]);
@@ -933,7 +934,7 @@ class ContactTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resets_stay_in_touch_frequency_if_set_to_0()
     {
         $account = factory(Account::class)->create([]);
@@ -952,7 +953,7 @@ class ContactTest extends FeatureTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_false_if_frequency_is_not_an_integer()
     {
         $account = factory(Account::class)->create([]);
@@ -965,7 +966,7 @@ class ContactTest extends FeatureTestCase
         $this->assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_stay_in_touch_trigger_date()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -1002,7 +1003,7 @@ class ContactTest extends FeatureTestCase
         $this->assertNull($contact->stay_in_touch_trigger_date);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_the_stay_in_touch_email()
     {
         config(['monica.requires_subscription' => false]);
@@ -1034,7 +1035,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_age_at_death()
     {
         $contact = factory(Contact::class)->create();
@@ -1048,7 +1049,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function getting_age_at_death_returns_null()
     {
         $contact = factory(Contact::class)->create();
@@ -1060,7 +1061,7 @@ class ContactTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_default_avatar_url_attribute()
     {
         $contact = factory(Contact::class)->create([

--- a/tests/Unit/Models/ConversationTest.php
+++ b/tests/Unit/Models/ConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class ConversationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -25,7 +26,7 @@ class ConversationTest extends TestCase
         $this->assertTrue($conversation->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create();
@@ -36,7 +37,7 @@ class ConversationTest extends TestCase
         $this->assertTrue($conversation->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact_field_type()
     {
         $account = factory(Account::class)->create([]);
@@ -51,7 +52,7 @@ class ConversationTest extends TestCase
         $this->assertTrue($conversation->contactFieldType()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_messages()
     {
         $conversation = factory(Conversation::class)->create();

--- a/tests/Unit/Models/DayTest.php
+++ b/tests/Unit/Models/DayTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Journal\Day;
 use Illuminate\Support\Carbon;
@@ -11,7 +12,7 @@ class DayTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_info_for_journal_entry_that_doesnt_happen_today()
     {
         $day = factory(Day::class)->make();
@@ -42,7 +43,7 @@ class DayTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_info_for_journal_entry_that_happen_today()
     {
         $date = now();

--- a/tests/Unit/Models/DocumentTest.php
+++ b/tests/Unit/Models/DocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class DocumentTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -23,7 +24,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($document->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create();
@@ -34,7 +35,7 @@ class DocumentTest extends TestCase
         $this->assertTrue($document->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_download_link()
     {
         $document = factory(Document::class)->create();

--- a/tests/Unit/Models/EmotionTest.php
+++ b/tests/Unit/Models/EmotionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Instance\Emotion\Emotion;
 use App\Models\Instance\Emotion\PrimaryEmotion;
@@ -12,7 +13,7 @@ class EmotionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function emotion_belongs_to_a_primary_emotion()
     {
         $emotion = factory(Emotion::class)->create([]);
@@ -22,7 +23,7 @@ class EmotionTest extends TestCase
         $this->assertTrue($emotion->secondary->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function secondary_emotion_belongs_to_a_primary_emotion()
     {
         $secondaryEmotion = factory(SecondaryEmotion::class)->create([]);
@@ -30,7 +31,7 @@ class EmotionTest extends TestCase
         $this->assertTrue($secondaryEmotion->primary->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function a_primary_emotion_has_multiple_emotions()
     {
         $primaryEmotion = factory(PrimaryEmotion::class)->create([]);

--- a/tests/Unit/Models/EntryTest.php
+++ b/tests/Unit/Models/EntryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Journal\Entry;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class EntryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_info_for_journal_entry()
     {
         $entry = factory(Entry::class)->make([

--- a/tests/Unit/Models/GenderTest.php
+++ b/tests/Unit/Models/GenderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class GenderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -23,7 +24,7 @@ class GenderTest extends TestCase
         $this->assertTrue($gender->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_contacts()
     {
         $account = factory(Account::class)->create([]);
@@ -36,7 +37,7 @@ class GenderTest extends TestCase
         $this->assertTrue($gender->contacts()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_gender_name()
     {
         $gender = new Gender;
@@ -48,7 +49,7 @@ class GenderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_default_gender()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Models/GiftTest.php
+++ b/tests/Unit/Models/GiftTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Gift;
@@ -12,7 +13,7 @@ class GiftTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_particular_recipient_returns_false_if_it_s_for_no_specific_recipient()
     {
         $gift = factory(Gift::class)->make();
@@ -22,7 +23,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function has_particular_recipient_returns_true_if_it_s_for_a_specific_recipient()
     {
         $gift = factory(Gift::class)->make([
@@ -34,7 +35,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_is_for_attribute()
     {
         $gift = factory(Gift::class)->make([
@@ -47,7 +48,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_recipient_name()
     {
         $contact = factory(Contact::class)->create(['first_name' => 'Regis']);
@@ -63,7 +64,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_gift_name()
     {
         $gift = factory(Gift::class)->make([
@@ -76,7 +77,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_gift_url()
     {
         $gift = factory(Gift::class)->make([
@@ -89,7 +90,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_comment()
     {
         $gift = factory(Gift::class)->make([
@@ -102,7 +103,7 @@ class GiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_value()
     {
         $user = factory(User::class)->create();

--- a/tests/Unit/Models/Google2FATest.php
+++ b/tests/Unit/Models/Google2FATest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
+use PragmaRX\Google2FALaravel\Support\Authenticator;
 use Tests\TestCase;
 use App\Models\User\User;
 use Illuminate\Session\Store;
@@ -13,7 +15,7 @@ class Google2FATest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tests_a_wrong_key_for_Google2fa()
     {
         $google2fa = app('pragmarx.google2fa');
@@ -25,7 +27,7 @@ class Google2FATest extends TestCase
         $this->assertFalse($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_tests_a_correct_key_for_Google2fa()
     {
         $google2fa = app('pragmarx.google2fa');
@@ -38,7 +40,7 @@ class Google2FATest extends TestCase
         $this->assertTrue($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_logs_in_with_Google2Fa()
     {
         config(['google2fa.enabled' => true]);
@@ -55,7 +57,7 @@ class Google2FATest extends TestCase
         $request->setLaravelSession(new Store('test', new NullSessionHandler));
         $request->getSession()->start();
 
-        $authenticator = new \PragmaRX\Google2FALaravel\Support\Authenticator($request);
+        $authenticator = new Authenticator($request);
 
         $this->assertFalse($authenticator->isAuthenticated());
 

--- a/tests/Unit/Models/IdHasherTest.php
+++ b/tests/Unit/Models/IdHasherTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
+use App\Exceptions\WrongIdException;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Services\Instance\IdHasher;
@@ -11,7 +13,7 @@ class IdHasherTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_prepends_the_id_with_the_letter_h()
     {
         $idHasher = new IdHasher();
@@ -25,7 +27,7 @@ class IdHasherTest extends TestCase
         $this->assertEquals('h', $value);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_id_back()
     {
         $idHasher = new IdHasher();
@@ -39,19 +41,19 @@ class IdHasherTest extends TestCase
         $this->assertEquals($test_id, $result_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_an_exception_when_the_id_is_not_valid()
     {
         $idHasher = new IdHasher();
 
         $test_id = rand();
 
-        $this->expectException(\App\Exceptions\WrongIdException::class);
+        $this->expectException(WrongIdException::class);
 
         $idHasher->decodeId($test_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_decodes_the_hash_and_returns_the_right_id()
     {
         $idHasher = new IdHasher();

--- a/tests/Unit/Models/ImportJobTest.php
+++ b/tests/Unit/Models/ImportJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -44,7 +45,7 @@ ADR:;;17 Shakespeare Ave.;Southampton;;SO17 2HB;United Kingdom
 END:VCARD
 ';
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user()
     {
         $importJob = factory(ImportJob::class)->create();
@@ -52,7 +53,7 @@ END:VCARD
         $this->assertTrue($importJob->user()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -67,7 +68,7 @@ END:VCARD
         $this->assertTrue($importJob->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_reports()
     {
         $account = factory(Account::class)->create([]);
@@ -87,7 +88,7 @@ END:VCARD
         $this->assertTrue($importJob->importJobReports()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_initiates_the_job()
     {
         $importJob = factory(ImportJob::class)->make([]);
@@ -99,7 +100,7 @@ END:VCARD
         $this->assertNotNull($importJob->started_at);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_finalizes_the_job()
     {
         $importJob = factory(ImportJob::class)->make([]);
@@ -111,7 +112,7 @@ END:VCARD
         $this->assertNotNull($importJob->ended_at);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_and_throws_an_exception()
     {
         $importJob = factory(ImportJob::class)->create([]);
@@ -126,7 +127,7 @@ END:VCARD
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_physical_file()
     {
         Storage::fake('public');
@@ -147,7 +148,7 @@ END:VCARD
         $this->assertIsResource($importJob->physicalFile);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_file_doesnt_exist()
     {
         Storage::fake('public', [
@@ -165,7 +166,7 @@ END:VCARD
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_the_file()
     {
         Storage::fake('public');
@@ -183,7 +184,7 @@ END:VCARD
         Storage::disk('public')->assertMissing($importJob->filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_how_many_entries_there_are_and_populate_the_entries_array()
     {
         Storage::fake('public');
@@ -206,7 +207,7 @@ END:VCARD
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_process_an_entry_if_import_is_not_feasible()
     {
         $importJob = $this->createImportJob();
@@ -225,7 +226,7 @@ END:VCARD
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_process_an_entry_if_contact_already_exists()
     {
         $importJob = $this->createImportJob();
@@ -256,7 +257,7 @@ END:VCARD
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function skipping_entries_increments_counter_and_file_job_report()
     {
         $importJob = $this->createImportJob();
@@ -276,7 +277,7 @@ END:VCARD
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_files_an_import_job_report()
     {
         $importJob = $this->createImportJob();

--- a/tests/Unit/Models/JournalEntryTest.php
+++ b/tests/Unit/Models/JournalEntryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Journal\Entry;
@@ -14,7 +15,7 @@ class JournalEntryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -25,7 +26,7 @@ class JournalEntryTest extends TestCase
         $this->assertTrue($task->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_polymorphic_relations()
     {
         $activity = factory(Activity::class)->create();
@@ -38,7 +39,7 @@ class JournalEntryTest extends TestCase
         $this->assertEquals($journalEntry->id, $activity->journalEntry->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_polymorphic_relations2()
     {
         $entry = factory(Entry::class)->create();
@@ -52,7 +53,7 @@ class JournalEntryTest extends TestCase
         $this->assertEquals($journalEntry->id, $entry->journalEntry->id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_add_adds_data_of_the_right_type()
     {
         $activity = factory(Activity::class)->create();
@@ -68,7 +69,7 @@ class JournalEntryTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_object_data_returns_an_object()
     {
         $activity = factory(Activity::class)->create();
@@ -95,7 +96,7 @@ class JournalEntryTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_edit_journal_entry()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1, 0, 0, 0));

--- a/tests/Unit/Models/LIfeEventTypeTest.php
+++ b/tests/Unit/Models/LIfeEventTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class LIfeEventTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $lifeEventType = factory(LifeEventType::class)->create([]);
@@ -21,7 +22,7 @@ class LIfeEventTypeTest extends TestCase
         $this->assertTrue($lifeEventType->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_category()
     {
         $lifeEventType = factory(LifeEventType::class)->create([]);
@@ -29,7 +30,7 @@ class LIfeEventTypeTest extends TestCase
         $this->assertTrue($lifeEventType->lifeEventCategory()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_events()
     {
         $account = factory(Account::class)->create([]);
@@ -44,7 +45,7 @@ class LIfeEventTypeTest extends TestCase
         $this->assertTrue($lifeEventType->lifeEvents()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_name_attribute()
     {
         $lifeEventType = factory(LifeEventType::class)->create([

--- a/tests/Unit/Models/LifeEventCategoryTest.php
+++ b/tests/Unit/Models/LifeEventCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\LifeEventType;
@@ -12,7 +13,7 @@ class LifeEventCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -23,7 +24,7 @@ class LifeEventCategoryTest extends TestCase
         $this->assertTrue($lifeEventCategory->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_life_event_types()
     {
         $lifeEventCategory = factory(LifeEventCategory::class)->create();
@@ -34,7 +35,7 @@ class LifeEventCategoryTest extends TestCase
         $this->assertTrue($lifeEventCategory->lifeEventTypes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_name_attribute()
     {
         $lifeEventCategory = factory(LifeEventCategory::class)->create([

--- a/tests/Unit/Models/LifeEventTest.php
+++ b/tests/Unit/Models/LifeEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Reminder;
 use App\Models\Contact\LifeEvent;
@@ -11,7 +12,7 @@ class LifeEventTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -19,7 +20,7 @@ class LifeEventTest extends TestCase
         $this->assertTrue($lifeEvent->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -27,7 +28,7 @@ class LifeEventTest extends TestCase
         $this->assertTrue($lifeEvent->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_type()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -35,7 +36,7 @@ class LifeEventTest extends TestCase
         $this->assertTrue($lifeEvent->lifeEventType()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_a_reminder()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -48,7 +49,7 @@ class LifeEventTest extends TestCase
         $this->assertTrue($lifeEvent->reminder()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_name_attribute()
     {
         $lifeEvent = factory(LifeEvent::class)->create([
@@ -61,7 +62,7 @@ class LifeEventTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_note_attribute()
     {
         $lifeEvent = factory(LifeEvent::class)->create([

--- a/tests/Unit/Models/MessageTest.php
+++ b/tests/Unit/Models/MessageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class MessageTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class MessageTest extends TestCase
         $this->assertTrue($message->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create();
@@ -35,7 +36,7 @@ class MessageTest extends TestCase
         $this->assertTrue($message->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_conversation()
     {
         $conversation = factory(Conversation::class)->create();
@@ -46,7 +47,7 @@ class MessageTest extends TestCase
         $this->assertTrue($message->conversation()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_content_attribute()
     {
         $message = factory(Message::class)->create([

--- a/tests/Unit/Models/NoteTest.php
+++ b/tests/Unit/Models/NoteTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Note;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class NoteTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -25,7 +26,7 @@ class NoteTest extends TestCase
         $this->assertTrue($note->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -36,7 +37,7 @@ class NoteTest extends TestCase
         $this->assertTrue($note->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_favorited_notes()
     {
         $note = factory(Note::class)->create(['is_favorited' => true]);

--- a/tests/Unit/Models/OccupationTest.php
+++ b/tests/Unit/Models/OccupationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -13,7 +14,7 @@ class OccupationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class OccupationTest extends TestCase
         $this->assertTrue($occupation->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -34,7 +35,7 @@ class OccupationTest extends TestCase
         $this->assertTrue($occupation->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_company()
     {
         $company = factory(Company::class)->create([]);

--- a/tests/Unit/Models/PetCategoryTest.php
+++ b/tests/Unit/Models/PetCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\PetCategory;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class PetCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_only_common_pets()
     {
         $petCategory = new PetCategory;
@@ -21,7 +22,7 @@ class PetCategoryTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_pet_category_name()
     {
         $petCategory = new PetCategory;

--- a/tests/Unit/Models/PetTest.php
+++ b/tests/Unit/Models/PetTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Pet;
 use App\Models\Account\Account;
@@ -13,7 +14,7 @@ class PetTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -26,7 +27,7 @@ class PetTest extends TestCase
         $this->assertTrue($pet->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -38,7 +39,7 @@ class PetTest extends TestCase
         $this->assertTrue($pet->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_pet_category()
     {
         $petCategory = factory(PetCategory::class)->create([]);
@@ -49,7 +50,7 @@ class PetTest extends TestCase
         $this->assertTrue($pet->petCategory()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_name()
     {
         $pet = new Pet;

--- a/tests/Unit/Models/PhotoTest.php
+++ b/tests/Unit/Models/PhotoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Photo;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class PhotoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -22,7 +23,7 @@ class PhotoTest extends TestCase
         $this->assertTrue($photo->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_contacts()
     {
         $contact = factory(Contact::class)->create();
@@ -35,7 +36,7 @@ class PhotoTest extends TestCase
         $this->assertTrue($photo->contacts()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_url()
     {
         $photo = factory(Photo::class)->create();

--- a/tests/Unit/Models/PlaceTest.php
+++ b/tests/Unit/Models/PlaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Weather;
@@ -11,21 +12,21 @@ class PlaceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $place = factory(Place::class)->create([]);
         $this->assertTrue($place->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_weathers()
     {
         $weather = factory(Weather::class)->create([]);
         $this->assertTrue($weather->place->weathers()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_full_address_as_a_string()
     {
         $place = factory(Place::class)->create([]);
@@ -35,7 +36,7 @@ class PlaceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_country_name()
     {
         $place = factory(Place::class)->create([]);
@@ -45,7 +46,7 @@ class PlaceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_link_to_google_maps()
     {
         $place = factory(Place::class)->create([]);
@@ -56,7 +57,7 @@ class PlaceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_google_map_url_with_latitude_longitude()
     {
         $place = new Place;

--- a/tests/Unit/Models/RelationshipTest.php
+++ b/tests/Unit/Models/RelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class RelationshipTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class RelationshipTest extends TestCase
         $this->assertTrue($relationship->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -35,7 +36,7 @@ class RelationshipTest extends TestCase
         $this->assertTrue($relationship->contactIs()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_another_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -46,7 +47,7 @@ class RelationshipTest extends TestCase
         $this->assertTrue($relationship->ofContact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_relationship_type()
     {
         $account = factory(Account::class)->create([]);
@@ -61,7 +62,7 @@ class RelationshipTest extends TestCase
         $this->assertTrue($relationship->relationshipType()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact_through_with_contact_field()
     {
         $contact = factory(Contact::class)->create([]);
@@ -72,7 +73,7 @@ class RelationshipTest extends TestCase
         $this->assertTrue($relationship->ofContact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_reverse_relationship()
     {
         $account = factory(Account::class)->create();
@@ -118,7 +119,7 @@ class RelationshipTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_not_gets_the_reverse_relationship()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Models/RelationshipTypeGroupTest.php
+++ b/tests/Unit/Models/RelationshipTypeGroupTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Relationship\RelationshipType;
@@ -11,7 +12,7 @@ class RelationshipTypeGroupTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Models/RelationshipTypeTest.php
+++ b/tests/Unit/Models/RelationshipTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class RelationshipTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class RelationshipTypeTest extends TestCase
         $this->assertTrue($relationshipType->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_relationship_type_group()
     {
         $account = factory(Account::class)->create([]);
@@ -35,7 +36,7 @@ class RelationshipTypeTest extends TestCase
         $this->assertTrue($relationshipTypeGroup->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_masculine_short_name_of_the_relationship_type()
     {
         $account = factory(Account::class)->create([]);
@@ -51,7 +52,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_feminine_short_name_of_the_relationship_type()
     {
         $account = factory(Account::class)->create([]);
@@ -67,7 +68,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_masculine_name_of_the_relationship_type_with_the_name_of_the_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -88,7 +89,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_feminine_name_of_the_relationship_type_with_the_name_of_the_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -109,7 +110,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_both_names_of_the_relationship_type_with_the_name_of_the_contact_and_the_opposite_version()
     {
         $account = factory(Account::class)->create([]);
@@ -130,7 +131,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_only_one_name_of_the_relationship_type_if_name_and_name_reverse_are_similar()
     {
         $account = factory(Account::class)->create([]);
@@ -151,7 +152,7 @@ class RelationshipTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_reverse_relationship_type()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Models/ReminderOutboxTest.php
+++ b/tests/Unit/Models/ReminderOutboxTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\ReminderOutbox;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,21 +11,21 @@ class ReminderOutboxTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $reminderOutbox = factory(ReminderOutbox::class)->create([]);
         $this->assertTrue($reminderOutbox->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_reminder()
     {
         $reminderOutbox = factory(ReminderOutbox::class)->create([]);
         $this->assertTrue($reminderOutbox->reminder()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_user()
     {
         $reminderOutbox = factory(ReminderOutbox::class)->create([]);

--- a/tests/Unit/Models/ReminderRuleTest.php
+++ b/tests/Unit/Models/ReminderRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\ReminderRule;
@@ -11,7 +12,7 @@ class ReminderRuleTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -20,7 +21,7 @@ class ReminderRuleTest extends TestCase
         $this->assertTrue($reminderRule->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_number_of_days_before_attribute()
     {
         $reminderRule = factory(ReminderRule::class)->create(['number_of_days_before' => '14']);
@@ -31,7 +32,7 @@ class ReminderRuleTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_number_of_days_before_attribute()
     {
         $reminderRule = new ReminderRule;

--- a/tests/Unit/Models/ReminderTest.php
+++ b/tests/Unit/Models/ReminderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -16,7 +17,7 @@ class ReminderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -27,7 +28,7 @@ class ReminderTest extends TestCase
         $this->assertTrue($reminder->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -38,7 +39,7 @@ class ReminderTest extends TestCase
         $this->assertTrue($reminder->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_has_many_reminder_outbox()
     {
         $user = factory(User::class)->create([]);
@@ -52,7 +53,7 @@ class ReminderTest extends TestCase
         $this->assertTrue($reminder->reminderOutboxes()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_title_attribute()
     {
         $reminder = factory(Reminder::class)->create([
@@ -65,7 +66,7 @@ class ReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_description_attribute()
     {
         $reminder = factory(Reminder::class)->create([
@@ -78,7 +79,7 @@ class ReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_next_expected_date()
     {
         $timezone = 'UTC';
@@ -132,7 +133,7 @@ class ReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_calculates_next_expected_date_in_timezone()
     {
         config(['app.timezone' => 'Europe/Paris']);
@@ -155,7 +156,7 @@ class ReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_schedules_a_reminder_for_one_user()
     {
         Carbon::setTestNow(Carbon::create(2017, 2, 1));
@@ -177,7 +178,7 @@ class ReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function scheduling_a_reminder_also_schedules_notifications_for_one_user()
     {
         Carbon::setTestNow(Carbon::create(2017, 2, 1));
@@ -222,7 +223,7 @@ class ReminderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_schedule_a_notification_if_date_is_too_close_to_present_date()
     {
         Carbon::setTestNow(Carbon::create(2017, 2, 1));

--- a/tests/Unit/Models/SpecialDateTest.php
+++ b/tests/Unit/Models/SpecialDateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\FeatureTestCase;
 use App\Models\Account\Account;
@@ -13,7 +14,7 @@ class SpecialDateTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class SpecialDateTest extends FeatureTestCase
         $this->assertTrue($specialDate->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -39,14 +40,14 @@ class SpecialDateTest extends FeatureTestCase
         $this->assertTrue($specialDate->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_age_returns_null_if_no_date_is_set()
     {
         $specialDate = new SpecialDate;
         $this->assertNull($specialDate->getAge());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_age_returns_null_if_year_is_unknown()
     {
         $specialDate = factory(SpecialDate::class)->make();
@@ -56,7 +57,7 @@ class SpecialDateTest extends FeatureTestCase
         $this->assertNull($specialDate->getAge());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function get_age_returns_age()
     {
         Carbon::setTestNow(Carbon::create(2020, 2, 17, 17, 0, 0));
@@ -72,7 +73,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_from_age_sets_the_right_date()
     {
         $specialDate = factory(SpecialDate::class)->make();
@@ -94,7 +95,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_from_date_creates_an_approximate_date()
     {
         $specialDate = factory(SpecialDate::class)->make();
@@ -121,7 +122,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function create_from_date_creates_an_exact_date()
     {
         $specialDate = factory(SpecialDate::class)->make();
@@ -148,7 +149,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function set_contact_sets_the_contact_information()
     {
         $specialDate = factory(SpecialDate::class)->make();
@@ -168,7 +169,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function to_short_string_returns_date_with_year()
     {
         $specialDate = new SpecialDate;
@@ -181,7 +182,7 @@ class SpecialDateTest extends FeatureTestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function to_short_string_returns_date_without_year()
     {
         $specialDate = new SpecialDate;

--- a/tests/Unit/Models/TagTest.php
+++ b/tests/Unit/Models/TagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class TagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -24,7 +25,7 @@ class TagTest extends TestCase
         $this->assertTrue($tag->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_contacts()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Models/TaskTest.php
+++ b/tests/Unit/Models/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
@@ -12,7 +13,7 @@ class TaskTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -25,7 +26,7 @@ class TaskTest extends TestCase
         $this->assertTrue($task->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -38,7 +39,7 @@ class TaskTest extends TestCase
         $this->assertTrue($task->contact()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_completed_items()
     {
         $task = factory(Task::class)->create(['completed' => true]);
@@ -52,7 +53,7 @@ class TaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_filters_by_incomplete_items()
     {
         $task = factory(Task::class)->create(['completed' => false]);

--- a/tests/Unit/Models/TermTest.php
+++ b/tests/Unit/Models/TermTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Settings\Term;
@@ -12,7 +13,7 @@ class TermTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_users()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -30,7 +31,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_account()
     {
         $account = factory(Account::class)->create([]);
@@ -39,7 +40,7 @@ class UserTest extends TestCase
         $this->assertTrue($user->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_many_terms()
     {
         $account = factory(Account::class)->create([]);
@@ -54,7 +55,7 @@ class UserTest extends TestCase
         $this->assertTrue($user->terms()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function name_accessor_returns_name_in_the_user_preferred_way()
     {
         $user = new User;
@@ -75,7 +76,7 @@ class UserTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_2fa_secret_attribute()
     {
         $user = new User;
@@ -90,7 +91,7 @@ class UserTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_fluid_layout()
     {
         $user = new User;
@@ -109,7 +110,7 @@ class UserTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_locale()
     {
         $user = new User;
@@ -121,7 +122,7 @@ class UserTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_should_not_be_reminded_because_dates_are_different()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -135,7 +136,7 @@ class UserTest extends TestCase
         $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->initial_date));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_should_not_be_reminded_because_hours_are_different()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 0, 0));
@@ -149,7 +150,7 @@ class UserTest extends TestCase
         $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->initial_date));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_should_not_be_reminded_because_timezone_is_different()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 0, 0));
@@ -166,7 +167,7 @@ class UserTest extends TestCase
         $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->initial_date));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function user_should_be_reminded()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 32, 12));
@@ -180,7 +181,7 @@ class UserTest extends TestCase
         $this->assertTrue($user->isTheRightTimeToBeReminded($reminder->initial_date));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_en()
     {
         App::setLocale('en');
@@ -202,7 +203,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_fr()
     {
         App::setLocale('fr');
@@ -224,7 +225,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_cs()
     {
         App::setLocale('cs');
@@ -246,7 +247,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_de()
     {
         App::setLocale('de');
@@ -268,7 +269,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_es()
     {
         App::setLocale('es');
@@ -290,7 +291,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_he()
     {
         App::setLocale('he');
@@ -312,7 +313,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_it()
     {
         App::setLocale('it');
@@ -334,7 +335,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_nl()
     {
         App::setLocale('nl');
@@ -356,7 +357,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_pt()
     {
         App::setLocale('pt');
@@ -378,7 +379,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_ru()
     {
         App::setLocale('ru');
@@ -400,7 +401,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_default_user_zh()
     {
         App::setLocale('zh');
@@ -422,7 +423,7 @@ class UserTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_a_verification_email()
     {
         config(['monica.signup_double_optin' => true]);
@@ -439,7 +440,7 @@ class UserTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_send_a_verification_email_if_the_double_optin_is_disabled_at_the_instance_level()
     {
         config(['monica.signup_double_optin' => false]);

--- a/tests/Unit/Models/WeatherTest.php
+++ b/tests/Unit/Models/WeatherTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Models;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Weather;
@@ -11,7 +12,7 @@ class WeatherTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_an_account()
     {
         $account = factory(Account::class)->create([]);
@@ -21,14 +22,14 @@ class WeatherTest extends TestCase
         $this->assertTrue($weather->account()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_belongs_to_a_place()
     {
         $weather = factory(Weather::class)->create([]);
         $this->assertTrue($weather->place()->exists());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_current_temperature()
     {
         $weather = factory(Weather::class)->create();
@@ -39,7 +40,7 @@ class WeatherTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_current_temperature_in_celsius()
     {
         $weather = factory(Weather::class)->create();
@@ -50,7 +51,7 @@ class WeatherTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_current_temperature_in_fahrenheit()
     {
         $weather = factory(Weather::class)->create();
@@ -61,7 +62,7 @@ class WeatherTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_current_summary()
     {
         $weather = factory(Weather::class)->create();
@@ -72,7 +73,7 @@ class WeatherTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_current_code()
     {
         $weather = factory(Weather::class)->create();
@@ -83,7 +84,7 @@ class WeatherTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_weather_emoji()
     {
         $weather = factory(Weather::class)->create();

--- a/tests/Unit/Services/Account/Activity/ActivityStatisticServiceTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityStatisticServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Account\Account;
@@ -16,7 +17,7 @@ class ActivityStatisticServiceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_activities_since_a_given_number_of_months()
     {
         $service = new ActivityStatisticService;
@@ -41,7 +42,7 @@ class ActivityStatisticServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_an_empty_list_of_activities()
     {
         $service = new ActivityStatisticService;
@@ -61,7 +62,7 @@ class ActivityStatisticServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_unique_activity_types()
     {
         $service = new ActivityStatisticService;
@@ -125,7 +126,7 @@ class ActivityStatisticServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_the_breakdown_of_activities_per_year()
     {
         $service = new ActivityStatisticService;
@@ -187,7 +188,7 @@ class ActivityStatisticServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_a_list_of_activities_per_month_for_given_year()
     {
         $service = new ActivityStatisticService;

--- a/tests/Unit/Services/Account/Activity/ActivityType/CreateActivityTypeTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityType/CreateActivityTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityType;
@@ -15,7 +16,7 @@ class CreateActivityTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_activity_type()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class CreateActivityTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -57,7 +58,7 @@ class CreateActivityTypeTest extends TestCase
         app(CreateActivityType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_activity_type_category_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/ActivityType/DestroyActivityTypeTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityType/DestroyActivityTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityType;
@@ -14,7 +15,7 @@ class DestroyActivityTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_activity_type()
     {
         $activityType = factory(ActivityType::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyActivityTypeTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_activity_type()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyActivityTypeTest extends TestCase
         app(DestroyActivityType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/Activity/ActivityType/UpdateActivityTypeTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityType/UpdateActivityTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityType;
@@ -15,7 +16,7 @@ class UpdateActivityTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_activity_type()
     {
         $activityType = factory(ActivityType::class)->create([]);
@@ -47,7 +48,7 @@ class UpdateActivityTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $activityType = factory(ActivityType::class)->create([]);
@@ -66,7 +67,7 @@ class UpdateActivityTypeTest extends TestCase
         app(UpdateActivityType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_activity_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/ActivityTypeCategory/CreateActivityTypeCategoryTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityTypeCategory/CreateActivityTypeCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityTypeCategory;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityTypeCategory;
@@ -13,7 +14,7 @@ class CreateActivityTypeCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_activity_type_category()
     {
         $account = factory(Account::class)->create([]);
@@ -39,7 +40,7 @@ class CreateActivityTypeCategoryTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [

--- a/tests/Unit/Services/Account/Activity/ActivityTypeCategory/DestroyActivityTypeCategoryTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityTypeCategory/DestroyActivityTypeCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityTypeCategory;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityTypeCategory;
@@ -14,7 +15,7 @@ class DestroyActivityTypeCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_activity_type_category()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyActivityTypeCategoryTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_activity_type_category()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyActivityTypeCategoryTest extends TestCase
         app(DestroyActivityTypeCategory::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/Activity/ActivityTypeCategory/UpdateActivityTypeCategoryTest.php
+++ b/tests/Unit/Services/Account/Activity/ActivityTypeCategory/UpdateActivityTypeCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity\ActivityTypeCategory;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\ActivityTypeCategory;
@@ -14,7 +15,7 @@ class UpdateActivityTypeCategoryTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_activity_type_category()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([]);
@@ -41,7 +42,7 @@ class UpdateActivityTypeCategoryTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $activityTypeCategory = factory(ActivityTypeCategory::class)->create([]);
@@ -54,7 +55,7 @@ class UpdateActivityTypeCategoryTest extends TestCase
         app(UpdateActivityTypeCategory::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_activity_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/AttachContactToActivityTest.php
+++ b/tests/Unit/Services/Account/Activity/AttachContactToActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class AttachContactToActivityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_attaches_contacts()
     {
         $activity = factory(Activity::class)->create([]);
@@ -61,7 +62,7 @@ class AttachContactToActivityTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $activity = factory(Activity::class)->create([]);
@@ -78,7 +79,7 @@ class AttachContactToActivityTest extends TestCase
         app(AttachContactToActivity::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $activity = factory(Activity::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/CreateActivityTest.php
+++ b/tests/Unit/Services/Account/Activity/CreateActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -17,7 +18,7 @@ class CreateActivityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_activity_and_creates_an_entry_in_the_journal()
     {
         $account = factory(Account::class)->create();
@@ -69,7 +70,7 @@ class CreateActivityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_emotions()
     {
         $account = factory(Account::class)->create();
@@ -112,7 +113,7 @@ class CreateActivityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);
@@ -125,7 +126,7 @@ class CreateActivityTest extends TestCase
         app(CreateActivity::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_activity_type_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/DestroyActivityTest.php
+++ b/tests/Unit/Services/Account/Activity/DestroyActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class DestroyActivityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_activity()
     {
         $activity = factory(Activity::class)->create([]);
@@ -36,7 +37,7 @@ class DestroyActivityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_the_journal_entry_when_destroying_the_activity()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Activity/UpdateActivityTest.php
+++ b/tests/Unit/Services/Account/Activity/UpdateActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Activity;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class UpdateActivityTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_activity()
     {
         $activity = factory(Activity::class)->create([]);
@@ -48,7 +49,7 @@ class UpdateActivityTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_old_associated_contacts()
     {
         $activity = factory(Activity::class)->create();
@@ -99,7 +100,7 @@ class UpdateActivityTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_old_associated_contacts_and_keep_previous_one()
     {
         $activity = factory(Activity::class)->create();
@@ -149,7 +150,7 @@ class UpdateActivityTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $activity = factory(Activity::class)->create([]);
@@ -166,7 +167,7 @@ class UpdateActivityTest extends TestCase
         app(UpdateActivity::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $activity = factory(Activity::class)->create([]);

--- a/tests/Unit/Services/Account/Company/CreateCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/CreateCompanyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Company;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use function Safe\json_encode;
@@ -17,7 +18,7 @@ class CreateCompanyTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_company()
     {
         Queue::fake();
@@ -61,7 +62,7 @@ class CreateCompanyTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Company/DestroyCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/DestroyCompanyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Company;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -14,7 +15,7 @@ class DestroyCompanyTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_company()
     {
         $company = factory(Company::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyCompanyTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_company()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyCompanyTest extends TestCase
         app(DestroyCompany::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/Company/UpdateCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/UpdateCompanyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Company;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -14,7 +15,7 @@ class UpdateCompanyTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_company()
     {
         $company = factory(Company::class)->create([]);
@@ -43,7 +44,7 @@ class UpdateCompanyTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $company = factory(Company::class)->create([]);
@@ -56,7 +57,7 @@ class UpdateCompanyTest extends TestCase
         app(UpdateCompany::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_place_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Gender/CreateGenderTest.php
+++ b/tests/Unit/Services/Account/Gender/CreateGenderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Gender;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
@@ -13,7 +14,7 @@ class CreateGenderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_gender()
     {
         $account = factory(Account::class)->create([]);
@@ -39,7 +40,7 @@ class CreateGenderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Gender/DestroyGenderTest.php
+++ b/tests/Unit/Services/Account/Gender/DestroyGenderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Gender;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class DestroyGenderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_gender()
     {
         $gender = factory(Gender::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyGenderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_gender()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyGenderTest extends TestCase
         app(DestroyGender::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/Gender/UpdateGenderTest.php
+++ b/tests/Unit/Services/Account/Gender/UpdateGenderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Gender;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class UpdateGenderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_gender()
     {
         $gender = factory(Gender::class)->create([]);
@@ -41,7 +42,7 @@ class UpdateGenderTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $gender = factory(Gender::class)->create([]);
@@ -55,7 +56,7 @@ class UpdateGenderTest extends TestCase
         app(UpdateGender::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_place_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/LifeEvent/LifeEventType/CreateLifeEventTypeTest.php
+++ b/tests/Unit/Services/Account/LifeEvent/LifeEventType/CreateLifeEventTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\LifeEvent\LifeEventType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\LifeEventType;
@@ -15,7 +16,7 @@ class CreateLifeEventTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_life_event_type()
     {
         $account = factory(Account::class)->create([]);
@@ -44,7 +45,7 @@ class CreateLifeEventTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -55,7 +56,7 @@ class CreateLifeEventTypeTest extends TestCase
         app(CreateLifeEventType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_life_event_category_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/LifeEvent/LifeEventType/DestroyLifeEventTypeTest.php
+++ b/tests/Unit/Services/Account/LifeEvent/LifeEventType/DestroyLifeEventTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\LifeEvent\LifeEventType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\LifeEventType;
@@ -14,7 +15,7 @@ class DestroyLifeEventTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_life_event_type()
     {
         $lifeEventType = factory(LifeEventType::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyLifeEventTypeTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_life_event_type()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyLifeEventTypeTest extends TestCase
         app(DestroyLifeEventType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/LifeEvent/LifeEventType/UpdateLifeEventTypeTest.php
+++ b/tests/Unit/Services/Account/LifeEvent/LifeEventType/UpdateLifeEventTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\LifeEvent\LifeEventType;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\LifeEventType;
@@ -15,7 +16,7 @@ class UpdateLifeEventTypeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_life_event_type()
     {
         $lifeEventType = factory(LifeEventType::class)->create([]);
@@ -45,7 +46,7 @@ class UpdateLifeEventTypeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $lifeEventType = factory(LifeEventType::class)->create([]);
@@ -63,7 +64,7 @@ class UpdateLifeEventTypeTest extends TestCase
         app(UpdateLifeEventType::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_life_event_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Photo/DestroyPhotoTest.php
+++ b/tests/Unit/Services/Account/Photo/DestroyPhotoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Photo;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Photo;
 use App\Models\Account\Account;
@@ -18,7 +19,7 @@ class DestroyPhotoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_photo()
     {
         $contact = factory(Contact::class)->create([]);
@@ -42,7 +43,7 @@ class DestroyPhotoTest extends TestCase
         Storage::disk('photos')->assertMissing('photo.png');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -54,7 +55,7 @@ class DestroyPhotoTest extends TestCase
         app(DestroyPhoto::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_a_photo_doesnt_exist()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Photo/UploadPhotoTest.php
+++ b/tests/Unit/Services/Account/Photo/UploadPhotoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Photo;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Photo;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class UploadPhotoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uploads_a_photo()
     {
         Storage::fake('photos');
@@ -44,7 +45,7 @@ class UploadPhotoTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -56,7 +57,7 @@ class UploadPhotoTest extends TestCase
         app(UploadPhoto::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_does_not_exist()
     {
         Storage::fake('photos');

--- a/tests/Unit/Services/Account/Place/CreatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/CreatePlaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Place;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class CreatePlaceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_place_without_fetching_geolocation_information()
     {
         $account = factory(Account::class)->create([]);
@@ -45,7 +46,7 @@ class CreatePlaceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_place_and_fetch_geolocation_information()
     {
         config(['monica.enable_geolocation' => true]);
@@ -80,7 +81,7 @@ class CreatePlaceTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Place/DestroyPlaceTest.php
+++ b/tests/Unit/Services/Account/Place/DestroyPlaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Place;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class DestroyPlaceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_place()
     {
         $place = factory(Place::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyPlaceTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_places()
     {
         $account = factory(Account::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyPlaceTest extends TestCase
         app(DestroyPlace::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [

--- a/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Place;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class UpdatePlaceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_place_without_fetching_geolocation_information()
     {
         $place = factory(Place::class)->create([]);
@@ -47,7 +48,7 @@ class UpdatePlaceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_place_and_fetch_geolocation_information()
     {
         config(['monica.enable_geolocation' => true]);
@@ -83,7 +84,7 @@ class UpdatePlaceTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $place = factory(Place::class)->create([]);
@@ -96,7 +97,7 @@ class UpdatePlaceTest extends TestCase
         app(UpdatePlace::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_place_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Settings/ArchiveAllContactsTest.php
+++ b/tests/Unit/Services/Account/Settings/ArchiveAllContactsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class ArchiveAllContactsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_archives_all_the_contacts_in_an_account()
     {
         $user = factory(User::class)->create([]);
@@ -35,7 +36,7 @@ class ArchiveAllContactsTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];

--- a/tests/Unit/Services/Account/Settings/DestroyAccountTest.php
+++ b/tests/Unit/Services/Account/Settings/DestroyAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class DestroyAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_an_account()
     {
         $user = factory(User::class)->create([]);
@@ -36,7 +37,7 @@ class DestroyAccountTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];

--- a/tests/Unit/Services/Account/Settings/DestroyAllDocumentsTest.php
+++ b/tests/Unit/Services/Account/Settings/DestroyAllDocumentsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Http\UploadedFile;
@@ -15,7 +16,7 @@ class DestroyAllDocumentsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_all_documents()
     {
         Storage::fake();
@@ -42,7 +43,7 @@ class DestroyAllDocumentsTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [

--- a/tests/Unit/Services/Account/Settings/DestroyAllPhotosTest.php
+++ b/tests/Unit/Services/Account/Settings/DestroyAllPhotosTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Http\UploadedFile;
@@ -15,7 +16,7 @@ class DestroyAllPhotosTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_all_photos()
     {
         Storage::fake();
@@ -42,7 +43,7 @@ class DestroyAllPhotosTest extends TestCase
         }
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];

--- a/tests/Unit/Services/Account/Settings/ExportAccountTest.php
+++ b/tests/Unit/Services/Account/Settings/ExportAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Jobs\ExportAccount;
@@ -19,7 +20,7 @@ class ExportAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_account_json()
     {
         Notification::fake();
@@ -50,7 +51,7 @@ class ExportAccountTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_account_sql()
     {
         Notification::fake();
@@ -83,7 +84,7 @@ class ExportAccountTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_account_file()
     {
         Storage::fake();
@@ -99,7 +100,7 @@ class ExportAccountTest extends TestCase
         Storage::disk('public')->assertExists($job->filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_account_file_sql()
     {
         Storage::fake();
@@ -117,7 +118,7 @@ class ExportAccountTest extends TestCase
         Storage::disk('public')->assertExists($job->filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_json_file()
     {
         Storage::fake();
@@ -237,7 +238,7 @@ class ExportAccountTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_json_file_contacts()
     {
         Storage::fake();

--- a/tests/Unit/Services/Account/Settings/ResetAccountTest.php
+++ b/tests/Unit/Services/Account/Settings/ResetAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class ResetAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_resets_an_account()
     {
         // populate the account with fake contacts and activities
@@ -56,7 +57,7 @@ class ResetAccountTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];

--- a/tests/Unit/Services/Account/Settings/SqlExportAccountTest.php
+++ b/tests/Unit/Services/Account/Settings/SqlExportAccountTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Account\Settings;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Illuminate\Support\Facades\Storage;
@@ -13,7 +14,7 @@ class SqlExportAccountTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_exports_account_information()
     {
         Storage::fake('local');
@@ -32,7 +33,7 @@ class SqlExportAccountTest extends TestCase
         Storage::disk('local')->assertExists($filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];

--- a/tests/Unit/Services/Auth/PopulateContactFieldTypesTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateContactFieldTypesTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Auth;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class PopulateContactFieldTypesTableTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -32,7 +33,7 @@ class PopulateContactFieldTypesTableTest extends TestCase
         app(PopulateContactFieldTypesTable::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populate_contact_field_types_tables()
     {
         $account = factory(Account::class)->create([]);
@@ -61,7 +62,7 @@ class PopulateContactFieldTypesTableTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_only_populates_partially()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Auth/PopulateLifeEventsTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateLifeEventsTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Auth;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class PopulateLifeEventsTableTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -34,7 +35,7 @@ class PopulateLifeEventsTableTest extends TestCase
         app(PopulateLifeEventsTable::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populate_life_event_tables()
     {
         $account = factory(Account::class)->create([]);
@@ -73,7 +74,7 @@ class PopulateLifeEventsTableTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_refuses_to_populate_table_if_account_doesnt_have_locale()
     {
         $account = factory(Account::class)->create([]);
@@ -86,7 +87,7 @@ class PopulateLifeEventsTableTest extends TestCase
         $this->assertFalse(app(PopulateLifeEventsTable::class)->execute($request));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_only_populates_life_event_tables_partially()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Auth/PopulateModulesTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateModulesTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Auth;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class PopulateModulesTableTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -35,7 +36,7 @@ class PopulateModulesTableTest extends TestCase
         app(PopulateModulesTable::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_populate_modules_tables()
     {
         $account = factory(Account::class)->create([]);
@@ -67,7 +68,7 @@ class PopulateModulesTableTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_only_populates_module_tables_partially()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/BaseServiceTest.php
+++ b/tests/Unit/Services/BaseServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Services\BaseService;
@@ -11,7 +12,7 @@ class BaseServiceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_empty_rule_array(): void
     {
         $stub = new class extends BaseService {};
@@ -21,7 +22,7 @@ class BaseServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_rules(): void
     {
         $rules = [
@@ -38,7 +39,7 @@ class BaseServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_or_the_actual_value(): void
     {
         $stub = new class extends BaseService {};
@@ -66,7 +67,7 @@ class BaseServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_or_the_actual_date(): void
     {
         $stub = new class extends BaseService {};
@@ -94,7 +95,7 @@ class BaseServiceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_the_default_value_or_the_given_value(): void
     {
         $stub = new class extends BaseService {};

--- a/tests/Unit/Services/Contact/Address/CreateAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/CreateAddressTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Address;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
@@ -15,7 +16,7 @@ class CreateAddressTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_address()
     {
         $contact = factory(Contact::class)->create([]);
@@ -52,7 +53,7 @@ class CreateAddressTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);
@@ -65,7 +66,7 @@ class CreateAddressTest extends TestCase
         app(CreateAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create();
@@ -87,7 +88,7 @@ class CreateAddressTest extends TestCase
         app(CreateAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Address/DestroyAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/DestroyAddressTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Address;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class DestroyAddressTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_an_address()
     {
         $address = factory(Address::class)->create([]);
@@ -31,7 +32,7 @@ class DestroyAddressTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_is_not_linked_to_address()
     {
         $contact = factory(Contact::class)->create([]);
@@ -46,7 +47,7 @@ class DestroyAddressTest extends TestCase
         app(DestroyAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_do_not_exist()
     {
         $request = [
@@ -58,7 +59,7 @@ class DestroyAddressTest extends TestCase
         app(DestroyAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create();

--- a/tests/Unit/Services/Contact/Address/UpdateAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/UpdateAddressTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Address;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
@@ -15,7 +16,7 @@ class UpdateAddressTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_address()
     {
         $address = factory(Address::class)->create([]);
@@ -53,7 +54,7 @@ class UpdateAddressTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $address = factory(Address::class)->create([]);
@@ -66,7 +67,7 @@ class UpdateAddressTest extends TestCase
         app(UpdateAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create();
@@ -93,7 +94,7 @@ class UpdateAddressTest extends TestCase
         app(UpdateAddress::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_address_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/Avatar/GenerateDefaultAvatarTest.php
+++ b/tests/Unit/Services/Contact/Avatar/GenerateDefaultAvatarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Avatar;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Http\UploadedFile;
@@ -13,7 +14,7 @@ class GenerateDefaultAvatarTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_generates_a_default_avatar()
     {
         $contact = factory(Contact::class)->create([
@@ -32,7 +33,7 @@ class GenerateDefaultAvatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [];
@@ -41,7 +42,7 @@ class GenerateDefaultAvatarTest extends TestCase
         app(GenerateDefaultAvatar::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_replaces_existing_default_avatar()
     {
         $file = UploadedFile::fake()->image('image.png');

--- a/tests/Unit/Services/Contact/Avatar/GetAvatarsFromInternetTest.php
+++ b/tests/Unit/Services/Contact/Avatar/GetAvatarsFromInternetTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Avatar;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\ContactField;
@@ -14,7 +15,7 @@ class GetAvatarsFromInternetTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_contact_object_with_avatars()
     {
         $contact = factory(Contact::class)->create([]);
@@ -44,7 +45,7 @@ class GetAvatarsFromInternetTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function gravatar_is_null_if_contact_doesnt_have_an_email()
     {
         $contact = factory(Contact::class)->create([]);
@@ -60,7 +61,7 @@ class GetAvatarsFromInternetTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function avatar_source_falls_back_to_default_if_gravatar_doesnt_exist_anymore()
     {
         $contact = factory(Contact::class)->create([
@@ -96,7 +97,7 @@ class GetAvatarsFromInternetTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [

--- a/tests/Unit/Services/Contact/Avatar/GetGravatarTest.php
+++ b/tests/Unit/Services/Contact/Avatar/GetGravatarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Avatar;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\ContactField;
@@ -15,7 +16,7 @@ class GetGravatarTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_gravatar_url()
     {
         $contact = factory(Contact::class)->create();
@@ -40,7 +41,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_gravatar_of_real_email()
     {
         $contact = factory(Contact::class)->create();
@@ -71,7 +72,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_url()
     {
         $request = [
@@ -87,7 +88,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_url_with_a_small_avatar_size()
     {
         $request = [
@@ -103,7 +104,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_url_with_a_default_avatar_size()
     {
         $request = [
@@ -119,7 +120,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_if_no_avatar_is_found()
     {
         $request = [
@@ -132,7 +133,7 @@ class GetGravatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [

--- a/tests/Unit/Services/Contact/Avatar/UpdateAvatarTest.php
+++ b/tests/Unit/Services/Contact/Avatar/UpdateAvatarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Avatar;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Photo;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class UpdateAvatarTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_avatar_with_gravatar()
     {
         $contact = factory(Contact::class)->create([]);
@@ -39,7 +40,7 @@ class UpdateAvatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_avatar_with_default_avatar()
     {
         $contact = factory(Contact::class)->create([]);
@@ -63,7 +64,7 @@ class UpdateAvatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_avatar_with_existing_photo()
     {
         $contact = factory(Contact::class)->create([]);
@@ -92,7 +93,7 @@ class UpdateAvatarTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -106,7 +107,7 @@ class UpdateAvatarTest extends TestCase
         app(UpdateAvatar::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);
@@ -121,7 +122,7 @@ class UpdateAvatarTest extends TestCase
         app(UpdateAvatar::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);
@@ -137,7 +138,7 @@ class UpdateAvatarTest extends TestCase
         app(UpdateAvatar::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_photo_not_linked_to_account()
     {
         // Case: photo doesn't exist

--- a/tests/Unit/Services/Contact/Call/CreateCallTest.php
+++ b/tests/Unit/Services/Contact/Call/CreateCallTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Call;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Call;
 use App\Models\Account\Account;
@@ -16,7 +17,7 @@ class CreateCallTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_call()
     {
         $contact = factory(Contact::class)->create([]);
@@ -44,7 +45,7 @@ class CreateCallTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_call_and_who_called_information()
     {
         $contact = factory(Contact::class)->create([]);
@@ -68,7 +69,7 @@ class CreateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_emotions()
     {
         $contact = factory(Contact::class)->create([]);
@@ -113,7 +114,7 @@ class CreateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_adding_emotions_when_emotion_is_unknown()
     {
         $contact = factory(Contact::class)->create([]);
@@ -134,7 +135,7 @@ class CreateCallTest extends TestCase
         app(CreateCall::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_call_without_the_content()
     {
         $contact = factory(Contact::class)->create([]);
@@ -155,7 +156,7 @@ class CreateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_last_call_info()
     {
         $contact = factory(Contact::class)->create([
@@ -178,7 +179,7 @@ class CreateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_update_the_last_call_info()
     {
         $contact = factory(Contact::class)->create([
@@ -201,7 +202,7 @@ class CreateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -215,7 +216,7 @@ class CreateCallTest extends TestCase
         app(CreateCall::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);
@@ -231,7 +232,7 @@ class CreateCallTest extends TestCase
         app(CreateCall::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Call/DestroyCallTest.php
+++ b/tests/Unit/Services/Contact/Call/DestroyCallTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Call;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Call;
 use App\Models\Contact\Contact;
@@ -15,7 +16,7 @@ class DestroyCallTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_call()
     {
         $contact = factory(Contact::class)->create([]);
@@ -40,7 +41,7 @@ class DestroyCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_emotions()
     {
         $contact = factory(Contact::class)->create([]);
@@ -72,7 +73,7 @@ class DestroyCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_last_talked_to_information()
     {
         $contact = factory(Contact::class)->create([
@@ -104,7 +105,7 @@ class DestroyCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_update_the_last_talked_to_information()
     {
         $contact = factory(Contact::class)->create([
@@ -128,7 +129,7 @@ class DestroyCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);

--- a/tests/Unit/Services/Contact/Call/UpdateCallTest.php
+++ b/tests/Unit/Services/Contact/Call/UpdateCallTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Call;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Call;
 use App\Models\Account\Account;
@@ -17,7 +18,7 @@ class UpdateCallTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_call()
     {
         $contact = factory(Contact::class)->create([]);
@@ -48,7 +49,7 @@ class UpdateCallTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_call_and_who_called_info()
     {
         $contact = factory(Contact::class)->create([]);
@@ -77,7 +78,7 @@ class UpdateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_call_without_the_content()
     {
         $contact = factory(Contact::class)->create([]);
@@ -105,7 +106,7 @@ class UpdateCallTest extends TestCase
     /**
      * Checks that it adds new emotions.
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_emotions()
     {
         $contact = factory(Contact::class)->create([]);
@@ -155,7 +156,7 @@ class UpdateCallTest extends TestCase
     /**
      * Checks that it removes old emotion and add new emotions.
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_and_updates_emotions()
     {
         $contact = factory(Contact::class)->create([]);
@@ -225,7 +226,7 @@ class UpdateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_last_call_info()
     {
         $contact = factory(Contact::class)->create([
@@ -252,7 +253,7 @@ class UpdateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_doesnt_update_the_last_call_info()
     {
         $contact = factory(Contact::class)->create([
@@ -279,7 +280,7 @@ class UpdateCallTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -293,7 +294,7 @@ class UpdateCallTest extends TestCase
         app(UpdateCall::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_call_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -309,7 +310,7 @@ class UpdateCallTest extends TestCase
         app(UpdateCall::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);

--- a/tests/Unit/Services/Contact/Contact/CreateContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/CreateContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Gender;
@@ -19,7 +20,7 @@ class CreateContactTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -63,7 +64,7 @@ class CreateContactTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_contact_with_email()
     {
         $account = factory(Account::class)->create([]);
@@ -103,7 +104,7 @@ class CreateContactTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_contact_and_triggers_an_audit_log()
     {
         Queue::fake();
@@ -144,7 +145,7 @@ class CreateContactTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_contact_without_gender()
     {
         $account = factory(Account::class)->create([]);
@@ -183,7 +184,7 @@ class CreateContactTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);
@@ -207,7 +208,7 @@ class CreateContactTest extends TestCase
         app(CreateContact::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $gender = factory(Gender::class)->create([]);

--- a/tests/Unit/Services/Contact/Contact/DeleteMeContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/DeleteMeContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class DeleteMeContactTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_set_me_as_a_a_contact()
     {
         $user = factory(User::class)->create();
@@ -39,7 +40,7 @@ class DeleteMeContactTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create();
@@ -53,7 +54,7 @@ class DeleteMeContactTest extends TestCase
         app(DeleteMeContact::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_not_found()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Contact/DestroyContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/DestroyContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class DestroyContactTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -32,7 +33,7 @@ class DestroyContactTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);
@@ -46,7 +47,7 @@ class DestroyContactTest extends TestCase
         app(DestroyContact::class)->handle($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -59,7 +60,7 @@ class DestroyContactTest extends TestCase
         app(DestroyContact::class)->handle($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_doesnt_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Contact/SetMeContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/SetMeContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class SetMeContactTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_set_me_as_a_a_contact()
     {
         $user = factory(User::class)->create();
@@ -37,7 +38,7 @@ class SetMeContactTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $user = factory(User::class)->create();
@@ -55,7 +56,7 @@ class SetMeContactTest extends TestCase
         app(SetMeContact::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_not_found()
     {
         $user = factory(User::class)->create();

--- a/tests/Unit/Services/Contact/Contact/UpdateBirthdayInformationTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateBirthdayInformationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Instance\SpecialDate;
@@ -13,7 +14,7 @@ class UpdateBirthdayInformationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_all_birthday_information()
     {
         // to delete birthday information, we need first to update the contact
@@ -66,7 +67,7 @@ class UpdateBirthdayInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_date_if_age_is_provided()
     {
         $contact = factory(Contact::class)->create([]);
@@ -96,7 +97,7 @@ class UpdateBirthdayInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_complete_date()
     {
         $contact = factory(Contact::class)->create([]);
@@ -130,7 +131,7 @@ class UpdateBirthdayInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_complete_date_and_sets_a_reminder()
     {
         $contact = factory(Contact::class)->create([]);
@@ -154,7 +155,7 @@ class UpdateBirthdayInformationTest extends TestCase
         $this->assertNotNull($contact->birthday_reminder_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -174,7 +175,7 @@ class UpdateBirthdayInformationTest extends TestCase
         app(UpdateBirthdayInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_and_account_are_not_linked()
     {
         $contact = factory(Contact::class)->create([]);

--- a/tests/Unit/Services/Contact/Contact/UpdateContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Contact\Contact;
@@ -13,7 +14,7 @@ class UpdateContactTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_contact()
     {
         $contact = factory(Contact::class)->create([]);
@@ -58,7 +59,7 @@ class UpdateContactTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_archived()
     {
         $contact = factory(Contact::class)->state('archived')->create([]);
@@ -93,7 +94,7 @@ class UpdateContactTest extends TestCase
         app(UpdateContact::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -125,7 +126,7 @@ class UpdateContactTest extends TestCase
         app(UpdateContact::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $contact = factory(Contact::class)->create([]);

--- a/tests/Unit/Services/Contact/Contact/UpdateDeceasedInformationTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateDeceasedInformationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;
@@ -14,7 +15,7 @@ class UpdateDeceasedInformationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_contact_as_not_deceased()
     {
         // first we are going to update a contact and set it as deceased,
@@ -57,7 +58,7 @@ class UpdateDeceasedInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_complete_date()
     {
         $contact = factory(Contact::class)->create([]);
@@ -91,7 +92,7 @@ class UpdateDeceasedInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_complete_date_with_unknown_year()
     {
         $contact = factory(Contact::class)->create([]);
@@ -125,7 +126,7 @@ class UpdateDeceasedInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_complete_date_and_sets_a_reminder()
     {
         $contact = factory(Contact::class)->create([]);
@@ -154,7 +155,7 @@ class UpdateDeceasedInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -173,7 +174,7 @@ class UpdateDeceasedInformationTest extends TestCase
         app(UpdateDeceasedInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_and_account_are_not_linked()
     {
         $contact = factory(Contact::class)->create([]);
@@ -193,7 +194,7 @@ class UpdateDeceasedInformationTest extends TestCase
         app(UpdateDeceasedInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_deceased_reminder()
     {
         $reminder = factory(Reminder::class)->create([]);
@@ -220,7 +221,7 @@ class UpdateDeceasedInformationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_deceased_special_date()
     {
         $special_date = factory(SpecialDate::class)->create();

--- a/tests/Unit/Services/Contact/Contact/UpdateWorkInformationTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateWorkInformationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Contact;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use function Safe\json_encode;
@@ -17,7 +18,7 @@ class UpdateWorkInformationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_work_information()
     {
         Queue::fake();
@@ -80,7 +81,7 @@ class UpdateWorkInformationTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $user = factory(User::class)->create([]);
@@ -93,7 +94,7 @@ class UpdateWorkInformationTest extends TestCase
         app(UpdateWorkInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Services/Contact/ContactField/CreateContactFieldTest.php
+++ b/tests/Unit/Services/Contact/ContactField/CreateContactFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\ContactField;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class CreateContactFieldTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_contact_field()
     {
         $account = factory(Account::class)->create();
@@ -39,7 +40,7 @@ class CreateContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create();
@@ -59,7 +60,7 @@ class CreateContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $account = factory(Account::class)->create();
@@ -79,7 +80,7 @@ class CreateContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_use_wrong_account()
     {
         $account = factory(Account::class)->create();
@@ -97,7 +98,7 @@ class CreateContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_use_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/ContactField/DestroyContactFieldTest.php
+++ b/tests/Unit/Services/Contact/ContactField/DestroyContactFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\ContactField;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\ContactField;
@@ -14,7 +15,7 @@ class DestroyContactFieldTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_contact_field()
     {
         $contactField = factory(ContactField::class)->create();
@@ -31,7 +32,7 @@ class DestroyContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create();
@@ -45,7 +46,7 @@ class DestroyContactFieldTest extends TestCase
         app(DestroyContactField::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_doesnt_exist()
     {
         $account = factory(Account::class)->create();
@@ -59,7 +60,7 @@ class DestroyContactFieldTest extends TestCase
         app(DestroyContactField::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_use_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/ContactField/UpdateContactFieldTest.php
+++ b/tests/Unit/Services/Contact/ContactField/UpdateContactFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\ContactField;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\ContactField;
@@ -14,7 +15,7 @@ class UpdateContactFieldTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_contact_field()
     {
         $contactField = factory(ContactField::class)->create();
@@ -36,7 +37,7 @@ class UpdateContactFieldTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contactField = factory(ContactField::class)->create();
@@ -53,7 +54,7 @@ class UpdateContactFieldTest extends TestCase
         app(UpdateContactField::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $contactField = factory(ContactField::class)->create([]);
@@ -70,7 +71,7 @@ class UpdateContactFieldTest extends TestCase
         app(UpdateContactField::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_doesnt_exist()
     {
         $contactField = factory(ContactField::class)->create();
@@ -87,7 +88,7 @@ class UpdateContactFieldTest extends TestCase
         app(UpdateContactField::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_type_is_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class AddMessageToConversationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -29,7 +30,7 @@ class AddMessageToConversationTest extends TestCase
         app(AddMessageToConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_message()
     {
         $conversation = factory(Conversation::class)->create([]);
@@ -60,7 +61,7 @@ class AddMessageToConversationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_found()
     {
         $account = factory(Account::class)->create();
@@ -84,7 +85,7 @@ class AddMessageToConversationTest extends TestCase
         app(AddMessageToConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_conversation_is_not_found2()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class CreateConversationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_conversation()
     {
         $contact = factory(Contact::class)->create([]);
@@ -46,7 +47,7 @@ class CreateConversationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -61,7 +62,7 @@ class CreateConversationTest extends TestCase
         app(CreateConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -82,7 +83,7 @@ class CreateConversationTest extends TestCase
         app(CreateConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contactfieldtype_is_not_linked_to_account()
     {
         $contact = factory(Contact::class)->create([]);

--- a/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Message;
@@ -15,7 +16,7 @@ class DestroyConversationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_conversation()
     {
         $conversation = factory(Conversation::class)->create([
@@ -38,7 +39,7 @@ class DestroyConversationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function destroying_a_conversation_destroys_corresponding_messages()
     {
         $conversation = factory(Conversation::class)->create([
@@ -70,7 +71,7 @@ class DestroyConversationTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $conversation = factory(Conversation::class)->create([
@@ -86,7 +87,7 @@ class DestroyConversationTest extends TestCase
         app(DestroyConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_conversation_doesnt_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
@@ -14,7 +15,7 @@ class DestroyMessageTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_message()
     {
         $conversation = factory(Conversation::class)->create([]);
@@ -45,7 +46,7 @@ class DestroyMessageTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -58,7 +59,7 @@ class DestroyMessageTest extends TestCase
         app(DestroyMessage::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_message_doesnt_exist()
     {
         $conversation = factory(Conversation::class)->create([]);

--- a/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class UpdateConversationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_conversation()
     {
         $conversation = factory(Conversation::class)->create([
@@ -47,7 +48,7 @@ class UpdateConversationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -62,7 +63,7 @@ class UpdateConversationTest extends TestCase
         app(UpdateConversation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_conversation_doesnt_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Conversation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class UpdateMessageTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_conversation()
     {
         $conversation = factory(Conversation::class)->create([]);
@@ -57,7 +58,7 @@ class UpdateMessageTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -74,7 +75,7 @@ class UpdateMessageTest extends TestCase
         app(UpdateMessage::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_message_does_not_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Description;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use function Safe\json_encode;
@@ -16,7 +17,7 @@ class ClearPersonalDescriptionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_clears_a_personal_description(): void
     {
         Queue::fake();
@@ -58,7 +59,7 @@ class ClearPersonalDescriptionTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given(): void
     {
         $request = [

--- a/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Description;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use function Safe\json_encode;
@@ -16,7 +17,7 @@ class SetPersonalDescriptionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_personal_description(): void
     {
         Queue::fake();
@@ -59,7 +60,7 @@ class SetPersonalDescriptionTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given(): void
     {
         $request = [

--- a/tests/Unit/Services/Contact/Document/DestroyDocumentTest.php
+++ b/tests/Unit/Services/Contact/Document/DestroyDocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Document;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Document;
@@ -17,7 +18,7 @@ class DestroyDocumentTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_document()
     {
         Storage::fake();
@@ -43,7 +44,7 @@ class DestroyDocumentTest extends TestCase
         Storage::disk('public')->assertMissing($document->new_filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -55,7 +56,7 @@ class DestroyDocumentTest extends TestCase
         app(DestroyDocument::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_a_document_doesnt_exist()
     {
         $document = factory(Document::class)->create([]);

--- a/tests/Unit/Services/Contact/Document/UploadDocumentTest.php
+++ b/tests/Unit/Services/Contact/Document/UploadDocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Document;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -17,7 +18,7 @@ class UploadDocumentTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_uploads_a_document()
     {
         Storage::fake();
@@ -49,7 +50,7 @@ class UploadDocumentTest extends TestCase
         Storage::disk('public')->assertExists($document->new_filename);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -62,7 +63,7 @@ class UploadDocumentTest extends TestCase
         app(UploadDocument::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_does_not_exist()
     {
         Storage::fake();

--- a/tests/Unit/Services/Contact/Gift/AssociateGiftToPhotoTest.php
+++ b/tests/Unit/Services/Contact/Gift/AssociateGiftToPhotoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Gift;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gift;
 use App\Models\Account\Photo;
@@ -14,7 +15,7 @@ class AssociateGiftToPhotoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_associates_a_photo_to_a_gift()
     {
         $gift = factory(Gift::class)->create();
@@ -37,7 +38,7 @@ class AssociateGiftToPhotoTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $this->expectException(ValidationException::class);
@@ -49,7 +50,7 @@ class AssociateGiftToPhotoTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_photo_is_wrong_account()
     {
         $gift = factory(Gift::class)->create();

--- a/tests/Unit/Services/Contact/Gift/CreateGiftTest.php
+++ b/tests/Unit/Services/Contact/Gift/CreateGiftTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Gift;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gift;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class CreateGiftTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_gift()
     {
         $contact = factory(Contact::class)->create();
@@ -41,7 +42,7 @@ class CreateGiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $this->expectException(ValidationException::class);
@@ -54,7 +55,7 @@ class CreateGiftTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_contact_is_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Gift/DestroyGiftTest.php
+++ b/tests/Unit/Services/Contact/Gift/DestroyGiftTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Gift;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gift;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class DestroyGiftTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_gift()
     {
         $gift = factory(Gift::class)->create();
@@ -35,7 +36,7 @@ class DestroyGiftTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $this->expectException(ValidationException::class);
@@ -45,7 +46,7 @@ class DestroyGiftTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_gift_is_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Gift/UpdateGiftTest.php
+++ b/tests/Unit/Services/Contact/Gift/UpdateGiftTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Gift;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Gift;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class UpdateGiftTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_gift()
     {
         $gift = factory(Gift::class)->create();
@@ -39,7 +40,7 @@ class UpdateGiftTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $this->expectException(ValidationException::class);
@@ -50,7 +51,7 @@ class UpdateGiftTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_gift_wrong_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Label/UpdateAddessLabelTest.php
+++ b/tests/Unit/Services/Contact/Label/UpdateAddessLabelTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Label;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
@@ -15,7 +16,7 @@ class UpdateAddessLabelTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -45,7 +46,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_contact_field_multiple_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -101,7 +102,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -142,7 +143,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -183,7 +184,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $address = factory(Address::class)->create();
@@ -197,7 +198,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_doesnt_exist()
     {
         $account = factory(Account::class)->create([]);
@@ -211,7 +212,7 @@ class UpdateAddessLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_is_wrong_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/Label/UpdateContactFieldLabelTest.php
+++ b/tests/Unit/Services/Contact/Label/UpdateContactFieldLabelTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Label;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\ContactField;
@@ -15,7 +16,7 @@ class UpdateContactFieldLabelTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -45,7 +46,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_personal_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -75,7 +76,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_contact_field_multiple_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -131,7 +132,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_adds_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -172,7 +173,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_removes_contact_field_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -213,7 +214,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_account_doesnt_exist()
     {
         $contactField = factory(ContactField::class)->create();
@@ -227,7 +228,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_doesnt_exist()
     {
         $account = factory(Account::class)->create([]);
@@ -241,7 +242,7 @@ class UpdateContactFieldLabelTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_field_is_wrong_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/LifeEvent/CreateLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/CreateLifeEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\LifeEvent;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class CreateLifeEventTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_life_event()
     {
         $contact = factory(Contact::class)->create([]);
@@ -54,7 +55,7 @@ class CreateLifeEventTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_life_event_and_set_a_reminder()
     {
         $contact = factory(Contact::class)->create([]);
@@ -85,7 +86,7 @@ class CreateLifeEventTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -100,7 +101,7 @@ class CreateLifeEventTest extends TestCase
         app(CreateLifeEvent::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -123,7 +124,7 @@ class CreateLifeEventTest extends TestCase
         app(CreateLifeEvent::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_life_event_type_is_not_linked_to_account()
     {
         $contact = factory(Contact::class)->create([]);

--- a/tests/Unit/Services/Contact/LifeEvent/DestroyLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/DestroyLifeEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\LifeEvent;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Reminder;
@@ -15,7 +16,7 @@ class DestroyLifeEventTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_life_event()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -36,7 +37,7 @@ class DestroyLifeEventTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_life_event_and_associated_reminder()
     {
         $lifeEvent = factory(LifeEvent::class)->create([]);
@@ -58,7 +59,7 @@ class DestroyLifeEventTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -70,7 +71,7 @@ class DestroyLifeEventTest extends TestCase
         app(DestroyLifeEvent::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_life_event_doesnt_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/LifeEvent/UpdateLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/UpdateLifeEventTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\LifeEvent;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class UpdateLifeEventTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_life_event()
     {
         $lifeEvent = factory(LifeEvent::class)->create([
@@ -53,7 +54,7 @@ class UpdateLifeEventTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -68,7 +69,7 @@ class UpdateLifeEventTest extends TestCase
         app(UpdateLifeEvent::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_life_type_doesnt_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Occupation/CreateOccupationTest.php
+++ b/tests/Unit/Services/Contact/Occupation/CreateOccupationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Occupation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
@@ -15,7 +16,7 @@ class CreateOccupationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_an_occupation()
     {
         $account = factory(Account::class)->create([]);
@@ -48,7 +49,7 @@ class CreateOccupationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/Occupation/DestroyOccupationTest.php
+++ b/tests/Unit/Services/Contact/Occupation/DestroyOccupationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Occupation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Occupation;
 use App\Services\Contact\Occupation\DestroyOccupation;
@@ -11,7 +12,7 @@ class DestroyOccupationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_occupation()
     {
         $occupation = factory(Occupation::class)->create([]);

--- a/tests/Unit/Services/Contact/Occupation/UpdateOccupationTest.php
+++ b/tests/Unit/Services/Contact/Occupation/UpdateOccupationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Occupation;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Occupation;
@@ -14,7 +15,7 @@ class UpdateOccupationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_an_occupation()
     {
         $occupation = factory(Occupation::class)->create([]);
@@ -46,7 +47,7 @@ class UpdateOccupationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $occupation = factory(Occupation::class)->create([]);
@@ -59,7 +60,7 @@ class UpdateOccupationTest extends TestCase
         app(UpdateOccupation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_occupation_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/Relationship/CreateRelationshipTest.php
+++ b/tests/Unit/Services/Contact/Relationship/CreateRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Relationship;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -14,7 +15,7 @@ class CreateRelationshipTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_relationship()
     {
         $account = factory(Account::class)->create();
@@ -46,7 +47,7 @@ class CreateRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_adding_relationship_when_relationship_type_is_unknown()
     {
         $account = factory(Account::class)->create();
@@ -70,7 +71,7 @@ class CreateRelationshipTest extends TestCase
         app(CreateRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -93,7 +94,7 @@ class CreateRelationshipTest extends TestCase
         app(CreateRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_other_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -117,7 +118,7 @@ class CreateRelationshipTest extends TestCase
         app(CreateRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_relationship_and_reverse()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Relationship/DestroyRelationshipTest.php
+++ b/tests/Unit/Services/Contact/Relationship/DestroyRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Relationship;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class DestroyRelationshipTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_relationship()
     {
         $contactA = factory(Contact::class)->create([]);
@@ -42,7 +43,7 @@ class DestroyRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_relationship_and_reverse()
     {
         $contactA = factory(Contact::class)->create([]);
@@ -96,7 +97,7 @@ class DestroyRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_relationship_and_reverse_and_partial_contact()
     {
         $contactA = factory(Contact::class)->create([]);
@@ -155,7 +156,7 @@ class DestroyRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $account = factory(Account::class)->create([]);
@@ -169,7 +170,7 @@ class DestroyRelationshipTest extends TestCase
         app(DestroyRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_relationship_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -185,7 +186,7 @@ class DestroyRelationshipTest extends TestCase
         app(DestroyRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_relationship_between_two_contacts_and_deletes_the_contact()
     {
         $account = factory(Account::class)->create([]);
@@ -219,7 +220,7 @@ class DestroyRelationshipTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_deletes_relationship_between_two_contacts_and_doesnt_delete_the_contact()
     {
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Contact/Relationship/UpdateRelationshipTest.php
+++ b/tests/Unit/Services/Contact/Relationship/UpdateRelationshipTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Relationship;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -16,7 +17,7 @@ class UpdateRelationshipTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_relationship()
     {
         $account = factory(Account::class)->create();
@@ -73,7 +74,7 @@ class UpdateRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_partial_relationship()
     {
         $account = factory(Account::class)->create();
@@ -115,7 +116,7 @@ class UpdateRelationshipTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_relationship_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -135,7 +136,7 @@ class UpdateRelationshipTest extends TestCase
         app(UpdateRelationship::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_relationship_type_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Reminder/CreateReminderTest.php
+++ b/tests/Unit/Services/Contact/Reminder/CreateReminderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Reminder;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -17,7 +18,7 @@ class CreateReminderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_recurring_reminder()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -57,7 +58,7 @@ class CreateReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_one_time_reminder()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -97,7 +98,7 @@ class CreateReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_reminder_for_each_user_of_an_account()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -151,7 +152,7 @@ class CreateReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -166,7 +167,7 @@ class CreateReminderTest extends TestCase
         $reminderService = app(CreateReminder::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_ids_are_not_found()
     {
         $account = factory(Account::class)->create();
@@ -201,7 +202,7 @@ class CreateReminderTest extends TestCase
         $reminderService = app(CreateReminder::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_frequency_type_is_not_right()
     {
         $contact = factory(Contact::class)->create([]);

--- a/tests/Unit/Services/Contact/Reminder/DestroyReminderTest.php
+++ b/tests/Unit/Services/Contact/Reminder/DestroyReminderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Reminder;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -14,7 +15,7 @@ class DestroyReminderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_reminder()
     {
         $reminder = factory(Reminder::class)->create([
@@ -41,7 +42,7 @@ class DestroyReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_scheduled_reminders()
     {
         // prepare a reminder and schedule some notifications

--- a/tests/Unit/Services/Contact/Reminder/UpdateReminderTest.php
+++ b/tests/Unit/Services/Contact/Reminder/UpdateReminderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Reminder;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -15,7 +16,7 @@ class UpdateReminderTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_reminder()
     {
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
@@ -61,7 +62,7 @@ class UpdateReminderTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -76,7 +77,7 @@ class UpdateReminderTest extends TestCase
         app(UpdateReminder::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_frequency_type_is_not_right()
     {
         $reminder = factory(Reminder::class)->create([

--- a/tests/Unit/Services/Contact/Tag/AssociateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/AssociateTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Tag;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class AssociateTagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_non_english_tag_to_a_contact_when_tag_doesnt_exist_yet()
     {
         $contact = factory(Contact::class)->create([]);
@@ -46,7 +47,7 @@ class AssociateTagTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_tag_to_a_contact_when_tag_doesnt_exist_yet()
     {
         $contact = factory(Contact::class)->create([]);
@@ -77,7 +78,7 @@ class AssociateTagTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sets_a_tag_to_a_contact_when_tag_does_exist_yet()
     {
         $contact = factory(Contact::class)->create([]);
@@ -123,7 +124,7 @@ class AssociateTagTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -136,7 +137,7 @@ class AssociateTagTest extends TestCase
         app(AssociateTag::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_does_not_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Tag/CreateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/CreateTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Tag;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Services\Contact\Tag\CreateTag;
@@ -12,7 +13,7 @@ class CreateTagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_tag()
     {
         $tag = factory(Tag::class)->create([]);
@@ -36,7 +37,7 @@ class CreateTagTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [

--- a/tests/Unit/Services/Contact/Tag/DestroyTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/DestroyTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Tag;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class DestroyTagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_tag()
     {
         $contact = factory(Contact::class)->create([]);
@@ -55,7 +56,7 @@ class DestroyTagTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -67,7 +68,7 @@ class DestroyTagTest extends TestCase
         app(DestroyTag::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_tag_does_not_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Tag/DetachTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/DetachTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Tag;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class DetachTagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_detachs_a_tag()
     {
         $contact = factory(Contact::class)->create([]);
@@ -50,7 +51,7 @@ class DetachTagTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -62,7 +63,7 @@ class DetachTagTest extends TestCase
         app(DetachTag::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_does_not_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Contact/Tag/UpdateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/UpdateTagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Contact\Tag;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class UpdateTagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_tag()
     {
         $tag = factory(Tag::class)->create([]);
@@ -39,7 +40,7 @@ class UpdateTagTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -52,7 +53,7 @@ class UpdateTagTest extends TestCase
         app(UpdateTag::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_tag_does_not_exist()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/DavClient/AddAddressBookTest.php
+++ b/tests/Unit/Services/DavClient/AddAddressBookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use Mockery\MockInterface;
@@ -16,7 +17,7 @@ class AddAddressBookTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_an_addressbook()
     {
         $user = factory(User::class)->create([]);
@@ -65,7 +66,7 @@ class AddAddressBookTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_next_addressbook()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Services/DavClient/SynchronizeAddressBookTest.php
+++ b/tests/Unit/Services/DavClient/SynchronizeAddressBookTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Models\Account\AddressBookSubscription;
@@ -13,7 +14,7 @@ class SynchronizeAddressBookTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_runs_sync()
     {
         $this->mock(AddressBookSynchronizer::class, function (MockInterface $mock) {
@@ -36,7 +37,7 @@ class SynchronizeAddressBookTest extends TestCase
         (new SynchronizeAddressBook())->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_runs_sync_force()
     {
         $this->mock(AddressBookSynchronizer::class, function (MockInterface $mock) {

--- a/tests/Unit/Services/DavClient/UpdateSubscriptionLocalSyncTokenTest.php
+++ b/tests/Unit/Services/DavClient/UpdateSubscriptionLocalSyncTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Models\User\SyncToken;
@@ -14,7 +15,7 @@ class UpdateSubscriptionLocalSyncTokenTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_token()
     {
         $subscription = AddressBookSubscription::factory()->create([
@@ -48,7 +49,7 @@ class UpdateSubscriptionLocalSyncTokenTest extends TestCase
         $this->assertEquals($token->id, $subscription->localSyncToken);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_wont_update_null_token()
     {
         $subscription = AddressBookSubscription::factory()->create([

--- a/tests/Unit/Services/DavClient/Utils/AddressBookContactsPushMissedTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookContactsPushMissedTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Jobs\Dav\PushVCard;
@@ -22,7 +23,7 @@ class AddressBookContactsPushMissedTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_push_contacts_missed()
     {
         $subscription = AddressBookSubscription::factory()->create();

--- a/tests/Unit/Services/DavClient/Utils/AddressBookContactsPushTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookContactsPushTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use App\Jobs\Dav\PushVCard;
@@ -24,7 +25,7 @@ class AddressBookContactsPushTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_push_contacts_added()
     {
         $subscription = AddressBookSubscription::factory()->create();
@@ -86,7 +87,7 @@ class AddressBookContactsPushTest extends TestCase
         $this->assertEquals(ContactPushDto::MODE_MATCH_NONE, $dto->mode);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_push_contacts_modified()
     {
         $subscription = AddressBookSubscription::factory()->create();
@@ -150,7 +151,7 @@ class AddressBookContactsPushTest extends TestCase
         $this->assertEquals(1, $dto->mode);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_delete_contacts_removed()
     {
         $subscription = AddressBookSubscription::factory()->create();

--- a/tests/Unit/Services/DavClient/Utils/AddressBookContactsUpdaterMissedTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookContactsUpdaterMissedTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use Tests\Api\DAV\CardEtag;
@@ -21,7 +22,7 @@ class AddressBookContactsUpdaterMissedTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_missed()
     {
         $subscription = AddressBookSubscription::factory()->create();

--- a/tests/Unit/Services/DavClient/Utils/AddressBookContactsUpdaterTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookContactsUpdaterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Jobs\Dav\GetVCard;
 use Mockery\MockInterface;
@@ -25,7 +26,7 @@ class AddressBookContactsUpdaterTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_multiget()
     {
         $subscription = AddressBookSubscription::factory()->create();
@@ -71,7 +72,7 @@ class AddressBookContactsUpdaterTest extends TestCase
         $this->assertEquals(['https://test/dav/uuid2'], $hrefs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_deleted_multiget()
     {
         $subscription = AddressBookSubscription::factory()->create();
@@ -103,7 +104,7 @@ class AddressBookContactsUpdaterTest extends TestCase
         $this->assertEquals(['https://test/dav/uuid2'], $hrefs);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_simple()
     {
         $subscription = AddressBookSubscription::factory()->create([
@@ -169,7 +170,7 @@ class AddressBookContactsUpdaterTest extends TestCase
         $this->assertEquals('https://test/dav/uuid2', $dto->uri);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_deleted_simple()
     {
         $subscription = AddressBookSubscription::factory()->create([

--- a/tests/Unit/Services/DavClient/Utils/AddressBookGetterTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookGetterTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Helpers\DavTester;
 use App\Services\DavClient\Utils\AddressBookGetter;
@@ -13,7 +14,7 @@ class AddressBookGetterTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_address_book_data()
     {
         $tester = (new DavTester())
@@ -41,7 +42,7 @@ class AddressBookGetterTest extends TestCase
         ], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_on_server_not_compliant()
     {
         $tester = (new DavTester())
@@ -56,7 +57,7 @@ class AddressBookGetterTest extends TestCase
             ->execute($client);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_no_userprincipal()
     {
         $tester = (new DavTester())
@@ -72,7 +73,7 @@ class AddressBookGetterTest extends TestCase
             ->execute($client);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_no_addressbook()
     {
         $tester = (new DavTester())
@@ -89,7 +90,7 @@ class AddressBookGetterTest extends TestCase
             ->execute($client);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_no_addressbook_url()
     {
         $tester = (new DavTester())

--- a/tests/Unit/Services/DavClient/Utils/AddressBookSynchronizerTest.php
+++ b/tests/Unit/Services/DavClient/Utils/AddressBookSynchronizerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Mockery\MockInterface;
 use Tests\Api\DAV\CardEtag;
@@ -26,7 +27,7 @@ class AddressBookSynchronizerTest extends TestCase
     use DatabaseTransactions;
     use CardEtag;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_empty_changes()
     {
         Bus::fake();
@@ -50,7 +51,7 @@ class AddressBookSynchronizerTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_no_changes()
     {
         Bus::fake();
@@ -76,7 +77,7 @@ class AddressBookSynchronizerTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_added_local_contact()
     {
         Bus::fake();
@@ -116,7 +117,7 @@ class AddressBookSynchronizerTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_added_local_contact_batched()
     {
         Bus::fake();
@@ -153,7 +154,7 @@ class AddressBookSynchronizerTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_changes_deleted_contact_batched()
     {
         Bus::fake();
@@ -194,7 +195,7 @@ class AddressBookSynchronizerTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_forcesync_changes_added_local_contact()
     {
         Bus::fake();
@@ -255,7 +256,7 @@ class AddressBookSynchronizerTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_forcesync_changes_added_local_contact_batched()
     {
         Bus::fake();
@@ -307,7 +308,7 @@ class AddressBookSynchronizerTest extends TestCase
         });
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_forcesync_changes_deleted_contact_batched()
     {
         Bus::fake();

--- a/tests/Unit/Services/DavClient/Utils/Dav/DavClientTest.php
+++ b/tests/Unit/Services/DavClient/Utils/Dav/DavClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils\Dav;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Tests\Helpers\DavTester;
 use Illuminate\Support\Facades\Http;
@@ -13,7 +14,7 @@ class DavClientTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_options()
     {
         $tester = (new DavTester())
@@ -35,7 +36,7 @@ class DavClientTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_serviceurl()
     {
         $tester = (new DavTester())
@@ -49,7 +50,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('https://test/dav/', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_non_standard_serviceurl()
     {
         $tester = (new DavTester())
@@ -65,7 +66,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('https://test/dav/', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_non_standard_serviceurl2()
     {
         $tester = (new DavTester())
@@ -81,7 +82,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('https://test/dav/', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fail_non_standard()
     {
         $tester = (new DavTester())
@@ -93,7 +94,7 @@ class DavClientTest extends TestCase
         $client->getServiceUrl();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_base_uri()
     {
         $tester = (new DavTester())
@@ -109,7 +110,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('https://test/xxx', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_set_base_uri()
     {
         $tester = (new DavTester())
@@ -122,7 +123,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('https://new', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_call_propfind()
     {
         $tester = (new DavTester())
@@ -154,7 +155,7 @@ class DavClientTest extends TestCase
         ], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_property()
     {
         $tester = (new DavTester())
@@ -184,7 +185,7 @@ class DavClientTest extends TestCase
         $this->assertEquals('value', $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_supported_report()
     {
         $tester = (new DavTester('https://test/dav'))
@@ -221,7 +222,7 @@ class DavClientTest extends TestCase
         $this->assertEquals(['{DAV:}test1', '{DAV:}test2'], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_collection()
     {
         $tester = (new DavTester())
@@ -266,7 +267,7 @@ class DavClientTest extends TestCase
         ], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sync_collection_with_synctoken()
     {
         $tester = (new DavTester())
@@ -311,7 +312,7 @@ class DavClientTest extends TestCase
         ], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_addressbook_multiget_report()
     {
         $tester = (new DavTester())
@@ -354,7 +355,7 @@ class DavClientTest extends TestCase
         $tester->assert();
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_addressbook_query_report()
     {
         $tester = (new DavTester())
@@ -395,7 +396,7 @@ class DavClientTest extends TestCase
         ], $result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_proppatch()
     {
         $tester = (new DavTester())
@@ -427,7 +428,7 @@ class DavClientTest extends TestCase
         $this->assertTrue($result);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_run_proppatch_error()
     {
         $tester = (new DavTester())

--- a/tests/Unit/Services/DavClient/Utils/Model/ContactUpdateDtoTest.php
+++ b/tests/Unit/Services/DavClient/Utils/Model/ContactUpdateDtoTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\DavClient\Utils\Model;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\DavClient\Utils\Model\ContactUpdateDto;
@@ -10,7 +11,7 @@ class ContactUpdateDtoTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_dto_string()
     {
         $dto = new ContactUpdateDto('uri', 'etag', 'card');
@@ -19,7 +20,7 @@ class ContactUpdateDtoTest extends TestCase
         $this->assertEquals('card', $dto->card);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_create_dto_resource()
     {
         $resource = fopen(__DIR__.'/stub.vcf', 'r');

--- a/tests/Unit/Services/Instance/AuditLog/LogAccountActionTest.php
+++ b/tests/Unit/Services/Instance/AuditLog/LogAccountActionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Instance\AuditLog;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -15,7 +16,7 @@ class LogAccountActionTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_logs_an_action(): void
     {
         $michael = factory(User::class)->create([]);
@@ -51,7 +52,7 @@ class LogAccountActionTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_logs_an_action_about_a_contact(): void
     {
         $michael = factory(User::class)->create([]);
@@ -91,7 +92,7 @@ class LogAccountActionTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given(): void
     {
         $request = [

--- a/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
+++ b/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Instance\Geolocalization;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use Illuminate\Support\Facades\Http;
@@ -15,7 +16,7 @@ class GetGPSCoordinateTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_if_geolocation_is_disabled()
     {
         config(['monica.enable_geolocation' => false]);
@@ -31,7 +32,7 @@ class GetGPSCoordinateTest extends TestCase
         app(GetGPSCoordinate::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_gps_coordinates()
     {
         config(['monica.enable_geolocation' => true]);
@@ -61,7 +62,7 @@ class GetGPSCoordinateTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_null_if_address_is_garbage()
     {
         config(['monica.enable_geolocation' => true]);
@@ -89,7 +90,7 @@ class GetGPSCoordinateTest extends TestCase
         $this->assertNull($place);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         config(['monica.enable_geolocation' => true]);
@@ -104,7 +105,7 @@ class GetGPSCoordinateTest extends TestCase
         app(GetGPSCoordinate::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_release_the_job_if_rate_limited_second()
     {
         config(['monica.enable_geolocation' => true]);

--- a/tests/Unit/Services/Instance/TokenCleanTest.php
+++ b/tests/Unit/Services/Instance/TokenCleanTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Instance;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\User\SyncToken;
@@ -15,7 +16,7 @@ class TokenCleanTest extends TestCase
     use DatabaseTransactions,
         PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tokenclean_left_one_token()
     {
         $account = factory(Account::class)->create();
@@ -38,7 +39,7 @@ class TokenCleanTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function tokenclean_left_all_token()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
+++ b/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Instance\Weather;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Weather;
@@ -16,7 +17,7 @@ class GetWeatherInformationTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_gets_weather_information_normal()
     {
         $place = factory(Place::class)->create([
@@ -56,7 +57,7 @@ class GetWeatherInformationTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_weather_info_if_weather_not_enabled()
     {
         $place = factory(Place::class)->create([
@@ -74,7 +75,7 @@ class GetWeatherInformationTest extends TestCase
         app(GetWeatherInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_weather_info_if_weatherapi_key_not_provided()
     {
         $place = factory(Place::class)->create([
@@ -94,7 +95,7 @@ class GetWeatherInformationTest extends TestCase
         app(GetWeatherInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_cant_get_weather_info_if_latitude_longitude_are_null()
     {
         $place = factory(Place::class)->create([]);
@@ -112,7 +113,7 @@ class GetWeatherInformationTest extends TestCase
         app(GetWeatherInformation::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         config(['monica.enable_weather' => true]);

--- a/tests/Unit/Services/Task/CreateTaskTest.php
+++ b/tests/Unit/Services/Task/CreateTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Task;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class CreateTaskTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_task()
     {
         $contact = factory(Contact::class)->create([]);
@@ -42,7 +43,7 @@ class CreateTaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_task_without_contact_id()
     {
         $contact = factory(Contact::class)->create([]);
@@ -68,7 +69,7 @@ class CreateTaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_stores_a_task_without_description()
     {
         $contact = factory(Contact::class)->create([]);
@@ -94,7 +95,7 @@ class CreateTaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $contact = factory(Contact::class)->create([]);
@@ -109,7 +110,7 @@ class CreateTaskTest extends TestCase
         app(CreateTask::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/Task/DestroyTaskTest.php
+++ b/tests/Unit/Services/Task/DestroyTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Task;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class DestroyTaskTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_destroys_a_task()
     {
         $task = factory(Task::class)->create([]);
@@ -35,7 +36,7 @@ class DestroyTaskTest extends TestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $request = [
@@ -47,7 +48,7 @@ class DestroyTaskTest extends TestCase
         app(DestroyTask::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_a_task_doesnt_exist()
     {
         $task = factory(Task::class)->create([]);

--- a/tests/Unit/Services/Task/UpdateTaskTest.php
+++ b/tests/Unit/Services/Task/UpdateTaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Task;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
@@ -15,7 +16,7 @@ class UpdateTaskTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_task_associated_with_a_contact()
     {
         $task = factory(Task::class)->create([]);
@@ -45,7 +46,7 @@ class UpdateTaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_task_associated_without_a_contact()
     {
         $task = factory(Task::class)->create([
@@ -76,7 +77,7 @@ class UpdateTaskTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $task = factory(Task::class)->create([]);
@@ -93,7 +94,7 @@ class UpdateTaskTest extends TestCase
         app(UpdateTask::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_contact_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -114,7 +115,7 @@ class UpdateTaskTest extends TestCase
         app(UpdateTask::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_task_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/User/AcceptPolicyTest.php
+++ b/tests/Unit/Services/User/AcceptPolicyTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\User;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Settings\Term;
@@ -15,7 +16,7 @@ class AcceptPolicyTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_accepts_the_policy()
     {
         $user = factory(User::class)->create([]);
@@ -42,7 +43,7 @@ class AcceptPolicyTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $user = factory(User::class)->create([]);
@@ -55,7 +56,7 @@ class AcceptPolicyTest extends TestCase
         app(AcceptPolicy::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_user_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/User/EmailChangeTest.php
+++ b/tests/Unit/Services/User/EmailChangeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\User;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -16,7 +17,7 @@ class EmailChangeTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_user_email()
     {
         NotificationFacade::fake();
@@ -47,7 +48,7 @@ class EmailChangeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $user = factory(User::class)->create([]);
@@ -61,7 +62,7 @@ class EmailChangeTest extends TestCase
         app(EmailChange::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_user_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();
@@ -78,7 +79,7 @@ class EmailChangeTest extends TestCase
         app(EmailChange::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_user_email_and_send_confirmation()
     {
         NotificationFacade::fake();
@@ -111,7 +112,7 @@ class EmailChangeTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_sends_confirmation_email()
     {
         NotificationFacade::fake();

--- a/tests/Unit/Services/User/UpdateViewPreferenceTest.php
+++ b/tests/Unit/Services/User/UpdateViewPreferenceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\User;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
@@ -14,7 +15,7 @@ class UpdateViewPreferenceTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_the_contact_view_preferences()
     {
         $user = factory(User::class)->create([]);
@@ -39,7 +40,7 @@ class UpdateViewPreferenceTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_fails_if_wrong_parameters_are_given()
     {
         $user = factory(User::class)->create([]);
@@ -52,7 +53,7 @@ class UpdateViewPreferenceTest extends TestCase
         app(UpdateViewPreference::class)->execute($request);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_throws_an_exception_if_user_is_not_linked_to_account()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/VCard/ExportVCardTest.php
+++ b/tests/Unit/Services/VCard/ExportVCardTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Services\VCard;
 
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 use Tests\Api\DAV\CardEtag;
 use App\Models\Contact\Gender;
@@ -26,7 +28,7 @@ class ExportVCardTest extends TestCase
     /** @var int */
     const defaultPropsCount = 3;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_names()
     {
         $account = factory(Account::class)->create();
@@ -46,7 +48,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('N:Doe;John;;;', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_nickname()
     {
         $account = factory(Account::class)->create();
@@ -68,7 +70,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('NICKNAME:the nickname', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender()
     {
         $account = factory(Account::class)->create();
@@ -87,7 +89,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:M', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender_female()
     {
         $account = factory(Account::class)->create();
@@ -112,7 +114,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:F', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender_unknown()
     {
         $account = factory(Account::class)->create();
@@ -136,7 +138,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:U', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender_type_null()
     {
         $account = factory(Account::class)->create();
@@ -161,7 +163,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:O', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender_type_null_male()
     {
         $account = factory(Account::class)->create();
@@ -186,7 +188,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:O', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_gender_type_null_female()
     {
         $account = factory(Account::class)->create();
@@ -211,7 +213,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('GENDER:F', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_photo()
     {
         $account = factory(Account::class)->create();
@@ -231,7 +233,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('PHOTO;VALUE=URI:gravatar', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_work_org()
     {
         $account = factory(Account::class)->create();
@@ -251,7 +253,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('ORG:the company', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_work_title()
     {
         $account = factory(Account::class)->create();
@@ -271,7 +273,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('TITLE:job position', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_work_information()
     {
         $account = factory(Account::class)->create();
@@ -293,7 +295,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('TITLE:job position', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_birthday()
     {
         $account = factory(Account::class)->create();
@@ -311,7 +313,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('BDAY:20001005', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_birthday_with_unknown_year()
     {
         $account = factory(Account::class)->create();
@@ -329,7 +331,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('BDAY:--1005', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_contact_fields_empty()
     {
         $account = factory(Account::class)->create();
@@ -345,7 +347,7 @@ class ExportVCardTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_contact_fields()
     {
         $account = factory(Account::class)->create();
@@ -369,7 +371,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('EMAIL:john@doe.com', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_contact_fields_email_labels()
     {
         $account = factory(Account::class)->create();
@@ -397,7 +399,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('EMAIL;TYPE=WORK:john@doe.com', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_contact_fields_tel_labels()
     {
         $account = factory(Account::class)->create();
@@ -429,7 +431,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('TEL;TYPE=WORK:0123456789', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_contact_fields_personal_labels()
     {
         $account = factory(Account::class)->create();
@@ -457,8 +459,8 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('EMAIL;TYPE=Something:john@doe.com', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('socialProfileProvider')]
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[DataProvider('socialProfileProvider')]
+    #[Test]
     public function vcard_add_social_profile($name, $type, $data, $result)
     {
         $account = factory(Account::class)->create();
@@ -498,8 +500,8 @@ class ExportVCardTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('contactUrlProvider')]
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[DataProvider('contactUrlProvider')]
+    #[Test]
     public function vcard_add_contact_url($name, $protocol, $data, $result)
     {
         $account = factory(Account::class)->create();
@@ -532,7 +534,7 @@ class ExportVCardTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_addresses_empty()
     {
         $account = factory(Account::class)->create();
@@ -548,7 +550,7 @@ class ExportVCardTest extends TestCase
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_addresses()
     {
         $account = factory(Account::class)->create();
@@ -577,7 +579,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('ADR:;;12;beverly hills;;90210;US', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_add_addresses_with_labels()
     {
         $account = factory(Account::class)->create();
@@ -605,7 +607,7 @@ class ExportVCardTest extends TestCase
         $this->assertStringContainsString('ADR;TYPE=WORK:;;12;beverly hills;;90210;US', $vCard->serialize());
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_prepares_an_almost_empty_vcard()
     {
         $account = factory(Account::class)->create();
@@ -622,7 +624,7 @@ class ExportVCardTest extends TestCase
         $this->assertVObjectEqualsVObject($this->getCard($contact), $vCard);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_prepares_a_complete_vcard()
     {
         $account = factory(Account::class)->create();
@@ -659,7 +661,7 @@ class ExportVCardTest extends TestCase
         $this->assertVObjectEqualsVObject($this->getCard($contact), $vCard);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function vcard_with_tags()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/VCard/GetEtagTest.php
+++ b/tests/Unit/Services/VCard/GetEtagTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\VCard;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
@@ -12,7 +13,7 @@ class GetEtagTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_etag_local_contact()
     {
         $account = factory(Account::class)->create();
@@ -29,7 +30,7 @@ class GetEtagTest extends TestCase
         $this->assertEquals('"a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"', $etag);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_get_etag_distant_contact()
     {
         $account = factory(Account::class)->create();

--- a/tests/Unit/Services/VCard/ImportVCardTest.php
+++ b/tests/Unit/Services/VCard/ImportVCardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\VCard;
 
+use PHPUnit\Framework\Attributes\Test;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
@@ -26,7 +27,7 @@ class ImportVCardTest extends TestCase
     use DatabaseTransactions,
         PHPUnitAssertions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_because_no_firstname_or_nickname_in_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -37,7 +38,7 @@ class ImportVCardTest extends TestCase
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_because_no_firstname_in_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -50,7 +51,7 @@ class ImportVCardTest extends TestCase
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_because_empty_firstname_in_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -63,7 +64,7 @@ class ImportVCardTest extends TestCase
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -85,7 +86,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_because_empty_nickname_in_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -98,7 +99,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_not_import_because_empty_fullname_in_vcard()
     {
         $account = factory(Account::class)->create([]);
@@ -111,7 +112,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertFalse($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_import_firstname()
     {
         $account = factory(Account::class)->create([]);
@@ -124,7 +125,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertTrue($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_import_nickname()
     {
         $account = factory(Account::class)->create([]);
@@ -137,7 +138,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertTrue($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_can_import_fullname()
     {
         $account = factory(Account::class)->create([]);
@@ -150,7 +151,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertTrue($this->invokePrivateMethod($importVCard, 'canImportCurrentEntry', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_validates_email()
     {
         $account = factory(Account::class)->create([]);
@@ -165,7 +166,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertTrue($this->invokePrivateMethod($importVCard, 'isValidEmail', [$validEmail]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_checks_if_a_contact_exists()
     {
         $account = factory(Account::class)->create([]);
@@ -193,7 +194,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertNull($contact);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_an_unknown_name_if_no_name_is_in_entry()
     {
         $account = factory(Account::class)->create([]);
@@ -209,7 +210,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_name_for_N()
     {
         $account = factory(Account::class)->create([]);
@@ -223,7 +224,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Doe John john@doe.com', $this->invokePrivateMethod($importVCard, 'name', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_name_for_N_incomplete()
     {
         $account = factory(Account::class)->create([]);
@@ -237,7 +238,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Doe John john@doe.com', $this->invokePrivateMethod($importVCard, 'name', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_name_for_NICKNAME()
     {
         $account = factory(Account::class)->create([]);
@@ -251,7 +252,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('John john@doe.com', $this->invokePrivateMethod($importVCard, 'name', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_returns_a_name_for_FN()
     {
         $account = factory(Account::class)->create([]);
@@ -265,7 +266,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('John Doe john@doe.com', $this->invokePrivateMethod($importVCard, 'name', [$vcard]));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_formats_value()
     {
         $account = factory(Account::class)->create([]);
@@ -281,7 +282,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_contact()
     {
         $user = factory(User::class)->create([]);
@@ -303,7 +304,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertTrue($contact->exists);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_contact_in_address_book()
     {
         $user = factory(User::class)->create([]);
@@ -334,7 +335,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($addressBook->id, $contact->address_book_id);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_a_contact_with_birthdate()
     {
         $user = factory(User::class)->create([]);
@@ -358,7 +359,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('2001-04-01', $newContact->birthdate->date->format('Y-m-d'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_a_contact_with_birthdate_age_based()
     {
         Carbon::setTestNow(Carbon::create(2021, 8, 25, 7, 0, 0));
@@ -385,7 +386,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('2002-01-01', $newContact->birthdate->date->format('Y-m-d'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_a_contact_with_birthdate_and_replace_it()
     {
         $user = factory(User::class)->create([]);
@@ -410,7 +411,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('1990-01-01', $newContact->birthdate->date->format('Y-m-d'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_update_a_contact_with_deceased_date()
     {
         $user = factory(User::class)->create([]);
@@ -436,7 +437,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('2021-07-01', $newContact->deceasedDate->date->format('Y-m-d'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_creates_a_contact_with_process()
     {
         $user = factory(User::class)->create([]);
@@ -465,7 +466,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_updates_a_contact_with_process()
     {
         $user = factory(User::class)->create([]);
@@ -499,7 +500,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Miles', $contact->last_name);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_N()
     {
         $importVCard = new ImportVCard;
@@ -514,7 +515,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Jane', $contact['middle_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_NICKNAME()
     {
         $importVCard = new ImportVCard;
@@ -527,7 +528,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('John', $contact['first_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_FN()
     {
         $account = factory(Account::class)->create([]);
@@ -545,7 +546,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Doe', $contact['last_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_FN_last()
     {
         $account = factory(Account::class)->create([]);
@@ -566,7 +567,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('John', $contact['last_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_FN_extra_space()
     {
         $account = factory(Account::class)->create([]);
@@ -584,7 +585,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Doe', $contact['last_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_name_FN()
     {
         $account = factory(Account::class)->create([]);
@@ -603,7 +604,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('', Arr::get($contact, 'last_name'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_name_FN_last()
     {
         $account = factory(Account::class)->create([]);
@@ -625,7 +626,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('', Arr::get($contact, 'last_name'));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_names_FN_multiple()
     {
         $account = factory(Account::class)->create([]);
@@ -644,7 +645,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('Doe Marco', $contact['last_name']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_work_information()
     {
         $user = factory(User::class)->create();
@@ -674,7 +675,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         );
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_birthday()
     {
         config(['monica.requires_subscription' => false]);
@@ -701,7 +702,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ], $contact);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_birthday_compact_format()
     {
         config(['monica.requires_subscription' => false]);
@@ -726,7 +727,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ], $contact);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_birthday_year_unknown()
     {
         config(['monica.requires_subscription' => false]);
@@ -751,7 +752,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ], $contact);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_imports_address()
     {
         $account = factory(Account::class)->create([]);
@@ -788,7 +789,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_imports_partial_address()
     {
         $account = factory(Account::class)->create([]);
@@ -821,7 +822,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_updates_address()
     {
         $account = factory(Account::class)->create([]);
@@ -871,7 +872,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($place->country, 'US');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_updates_and_destroy_address()
     {
         $account = factory(Account::class)->create([]);
@@ -930,7 +931,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($place->country, 'US');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_imports_email()
     {
         $account = factory(Account::class)->create([]);
@@ -957,7 +958,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_updates_email()
     {
         $account = factory(Account::class)->create([]);
@@ -987,7 +988,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($email->data, 'other@doe.com');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function import_vcard_updates_and_detroy_email()
     {
         $account = factory(Account::class)->create([]);
@@ -1027,7 +1028,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($email1->data, 'other@doe.com');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_phone()
     {
         $account = factory(Account::class)->create([]);
@@ -1055,7 +1056,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_phone_by_national_format()
     {
         $account = factory(Account::class)->create([]);
@@ -1084,7 +1085,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_phone_by_international_format()
     {
         $account = factory(Account::class)->create([]);
@@ -1113,7 +1114,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_email_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -1162,7 +1163,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals($email->data, 'test@test.com');
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_address_labels()
     {
         $account = factory(Account::class)->create([]);
@@ -1212,7 +1213,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_categories()
     {
         $account = factory(Account::class)->create();
@@ -1251,7 +1252,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_notes()
     {
         $account = factory(Account::class)->create([]);
@@ -1275,7 +1276,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_new_categories()
     {
         $account = factory(Account::class)->create();
@@ -1339,7 +1340,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_uuid_default()
     {
         $account = factory(Account::class)->create();
@@ -1357,7 +1358,7 @@ END:VCARD', Reader::OPTION_FORGIVING + Reader::OPTION_IGNORE_INVALID_LINES);
         $this->assertEquals('31fdc242-c974-436e-98de-6b21624d6e34', $contact['uuid']);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function it_imports_uuid_contact()
     {
         $user = factory(User::class)->create([]);

--- a/tests/Unit/Traits/SearchableTest.php
+++ b/tests/Unit/Traits/SearchableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Traits;
 
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -10,7 +11,7 @@ class SearchableTest extends TestCase
 {
     use DatabaseTransactions;
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function testSearchContactsReturnsCollection()
     {
         $contact = factory(Contact::class)->make();
@@ -20,7 +21,7 @@ class SearchableTest extends TestCase
         $this->assertInstanceOf('Illuminate\Pagination\LengthAwarePaginator', $searchResults);
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function testSearchContactsThroughFirstNameAndResultContainsContact()
     {
         $contact = factory(Contact::class)->create(['first_name' => 'FirstName']);
@@ -30,7 +31,7 @@ class SearchableTest extends TestCase
         $this->assertTrue($searchResults->contains($contact));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function testSearchContactsThroughMiddleNameAndResultContainsContact()
     {
         $contact = factory(Contact::class)->create(['middle_name' => 'MiddleName']);
@@ -40,7 +41,7 @@ class SearchableTest extends TestCase
         $this->assertTrue($searchResults->contains($contact));
     }
 
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function testSearchContactsThroughLastNameAndResultContainsContact()
     {
         $contact = factory(Contact::class)->create(['last_name' => 'LastName']);
@@ -53,7 +54,7 @@ class SearchableTest extends TestCase
     /**
      * @psalm-suppress UndefinedFunction
      */
-    #[\PHPUnit\Framework\Attributes\Test]
+    #[Test]
     public function testFailingSearchContacts()
     {
         $contact = factory(Contact::class)->create(['first_name' => 'TestShouldFail']);


### PR DESCRIPTION
## Summary

Follow-up style polish to #669. After `PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES` converted 1397 doc-comment annotations into PHP 8 attributes, rector left them in fully-qualified form (`#[\PHPUnit\Framework\Attributes\Test]`). This PR adds `->withImportNames()` to `rector.php` and re-runs rector so the FQNs are pulled into `use` imports and replaced with the short form (`#[Test]`).

## Net effect

- `rector.php`: adds
  ```php
  ->withImportNames(
      importNames: true,
      importDocBlockNames: false,
      importShortClasses: false,
      removeUnusedImports: false,
  )
  ```
- 275 test files modified.
- 1414 FQN attribute occurrences resolved (1356 `Test` + 47 `Group` + 10 `DataProvider` + 1 `BeforeClass`) → short-form `#[Test]` etc.
- A handful of non-attribute FQNs also imported (e.g. `Sabre\DAV\Version`, `Sabre\VObject\Version`, `Laravel\Cashier\Subscription`, `Stripe\Exception\ApiErrorException`). No name collisions — the two `Sabre\Version` classes live in different files.

## Why now

The original D₃ pre-cleanup (#669) focused on eliminating the 1403 PHPUnit deprecations. The handoff for D₃ flagged the FQN attribute form as a deferred ~30-min style polish. Doing it now keeps D₃'s diff focused on the L11→L12 churn rather than mixing style noise into the framework bump.

## Verification

`vendor/bin/phpunit` before and after:

```
Tests: 1676, Assertions: 13180, Skipped: 12.
```

Identical run, zero deprecations, no behaviour change.

`phpstan` scope is `app/` only — not affected.
`psalm` is currently disabled (gated to PR-E per #647).

## Test plan

- [ ] CI passes: phpunit, phpstan, composer validate
- [ ] Spot-check a few modified files in the diff to confirm imports look sensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
