### PR TITLE
fix(db): restore tasks.contact_id nullable lost in l11 schema regression

### DIFF
--- a/database/migrations/2026_05_25_200000_restore_tasks_contact_id_nullable.php
+++ b/database/migrations/2026_05_25_200000_restore_tasks_contact_id_nullable.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Restore tasks.contact_id nullable after L11 schema-builder regression.
+ *
+ * Migration 2018_11_15_172333_make_contact_id_nullable_in_tasks made the
+ * column nullable. The later FK migration 2019_12_17_024553_add_foreign_keys
+ * called `->unsignedInteger('contact_id')->change()` without `->nullable()`.
+ *
+ * Pre-Laravel 11 (doctrine/dbal-backed) `->change()` merged modifiers, so the
+ * earlier nullable() stuck. Laravel 11's native schema builder replaces all
+ * modifiers, so the same call silently resets the column to NOT NULL.
+ *
+ * This breaks any code path that creates a task without a contact (CalDAV
+ * task imports, CreateTaskTest::it_stores_a_task_without_contact_id, etc.).
+ *
+ * Forward-only restore — old migrations are not modified.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->unsignedInteger('contact_id')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        // No-op: the column was meant to be nullable from 2018 onward;
+        // there is no meaningful "down" state to restore.
+    }
+};


### PR DESCRIPTION
## Summary

- Adds a forward-only migration restoring `tasks.contact_id` to nullable, undoing a silent L11 schema regression introduced when the trunk picked up Laravel 11's native (doctrine/dbal-free) schema builder.
- Migration `2018_11_15_172333_make_contact_id_nullable_in_tasks` originally made the column nullable; the later FK migration `2019_12_17_024553_add_foreign_keys.php:562` calls `->unsignedInteger('contact_id')->change()` without `->nullable()`. Under doctrine/dbal that merged modifiers, but L11 replaces all modifiers — silently resetting the column to NOT NULL.
- Only `tasks.contact_id` is affected; audited every other column in the FK migration against the test DB and all retained their intended nullability.

## Why this slipped through

CI's `tests.yml` runs `php artisan migrate --no-interaction -vvv` (incremental migrate), not `migrate:fresh`. The bug only manifests when migrations run from scratch — exactly what happens on truly empty CI databases, ephemeral test runners, and local `yarn run test` (whose `pretest` hook calls `migrate:fresh`).

Manifested as 6 errors + 1 failure on `migrate:fresh` + phpunit:

- `Tests\Api\DAV\VTodoTaskTest::test_caldav_put_one_task`
- `Tests\Api\DAV\VTodoTaskTest::test_caldav_update_existing_task`
- `Tests\Api\DAV\VTodoTaskTest::test_caldav_update_task_complete`
- `Tests\Unit\Services\Task\CreateTaskTest::it_stores_a_task_without_contact_id`
- `Tests\Unit\Services\Task\UpdateTaskTest::it_updates_a_task_associated_without_a_contact`
- (plus 2 more failure variants in the same VTodo cluster)

All 8 previously-failing tests pass with the fix; full suite back to 1676 tests / 13180 assertions / 12 skipped.

## Test plan

- [x] `php artisan migrate:fresh --env=testing --database=testing --force` runs clean
- [x] `SHOW COLUMNS FROM tasks LIKE 'contact_id'` shows `NULL=YES`
- [x] Full `vendor/bin/phpunit --no-coverage` → 1676 / 13180 / 12 skipped, no errors/failures
- [x] `vendor/bin/phpstan analyse` clean on the new migration
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
