### PR TITLE
fix(db): rename subscriptions.name to type for cashier 15

### DIFF
--- a/app/Helpers/InstanceHelper.php
+++ b/app/Helpers/InstanceHelper.php
@@ -67,7 +67,7 @@ class InstanceHelper
         if (is_null($stripeSubscription) || is_null($plan)) {
             return [
                 'type' => $subscription->stripe_price,
-                'name' => $subscription->name,
+                'name' => $subscription->type,
                 'id' => $subscription->stripe_id,
                 'price' => '?',
                 'friendlyPrice' => '?',
@@ -80,7 +80,7 @@ class InstanceHelper
 
         return [
             'type' => $plan->interval === 'month' ? 'monthly' : 'annual',
-            'name' => $subscription->name,
+            'name' => $subscription->type,
             'id' => $plan->id,
             'price' => $plan->amount,
             'friendlyPrice' => $amount,

--- a/app/Traits/Subscription.php
+++ b/app/Traits/Subscription.php
@@ -59,7 +59,7 @@ trait Subscription
 
         if ($subscription->stripe_price !== $oldPlan && $subscription->stripe_price === $plan['id']) {
             $subscription->forceFill([
-                'name' => $plan['name'],
+                'type' => $plan['name'],
             ])->save();
         }
 
@@ -111,7 +111,7 @@ trait Subscription
     {
         $plan = $this->getSubscribedPlan();
 
-        return is_null($plan) ? null : $plan->name;
+        return is_null($plan) ? null : $plan->type;
     }
 
     /**

--- a/database/factories/SettingsFactory.php
+++ b/database/factories/SettingsFactory.php
@@ -20,7 +20,7 @@ $factory->define(App\Models\Settings\Currency::class, function (Faker\Generator 
 $factory->define(\Laravel\Cashier\Subscription::class, function (Faker\Generator $faker) {
     return [
         'account_id' => factory(App\Models\Account\Account::class)->create()->id,
-        'name' => $faker->word(),
+        'type' => $faker->word(),
         'stripe_id' => $faker->word(),
         'stripe_price' => $faker->randomElement(['plan-1', 'plan-2', 'plan-3']),
         'quantity' => 1,

--- a/database/migrations/2026_05_25_210000_rename_subscriptions_name_to_type_for_cashier_15.php
+++ b/database/migrations/2026_05_25_210000_rename_subscriptions_name_to_type_for_cashier_15.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Rename subscriptions.name → subscriptions.type for Cashier 15.
+ *
+ * Monica's subscriptions table was created with a `name` column
+ * (2017_06_19_105842_add_stripe_fields_to_users.php — Cashier <12).
+ * From Cashier 12+, the column has been called `type`; Cashier's reference
+ * migration declares `$table->string('type')`. Cashier 15's
+ * SubscriptionBuilder, the Billable concerns, and the Subscription model
+ * all write/read `type` directly.
+ *
+ * When the fork bumped laravel/cashier ^14 → ^15 during the Laravel 11
+ * modernization (commit 94f18e508), the companion `name → type` rename
+ * migration was missed. The mismatch is silent until any code path tries
+ * to persist a Subscription — which throws SQLSTATE[42S22] "Column not
+ * found: 'type' in 'field list'".
+ *
+ * Forward-only rename — original column is repurposed, not duplicated,
+ * preserving any existing row data.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table) {
+            $table->renameColumn('name', 'type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('subscriptions', function (Blueprint $table) {
+            $table->renameColumn('type', 'name');
+        });
+    }
+};

--- a/tests/Unit/Helpers/InstanceHelperTest.php
+++ b/tests/Unit/Helpers/InstanceHelperTest.php
@@ -111,7 +111,7 @@ class InstanceHelperTest extends TestCase
         $subscription->shouldReceive('asStripeSubscription')
             ->andReturn($stripeSubscription);
         $subscription->shouldReceive('getAttribute')
-            ->with('name')
+            ->with('type')
             ->andReturn('Monthly');
 
         $this->assertEquals(

--- a/tests/Unit/Models/AccountTest.php
+++ b/tests/Unit/Models/AccountTest.php
@@ -295,7 +295,7 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
-            'name' => 'fakePlan',
+            'type' => 'fakePlan',
         ]);
 
         config(['monica.paid_plan_monthly_friendly_name' => 'fakePlan']);
@@ -314,7 +314,7 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
             'stripe_price' => 'chandler_annual',
             'stripe_id' => 'sub_C0R444pbxddhW7',
-            'name' => 'annualPlan',
+            'type' => 'annualPlan',
         ]);
 
         config(['monica.paid_plan_annual_friendly_name' => 'annualPlan']);
@@ -343,7 +343,7 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
-            'name' => 'fakePlan',
+            'type' => 'fakePlan',
         ]);
 
         $this->assertTrue($account->hasInvoices());
@@ -373,7 +373,7 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
-            'name' => 'fakePlan',
+            'type' => 'fakePlan',
         ]);
 
         $this->assertEquals(
@@ -398,7 +398,7 @@ class AccountTest extends FeatureTestCase
             'account_id' => $account->id,
             'stripe_price' => 'chandler_5',
             'stripe_id' => 'sub_C0R444pbxddhW7',
-            'name' => 'fakePlan',
+            'type' => 'fakePlan',
         ]);
 
         $this->assertEquals(


### PR DESCRIPTION
## Summary

- Adds a forward-only migration renaming `subscriptions.name` → `subscriptions.type` to match what Cashier 15 expects. Updates the 4 monica-app call sites that read/write the column, plus 6 test sites and the `\Laravel\Cashier\Subscription` factory.
- Companion to PR #671 — same shape of defect (silent schema regression introduced when the fork bumped to Laravel 11 / Cashier 15 in commit `94f18e508`). Both bugs only surface on `migrate:fresh` against the post-L11 code, which is why neither was caught by the standard CI flow.

## Why the column needs to be `type`

Cashier 12+ renamed the column from `name` to `type`. Cashier 15's `SubscriptionBuilder`, the `ManagesSubscriptions` concern, and the `Subscription` model all write/read `type` directly — see `vendor/laravel/cashier/database/migrations/2019_05_03_000002_create_subscriptions_table.php:17` (`$table->string('type')`). Monica's table was created in 2017 with `name` and the rename never landed when we bumped to Cashier 15.

## Symptoms before this fix

Any code path that persists a Cashier `Subscription` throws:

```
SQLSTATE[42S22]: Column not found: 'type' in 'field list'
```

Surfaced while wiring up `stripe-mock` for hermetic Stripe tests in a follow-on PR: the existing `AccountSubscriptionTest` exercises Cashier's `newSubscription` + `swap` + `cancel`, all of which fail on the schema mismatch. Also affects `tests/Unit/Models/AccountTest.php` (5 factory-override sites) and `tests/Unit/Helpers/InstanceHelperTest.php::it_fetches_subscription_information` (Mockery setup that mocks the wrong attribute name).

## What changed

| File | Change |
|---|---|
| `database/migrations/2026_05_25_210000_rename_subscriptions_name_to_type_for_cashier_15.php` | **New** forward-only migration. `Schema::table('subscriptions', fn ($t) => $t->renameColumn('name', 'type'))`. Reversible. |
| `app/Traits/Subscription.php` | 2 sites — `forceFill(['name' => …])` → `['type' => …]`; `$plan->name` → `$plan->type`. |
| `app/Helpers/InstanceHelper.php` | 2 sites — `$subscription->name` → `$subscription->type`. **Array key `'name'` preserved** — that's a monica-internal contract consumed by `resources/views/settings/subscriptions/account.blade.php`. |
| `database/factories/SettingsFactory.php` | Subscription factory seeds `type` instead of `name`. |
| `tests/Unit/Models/AccountTest.php` | 5 factory-override sites updated to `'type' => …`. |
| `tests/Unit/Helpers/InstanceHelperTest.php` | One Mockery `shouldReceive('getAttribute')->with('name')` → `->with('type')`. |

## Test plan

- [x] `php artisan migrate:fresh --env=testing --database=testing --force` runs clean
- [x] `SHOW COLUMNS FROM subscriptions LIKE 'type'` returns the column; `LIKE 'name'` returns nothing
- [x] Targeted filter `AccountTest|InstanceHelperTest|AccountSubscriptionTest`: was **9 errors + 4 failures + 12 skipped** before this fix → **0 errors + 0 failures + 12 skipped** after (`AccountSubscriptionTest` continues to skip on missing `STRIPE_SECRET` — expected on 4.x; addressed in the follow-on stripe-coverage PR)
- [x] Full `vendor/bin/phpunit --no-coverage`: 1676 / 13161 / 12 skipped, with **6 errors + 1 failure carried over from `tasks.contact_id` (PR #671)**, no new regressions introduced by this fix
- [x] `vendor/bin/phpstan analyse` clean on the 3 modified app files + the new migration
- [ ] CI green

## Why this slipped through the L11 upgrade

Same root cause as PR #671: CI's `tests.yml` runs `php artisan migrate --no-interaction -vvv` (incremental), not `migrate:fresh`. The bug only manifests when migrations run against an empty database. The Cashier reference migration that creates `subscriptions.type` is part of Cashier's own published migrations; we didn't pick up the renamed column because monica's table predates Cashier 12 and the upgrade ladder never included a rename hop.

## Relationship to PR #671

Independent of #671 — both PRs cleanly apply on 4.x in either order. Together they restore `migrate:fresh` to green (modulo the 12 Stripe tests, which still skip without `STRIPE_SECRET` set; that's the follow-on stripe-mock coverage work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
