### PR TITLE
fix(dev): unblock multi-clone docker stack and unbreak setup:test seeder

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -23,7 +23,7 @@ DB_TEST_PASSWORD=secret
 
 # Mail credentials used to send emails from the application.
 MAIL_MAILER=smtp
-MAIL_HOST=fake_mail
+MAIL_HOST=mail
 MAIL_PORT=1025
 MAIL_USERNAME=null
 MAIL_PASSWORD=null

--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -145,6 +145,13 @@ class SetupTest extends Command
         } else {
             $this->account = Account::createDefault('John', 'Doe', 'admin@admin.com', 'admin0');
 
+            // dev seeder must outlive the free-plan contact ceiling so the loop below can populate
+            // a meaningful account without tripping abort(402) when REQUIRES_SUBSCRIPTION=true
+            // (which docker-compose.dev.yml pins for the Stripe upgrade-flow smoke). Direct
+            // attribute assignment because the flag isn't in Account::$fillable.
+            $this->account->legacy_free_plan_unlimited_contacts = true;
+            $this->account->save();
+
             // set default admin account to confirmed
             /** @var User */
             $adminUser = $this->account->users()->first();
@@ -206,6 +213,8 @@ class SetupTest extends Command
         // create the second test, blank account
         if (! User::where('email', 'blank@blank.com')->exists()) {
             $blankAccount = Account::createDefault('Blank', 'State', 'blank@blank.com', 'blank0');
+            $blankAccount->legacy_free_plan_unlimited_contacts = true;
+            $blankAccount->save();
             $blankUser = $blankAccount->users()->first();
             $this->confirmUser($blankUser);
         }

--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -149,7 +149,7 @@ class SetupTest extends Command
             // a meaningful account without tripping abort(402) when REQUIRES_SUBSCRIPTION=true
             // (which docker-compose.dev.yml pins for the Stripe upgrade-flow smoke). Direct
             // attribute assignment because the flag isn't in Account::$fillable.
-            $this->account->legacy_free_plan_unlimited_contacts = true;
+            $this->account->legacy_free_plan_unlimited_contacts = 1;
             $this->account->save();
 
             // set default admin account to confirmed
@@ -213,7 +213,7 @@ class SetupTest extends Command
         // create the second test, blank account
         if (! User::where('email', 'blank@blank.com')->exists()) {
             $blankAccount = Account::createDefault('Blank', 'State', 'blank@blank.com', 'blank0');
-            $blankAccount->legacy_free_plan_unlimited_contacts = true;
+            $blankAccount->legacy_free_plan_unlimited_contacts = 1;
             $blankAccount->save();
             $blankUser = $blankAccount->users()->first();
             $this->confirmUser($blankUser);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,7 @@ services:
       - mysql
       - stripe-mock
     ports:
-      - 8082:80
+      - ${APP_PORT:-8082}:80
     env_file: .env.dev
     environment:
       # Route all Stripe SDK / Cashier traffic at the stripe-mock sidecar so the
@@ -66,7 +66,7 @@ services:
   stripe-mock:
     image: stripe/stripe-mock:v0.199.0
     ports:
-      - 12111:12111
+      - ${STRIPE_MOCK_PORT:-12111}:12111
 
   phpmyadmin:
     image: phpmyadmin:5.2
@@ -78,13 +78,12 @@ services:
       PMA_PASSWORD: sekret_root_password
     restart: always
     ports:
-      - 3000:80
+      - ${PHPMYADMIN_PORT:-3000}:80
     volumes:
       - /sessions
 
   mail:
-    container_name: fake_mail
     image: mailhog/mailhog:v1.0.1
     ports:
-      - 8025:8025
-      - 1025:1025
+      - ${MAILHOG_UI_PORT:-8025}:8025
+      - ${MAILHOG_SMTP_PORT:-1025}:1025


### PR DESCRIPTION
## Summary

Two dev-stack bugs found while following the spin-up instructions in discussion #675 against a fresh clone with another monica stack already on the host:

- **`mail` service hardcoded `container_name: fake_mail`** — colliding in docker's global namespace with any other clone (or stopped orphan). Drop the hardcode; let compose auto-name. Service-name DNS resolves identically on the project network, so `.env.dev` `MAIL_HOST` shifts from the old container_name `fake_mail` to the service name `mail`.
- **All five host port mappings were fixed values** (8082 / 3000 / 8025 / 1025 / 12111) — second `docker compose up` against the same host fails on port-already-in-use. Make them overridable via env vars (`APP_PORT`, `PHPMYADMIN_PORT`, `MAILHOG_UI_PORT`, `MAILHOG_SMTP_PORT`, `STRIPE_MOCK_PORT`) with their previous values as defaults. Container-internal ports unchanged so `STRIPE_API_BASE` / `MAIL_PORT` keep working.
- **`php artisan setup:test` aborted at contact 3 of 20** with HTTP 402 from `CreateContact::execute`. Root cause: `docker-compose.dev.yml` pins `REQUIRES_SUBSCRIPTION=true` for the Stripe upgrade-flow playwright smoke (#674), which makes `AccountHelper::hasLimitations` return true, and the free-plan contact ceiling kicks in. Flag both seeded accounts as `legacy_free_plan_unlimited_contacts` inside the seeder so the dev fixtures survive the subscription gate.

Discussion: brycehans/monica#675.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config` parses; defaults stay at 8082/3000/8025/1025/12111; no `container_name` rendered for the mail service; `MAIL_HOST` resolves to `mail`
- [x] With `APP_PORT=8083 PHPMYADMIN_PORT=3001 MAILHOG_UI_PORT=8027 MAILHOG_SMTP_PORT=1027 STRIPE_MOCK_PORT=12112 docker compose up`, all five host-side ports shift and the app is reachable on the new app port
- [x] With a second monica clone on `:8082`, this clone comes up cleanly on `:8083` without a global `fake_mail` collision
- [x] `php artisan setup:test` seeds 20/20 contacts with `REQUIRES_SUBSCRIPTION=true` still set in the container env (no workaround flag needed)
- [x] Both `admin@admin.com` (account 1) and `blank@blank.com` (account 2) have `legacy_free_plan_unlimited_contacts=1` after seeding
- [x] End-to-end login as `admin@admin.com / admin0` lands on `/dashboard`; `/people` lists the 20 seeded contacts

## Out of scope

- `php artisan monica:seed-regression-demo` (referenced in `CLAUDE.md` and discussion #675) is not implemented in any branch and the design spec at `docs/superpowers/specs/2026-05-19-browser-regression-seed-data-design.md` is missing. Tracking separately — this PR only restores the existing `setup:test` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
