### PR TITLE
refactor(js): convert require() → esm imports (phase 3 PR-V₂)

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,7 +5,7 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap');
+import './bootstrap';
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to
@@ -14,304 +14,175 @@ require('./bootstrap');
  */
 
 import Vue from 'vue';
+import Notifications from 'vue-notification';
+import Tooltip from 'vue-directive-tooltip';
+import VueClipboard from 'vue-clipboard2';
+
+// Custom components — Passport
+import PassportClients from './components/passport/Clients.vue';
+import PassportAuthorizedClients from './components/passport/AuthorizedClients.vue';
+import PassportPersonalAccessTokens from './components/passport/PersonalAccessTokens.vue';
+
+// Vue select
+import ContactSelect from './components/people/ContactSelect.vue';
+import ContactSearch from './components/people/ContactSearch.vue';
+import ContactMultiSearch from './components/people/ContactMultiSearch.vue';
+
+// Partials
+import Avatar from './components/partials/Avatar.vue';
+import Confirm from './components/partials/Confirm.vue';
+
+// Form elements
+import FormInput from './components/partials/form/Input.vue';
+import FormSelect from './components/partials/form/Select.vue';
+import FormDate from './components/partials/form/Date.vue';
+import FormCheckbox from './components/partials/form/Checkbox.vue';
+import FormRadio from './components/partials/form/Radio.vue';
+import FormTextarea from './components/partials/form/Textarea.vue';
+import FormToggle from './components/partials/form/Toggle.vue';
+import FormSpecialdate from './components/partials/SpecialDate.vue';
+import FormSpecialdeceased from './components/partials/SpecialDeceased.vue';
+
+// Dashboard
+import DashboardLog from './components/dashboard/DashboardLog.vue';
+
+// Contacts
+import Tags from './components/people/Tags.vue';
+import ContactAvatar from './components/people/SetAvatar.vue';
+import ContactFavorite from './components/people/SetFavorite.vue';
+import ContactArchive from './components/people/Archive.vue';
+import ContactAddress from './components/people/Addresses.vue';
+import ContactInformation from './components/people/ContactInformation.vue';
+import ContactList from './components/people/ContactList.vue';
+import ContactTask from './components/people/Tasks.vue';
+import ContactNote from './components/people/Notes.vue';
+import ContactGift from './components/people/gifts/Gifts.vue';
+import Pet from './components/people/Pets.vue';
+import MeContact from './components/people/MeContact.vue';
+import StayInTouch from './components/people/StayInTouch.vue';
+import LastCalled from './components/people/calls/LastCalled.vue';
+import PhoneCallList from './components/people/calls/PhoneCallList.vue';
+import ConversationList from './components/people/conversation/ConversationList.vue';
+import Conversation from './components/people/conversation/Conversation.vue';
+import Message from './components/people/conversation/Message.vue';
+import ActivityList from './components/people/activity/ActivityList.vue';
+import DocumentList from './components/people/document/DocumentList.vue';
+import CreateLifeEvent from './components/people/lifeevent/CreateLifeEvent.vue';
+import CreateDefaultLifeEvent from './components/people/lifeevent/content/CreateDefaultLifeEvent.vue';
+import LifeEventList from './components/people/lifeevent/LifeEventList.vue';
+import PhotoList from './components/people/photo/PhotoList.vue';
+
+// Journal
+import JournalList from './components/journal/JournalList.vue';
+import JournalRateDay from './components/journal/RateDay.vue';
+import JournalCalendar from './components/journal/partials/JournalCalendar.vue';
+import JournalContentRate from './components/journal/partials/JournalContentRate.vue';
+import JournalContentActivity from './components/journal/partials/JournalContentActivity.vue';
+import JournalContentEntry from './components/journal/partials/JournalContentEntry.vue';
+
+// Settings
+import ContactFieldTypes from './components/settings/ContactFieldTypes.vue';
+import Genders from './components/settings/Genders.vue';
+import ReminderRules from './components/settings/ReminderRules.vue';
+import ReminderTime from './components/settings/ReminderTime.vue';
+import MfaActivate from './components/settings/MfaActivate.vue';
+import WebauthnConnector from './components/settings/WebauthnConnector.vue';
+import RecoveryCodes from './components/settings/RecoveryCodes.vue';
+import Modules from './components/settings/Modules.vue';
+import ActivityTypes from './components/settings/ActivityTypes.vue';
+import LifeEventTypes from './components/settings/LifeEventTypes.vue';
+import DavResources from './components/settings/DAVResources.vue';
+
+import './testing';
+import common from './common';
+import methods from './methods';
+
 window.Vue = Vue;
 
 // Notifications
-import Notifications from 'vue-notification';
 Vue.use(Notifications);
 
 // Tooltip
-import Tooltip from 'vue-directive-tooltip';
 Vue.use(Tooltip, { delay: 0 });
 
 // Copy text from clipboard
-import VueClipboard from 'vue-clipboard2';
 VueClipboard.config.autoSetContainer = true;
 Vue.use(VueClipboard);
 
 // Custom components
-Vue.component(
-  'PassportClients',
-  require('./components/passport/Clients.vue').default
-);
-
-Vue.component(
-  'PassportAuthorizedClients',
-  require('./components/passport/AuthorizedClients.vue').default
-);
-
-Vue.component(
-  'PassportPersonalAccessTokens',
-  require('./components/passport/PersonalAccessTokens.vue').default
-);
+Vue.component('PassportClients', PassportClients);
+Vue.component('PassportAuthorizedClients', PassportAuthorizedClients);
+Vue.component('PassportPersonalAccessTokens', PassportPersonalAccessTokens);
 
 // Vue select
-Vue.component(
-  'ContactSelect',
-  require('./components/people/ContactSelect.vue').default
-);
-Vue.component(
-  'ContactSearch',
-  require('./components/people/ContactSearch.vue').default
-);
-Vue.component(
-  'ContactMultiSearch',
-  require('./components/people/ContactMultiSearch.vue').default
-);
+Vue.component('ContactSelect', ContactSelect);
+Vue.component('ContactSearch', ContactSearch);
+Vue.component('ContactMultiSearch', ContactMultiSearch);
 
 // Partials
-Vue.component(
-  'Avatar',
-  require('./components/partials/Avatar.vue').default
-);
-Vue.component(
-  'Confirm',
-  require('./components/partials/Confirm.vue').default
-);
+Vue.component('Avatar', Avatar);
+Vue.component('Confirm', Confirm);
 
 // Form elements
-Vue.component(
-  'FormInput',
-  require('./components/partials/form/Input.vue').default
-);
-Vue.component(
-  'FormSelect',
-  require('./components/partials/form/Select.vue').default
-);
-Vue.component(
-  'FormDate',
-  require('./components/partials/form/Date.vue').default
-);
-Vue.component(
-  'FormCheckbox',
-  require('./components/partials/form/Checkbox.vue').default
-);
-Vue.component(
-  'FormRadio',
-  require('./components/partials/form/Radio.vue').default
-);
-Vue.component(
-  'FormTextarea',
-  require('./components/partials/form/Textarea.vue').default
-);
-Vue.component(
-  'FormToggle',
-  require('./components/partials/form/Toggle.vue').default
-);
-Vue.component(
-  'FormSpecialdate',
-  require('./components/partials/SpecialDate.vue').default
-);
-Vue.component(
-  'FormSpecialdeceased',
-  require('./components/partials/SpecialDeceased.vue').default
-);
+Vue.component('FormInput', FormInput);
+Vue.component('FormSelect', FormSelect);
+Vue.component('FormDate', FormDate);
+Vue.component('FormCheckbox', FormCheckbox);
+Vue.component('FormRadio', FormRadio);
+Vue.component('FormTextarea', FormTextarea);
+Vue.component('FormToggle', FormToggle);
+Vue.component('FormSpecialdate', FormSpecialdate);
+Vue.component('FormSpecialdeceased', FormSpecialdeceased);
 
 // Dashboard
-Vue.component(
-  'DashboardLog',
-  require('./components/dashboard/DashboardLog.vue').default
-);
+Vue.component('DashboardLog', DashboardLog);
 
 // Contacts
-Vue.component(
-  'Tags',
-  require('./components/people/Tags.vue').default
-);
-
-Vue.component(
-  'ContactAvatar',
-  require('./components/people/SetAvatar.vue').default
-);
-Vue.component(
-  'ContactFavorite',
-  require('./components/people/SetFavorite.vue').default
-);
-
-Vue.component(
-  'ContactArchive',
-  require('./components/people/Archive.vue').default
-);
-
-Vue.component(
-  'ContactAddress',
-  require('./components/people/Addresses.vue').default
-);
-
-Vue.component(
-  'ContactInformation',
-  require('./components/people/ContactInformation.vue').default
-);
-
-Vue.component(
-  'ContactList',
-  require('./components/people/ContactList.vue').default
-);
-
-Vue.component(
-  'ContactTask',
-  require('./components/people/Tasks.vue').default
-);
-
-Vue.component(
-  'ContactNote',
-  require('./components/people/Notes.vue').default
-);
-
-Vue.component(
-  'ContactGift',
-  require('./components/people/gifts/Gifts.vue').default
-);
-
-Vue.component(
-  'Pet',
-  require('./components/people/Pets.vue').default
-);
-
-Vue.component(
-  'MeContact',
-  require('./components/people/MeContact.vue').default
-);
-Vue.component(
-  'StayInTouch',
-  require('./components/people/StayInTouch.vue').default
-);
-
-Vue.component(
-  'LastCalled',
-  require('./components/people/calls/LastCalled.vue').default
-);
-
-Vue.component(
-  'PhoneCallList',
-  require('./components/people/calls/PhoneCallList.vue').default
-);
-
-Vue.component(
-  'ConversationList',
-  require('./components/people/conversation/ConversationList.vue').default
-);
-
-Vue.component(
-  'Conversation',
-  require('./components/people/conversation/Conversation.vue').default
-);
-
-Vue.component(
-  'Message',
-  require('./components/people/conversation/Message.vue').default
-);
-
-Vue.component(
-  'ActivityList',
-  require('./components/people/activity/ActivityList.vue').default
-);
-
-Vue.component(
-  'DocumentList',
-  require('./components/people/document/DocumentList.vue').default
-);
-
-Vue.component(
-  'CreateLifeEvent',
-  require('./components/people/lifeevent/CreateLifeEvent.vue').default
-);
-
-Vue.component(
-  'CreateDefaultLifeEvent',
-  require('./components/people/lifeevent/content/CreateDefaultLifeEvent.vue').default
-);
-
-Vue.component(
-  'LifeEventList',
-  require('./components/people/lifeevent/LifeEventList.vue').default
-);
-
-Vue.component(
-  'PhotoList',
-  require('./components/people/photo/PhotoList.vue').default
-);
+Vue.component('Tags', Tags);
+Vue.component('ContactAvatar', ContactAvatar);
+Vue.component('ContactFavorite', ContactFavorite);
+Vue.component('ContactArchive', ContactArchive);
+Vue.component('ContactAddress', ContactAddress);
+Vue.component('ContactInformation', ContactInformation);
+Vue.component('ContactList', ContactList);
+Vue.component('ContactTask', ContactTask);
+Vue.component('ContactNote', ContactNote);
+Vue.component('ContactGift', ContactGift);
+Vue.component('Pet', Pet);
+Vue.component('MeContact', MeContact);
+Vue.component('StayInTouch', StayInTouch);
+Vue.component('LastCalled', LastCalled);
+Vue.component('PhoneCallList', PhoneCallList);
+Vue.component('ConversationList', ConversationList);
+Vue.component('Conversation', Conversation);
+Vue.component('Message', Message);
+Vue.component('ActivityList', ActivityList);
+Vue.component('DocumentList', DocumentList);
+Vue.component('CreateLifeEvent', CreateLifeEvent);
+Vue.component('CreateDefaultLifeEvent', CreateDefaultLifeEvent);
+Vue.component('LifeEventList', LifeEventList);
+Vue.component('PhotoList', PhotoList);
 
 // Journal
-Vue.component(
-  'JournalList',
-  require('./components/journal/JournalList.vue').default
-);
-
-Vue.component(
-  'JournalRateDay',
-  require('./components/journal/RateDay.vue').default
-);
-
-Vue.component(
-  'JournalCalendar',
-  require('./components/journal/partials/JournalCalendar.vue').default
-);
-
-Vue.component(
-  'JournalContentRate',
-  require('./components/journal/partials/JournalContentRate.vue').default
-);
-
-Vue.component(
-  'JournalContentActivity',
-  require('./components/journal/partials/JournalContentActivity.vue').default
-);
-
-Vue.component(
-  'JournalContentEntry',
-  require('./components/journal/partials/JournalContentEntry.vue').default
-);
+Vue.component('JournalList', JournalList);
+Vue.component('JournalRateDay', JournalRateDay);
+Vue.component('JournalCalendar', JournalCalendar);
+Vue.component('JournalContentRate', JournalContentRate);
+Vue.component('JournalContentActivity', JournalContentActivity);
+Vue.component('JournalContentEntry', JournalContentEntry);
 
 // Settings
-Vue.component(
-  'ContactFieldTypes',
-  require('./components/settings/ContactFieldTypes.vue').default
-);
-Vue.component(
-  'Genders',
-  require('./components/settings/Genders.vue').default
-);
-Vue.component(
-  'ReminderRules',
-  require('./components/settings/ReminderRules.vue').default
-);
-Vue.component(
-  'ReminderTime',
-  require('./components/settings/ReminderTime.vue').default
-);
-Vue.component(
-  'MfaActivate',
-  require('./components/settings/MfaActivate.vue').default
-);
-Vue.component(
-  'WebauthnConnector',
-  require('./components/settings/WebauthnConnector.vue').default
-);
-Vue.component(
-  'RecoveryCodes',
-  require('./components/settings/RecoveryCodes.vue').default
-);
-Vue.component(
-  'Modules',
-  require('./components/settings/Modules.vue').default
-);
-Vue.component(
-  'ActivityTypes',
-  require('./components/settings/ActivityTypes.vue').default
-);
-Vue.component(
-  'LifeEventTypes',
-  require('./components/settings/LifeEventTypes.vue').default
-);
-Vue.component(
-  'DavResources',
-  require('./components/settings/DAVResources.vue').default
-);
-
-require('./testing');
-
-var common = require('./common').default;
+Vue.component('ContactFieldTypes', ContactFieldTypes);
+Vue.component('Genders', Genders);
+Vue.component('ReminderRules', ReminderRules);
+Vue.component('ReminderTime', ReminderTime);
+Vue.component('MfaActivate', MfaActivate);
+Vue.component('WebauthnConnector', WebauthnConnector);
+Vue.component('RecoveryCodes', RecoveryCodes);
+Vue.component('Modules', Modules);
+Vue.component('ActivityTypes', ActivityTypes);
+Vue.component('LifeEventTypes', LifeEventTypes);
+Vue.component('DavResources', DavResources);
 
 common.loadLanguage(window.Laravel.locale, true).then((i18n) => {
   // the Vue appplication
@@ -329,7 +200,7 @@ common.loadLanguage(window.Laravel.locale, true).then((i18n) => {
     },
 
     // global methods
-    methods: require('./methods').default
+    methods,
   }).$mount('#app');
 
   return app;

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -1,31 +1,28 @@
-window._ = require('lodash');
+import _ from 'lodash';
+import Popper from 'popper.js';
+import jQuery from 'jquery';
+import axios from 'axios';
 
-/**
- * We'll load jQuery and the Bootstrap jQuery plugin which provides support
- * for JavaScript based Bootstrap features such as modals and tabs. This
- * code may be modified to fit the specific needs of your application.
- */
+// Bootstrap 4 jQuery plugins — side-effect imports that attach methods to
+// jQuery.fn. The plugins import jquery as an ESM dep themselves, so the
+// bundler hands them the same singleton we use here.
+import 'bootstrap/js/dist/util';
+import 'bootstrap/js/dist/button';
+import 'bootstrap/js/dist/collapse';
+import 'bootstrap/js/dist/dropdown';
+import 'bootstrap/js/dist/modal';
+import 'bootstrap/js/dist/tab';
 
-try {
-  window.Popper = require('popper.js').default;
-  window.$ = window.jQuery = require('jquery');
-
-  require('bootstrap/js/dist/util');
-  require('bootstrap/js/dist/button');
-  require('bootstrap/js/dist/collapse');
-  require('bootstrap/js/dist/dropdown');
-  require('bootstrap/js/dist/modal');
-  require('bootstrap/js/dist/tab');
-} catch (e) {}
-
+window._ = _;
+window.Popper = Popper;
+window.$ = window.jQuery = jQuery;
+window.axios = axios;
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests
  * to our Laravel back-end. This library automatically handles sending the
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
-
-window.axios = require('axios');
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
@@ -36,12 +33,12 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
  */
 
 // import Echo from 'laravel-echo'
-
-// window.Pusher = require('pusher-js');
-
+//
+// window.Pusher = Pusher;
+//
 // window.Echo = new Echo({
 //     broadcaster: 'pusher',
-//     key: process.env.MIX_PUSHER_APP_KEY,
-//     cluster: process.env.MIX_PUSHER_APP_CLUSTER,
+//     key: import.meta.env.VITE_PUSHER_APP_KEY,
+//     cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
 //     encrypted: true
 // });

--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -3,6 +3,10 @@
 // axios
 import axios from 'axios';
 
+// Vue (imported explicitly rather than relying on window.Vue — modules are
+// singletons, so this is the same instance app.js/stripe.js use.)
+import Vue from 'vue';
+
 // i18n
 import VueI18n from 'vue-i18n';
 Vue.use(VueI18n);

--- a/resources/js/components/dashboard/DashboardLog.vue
+++ b/resources/js/components/dashboard/DashboardLog.vue
@@ -203,7 +203,7 @@
                 {{ $t('dashboard.task_add_cta') }}
               </a>
             </p>
-            <img src="img/dashboard/blank_your_tasks.svg" :alt="$t('dashboard.tasks_tab_your_tasks')" />
+            <img src="/img/dashboard/blank_your_tasks.svg" :alt="$t('dashboard.tasks_tab_your_tasks')" />
           </div>
 
           <!-- Add a task -->

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -83,7 +83,7 @@
            class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc"
       >
         <div class="tc mb4">
-          <img src="img/journal/blank.svg" :alt="$t('journal.journal_empty')" />
+          <img src="/img/journal/blank.svg" :alt="$t('journal.journal_empty')" />
         </div>
         <h3>
           {{ $t('journal.journal_blank_cta') }}

--- a/resources/js/components/partials/form/Checkbox.vue
+++ b/resources/js/components/partials/form/Checkbox.vue
@@ -1,5 +1,5 @@
 <script>
-const input = require('./PInput').default;
+import input from './PInput';
 
 const checkbox = {
   name: 'checkbox',

--- a/resources/js/components/partials/form/Radio.vue
+++ b/resources/js/components/partials/form/Radio.vue
@@ -1,5 +1,5 @@
 <script>
-const input = require('./PInput').default;
+import input from './PInput';
 
 const radio = {
   name: 'radio',

--- a/resources/js/components/people/Addresses.vue
+++ b/resources/js/components/people/Addresses.vue
@@ -362,7 +362,7 @@ export default {
     toggleEditExcept(contactAddressId) {
       _.forEach(_.filter(this.contactAddresses, function (a) {
         return a.id !== contactAddressId;}
-      ), function (a) {
+      ), (a) => {
         this.$set(a, 'edit', false);
       });
     },

--- a/resources/js/components/people/Addresses.vue
+++ b/resources/js/components/people/Addresses.vue
@@ -347,7 +347,7 @@ export default {
     toggleEdit(contactAddress) {
       this.addMode = false;
       this.toggleEditExcept(contactAddress.id);
-      Vue.set(contactAddress, 'edit', !contactAddress.edit);
+      this.$set(contactAddress, 'edit', !contactAddress.edit);
       this.updateForm.id = contactAddress.id;
       this.updateForm.name = contactAddress.name;
       this.updateForm.street = contactAddress.street;
@@ -363,7 +363,7 @@ export default {
       _.forEach(_.filter(this.contactAddresses, function (a) {
         return a.id !== contactAddressId;}
       ), function (a) {
-        Vue.set(a, 'edit', false);
+        this.$set(a, 'edit', false);
       });
     },
 
@@ -381,12 +381,12 @@ export default {
 
     update(contactAddress) {
       var vm = this;
-      Vue.set(contactAddress, 'edit', !contactAddress.edit);
+      this.$set(contactAddress, 'edit', !contactAddress.edit);
       this.persistClient(
         'put', 'people/' + this.hash + '/addresses/' + contactAddress.id,
         this.updateForm
       ).then(response => {
-        Vue.set(vm.contactAddresses, vm.contactAddresses.indexOf(vm.contactAddresses.find(item => item.id === response.data.id)), response.data);
+        this.$set(vm.contactAddresses, vm.contactAddresses.indexOf(vm.contactAddresses.find(item => item.id === response.data.id)), response.data);
       });
     },
 

--- a/resources/js/components/people/ContactInformation.vue
+++ b/resources/js/components/people/ContactInformation.vue
@@ -214,7 +214,7 @@ export default {
     },
 
     toggleEdit(contactField) {
-      Vue.set(contactField, 'edit', !contactField.edit);
+      this.$set(contactField, 'edit', !contactField.edit);
       this.updateForm.id = contactField.id;
       this.updateForm.data = contactField.data;
       this.updateForm.contact_field_type_id = contactField.contact_field_type_id;

--- a/resources/js/components/people/Notes.vue
+++ b/resources/js/components/people/Notes.vue
@@ -149,7 +149,7 @@ export default {
     },
 
     toggleEditMode(note) {
-      Vue.set(note, 'edit', !note.edit);
+      this.$set(note, 'edit', !note.edit);
     },
 
     getNotes() {
@@ -185,7 +185,7 @@ export default {
     update(note) {
       axios.put('people/' + this.hash + '/notes/' + note.id, note)
         .then(response => {
-          Vue.set(note, 'edit', false);
+          this.$set(note, 'edit', false);
 
           this.$notify({
             group: 'main',

--- a/resources/js/components/people/Pets.vue
+++ b/resources/js/components/people/Pets.vue
@@ -204,7 +204,7 @@ export default {
     },
 
     toggleEdit(pet) {
-      Vue.set(pet, 'edit', !pet.edit);
+      this.$set(pet, 'edit', !pet.edit);
       this.updateForm.id = pet.id;
       this.updateForm.name = pet.name;
       this.updateForm.pet_category_id = pet.pet_category_id;
@@ -213,10 +213,10 @@ export default {
     update(pet) {
       axios.put('people/' + this.hash + '/pets/' + pet.id, this.updateForm)
         .then(response => {
-          Vue.set(pet, 'edit', !pet.edit);
-          Vue.set(pet, 'name', response.data.name);
-          Vue.set(pet, 'pet_category_id', response.data.pet_category_id);
-          Vue.set(pet, 'category_name', response.data.category_name);
+          this.$set(pet, 'edit', !pet.edit);
+          this.$set(pet, 'name', response.data.name);
+          this.$set(pet, 'pet_category_id', response.data.pet_category_id);
+          this.$set(pet, 'category_name', response.data.category_name);
 
           this.$notify({
             group: 'main',

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -171,6 +171,7 @@ import { SweetModal } from 'sweet-modal-vue';
 import { ToggleButton } from 'vue-js-toggle-button';
 import { validationMixin } from 'vuelidate';
 import { required, numeric } from 'vuelidate/lib/validators';
+import moment from 'moment-timezone';
 import StayInTouchLabel from './StayInTouchLabel';
 
 export default {
@@ -246,7 +247,6 @@ export default {
     },
 
     formatDate(dateAsString) {
-      const moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
       var date = moment.tz(moment(dateAsString), this.$root.timezone);

--- a/resources/js/components/people/Tasks.vue
+++ b/resources/js/components/people/Tasks.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div>
-      <img src="img/people/tasks.svg" :alt="$t('people.tasks_title')" class="icon-section icon-tasks" />
+      <img src="/img/people/tasks.svg" :alt="$t('people.tasks_title')" class="icon-section icon-tasks" />
       <h3>
         {{ $t('people.section_personal_tasks') }}
 
@@ -145,6 +145,8 @@
 </template>
 
 <script>
+import moment from 'moment-timezone';
+
 export default {
 
   props: {
@@ -210,7 +212,7 @@ export default {
     },
 
     toggleEditMode(task) {
-      Vue.set(task, 'edit', !task.edit);
+      this.$set(task, 'edit', !task.edit);
     },
 
     index() {
@@ -239,7 +241,7 @@ export default {
 
     toggleComplete(task) {
       this.updateMode = true;
-      Vue.set(task, 'disabled', true);
+      this.$set(task, 'disabled', true);
       this.update(task, false);
     },
 
@@ -247,8 +249,8 @@ export default {
       axios.put('tasks/' + task.id, task)
         .then(response => {
           this.updateMode = false;
-          Vue.set(task, 'disabled', false);
-          Vue.set(task, 'completed_at', response.data.completed_at ? this.formatDate(response.data.completed_at): null);
+          this.$set(task, 'disabled', false);
+          this.$set(task, 'completed_at', response.data.completed_at ? this.formatDate(response.data.completed_at): null);
           if (toggleEdit) {
             this.toggleEditMode(task);
           }
@@ -262,7 +264,6 @@ export default {
     },
 
     formatDate(dateAsString) {
-      const moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
 

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -219,7 +219,7 @@ export default {
     updateList(activity) {
       this.displayLogActivity = false;
       const index = this.activities.indexOf(this.activities.find(item => item.id === activity.id));
-      Vue.set(this.activities, index >= 0 ? index : this.activities.length, activity);
+      this.$set(this.activities, index >= 0 ? index : this.activities.length, activity);
     },
 
     showDestroyActivity(activity) {

--- a/resources/js/components/people/document/DocumentList.vue
+++ b/resources/js/components/people/document/DocumentList.vue
@@ -231,6 +231,8 @@
 </template>
 
 <script>
+import moment from 'moment-timezone';
+
 export default {
 
   props: {
@@ -291,7 +293,6 @@ export default {
     },
 
     formatTime(dateAsString) {
-      var moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
 
       var date = moment(dateAsString);

--- a/resources/js/components/people/gifts/Gift.vue
+++ b/resources/js/components/people/gifts/Gift.vue
@@ -70,6 +70,7 @@
 <script>
 
 import { SweetModal } from 'sweet-modal-vue';
+import moment from 'moment-timezone';
 
 export default {
 
@@ -106,7 +107,6 @@ export default {
     },
 
     formatDate(dateAsString) {
-      const moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
 

--- a/resources/js/components/people/gifts/Gifts.vue
+++ b/resources/js/components/people/gifts/Gifts.vue
@@ -4,7 +4,7 @@
 
     <!-- Title -->
     <div>
-      <img src="img/people/gifts.svg" :alt="$t('people.gifts_title')" class="icon-section icon-tasks" />
+      <img src="/img/people/gifts.svg" :alt="$t('people.gifts_title')" class="icon-section icon-tasks" />
       <h3>
         {{ $t('people.gifts_title') }}
         <a v-cy-name="'add-gift-button'" href="" class="btn f6 pt2" :class="[ dirltr ? 'fr' : 'fl' ]"
@@ -212,8 +212,8 @@ export default {
       gift.contact_id = this.contactId;
       axios.put(`people/${this.hash}/gifts/${gift.id}`, gift)
         .then(response => {
-          Vue.set(gift, 'status', response.data.data.status);
-          Vue.set(gift, 'date', response.data.data.date);
+          this.$set(gift, 'status', response.data.data.status);
+          this.$set(gift, 'date', response.data.data.date);
         });
     },
 

--- a/resources/js/components/people/photo/PhotoList.vue
+++ b/resources/js/components/people/photo/PhotoList.vue
@@ -34,7 +34,7 @@
         <h3 class="mb4 mt3">
           {{ $t('people.photo_list_blank_desc') }}
         </h3>
-        <img src="img/people/photos/photos_empty.svg" :alt="$t('people.photo_title')" class="w-50 center" />
+        <img src="/img/people/photos/photos_empty.svg" :alt="$t('people.photo_title')" class="w-50 center" />
       </div>
     </div>
 

--- a/resources/js/components/settings/ReminderTime.vue
+++ b/resources/js/components/settings/ReminderTime.vue
@@ -30,6 +30,8 @@
 </template>
 
 <script>
+import moment from 'moment-timezone';
+
 export default {
 
   props: {
@@ -85,7 +87,6 @@ export default {
     },
 
     computeMessage() {
-      var moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
 

--- a/resources/js/components/settings/WebauthnConnector.vue
+++ b/resources/js/components/settings/WebauthnConnector.vue
@@ -175,6 +175,7 @@
 
 <script>
 import { SweetModal } from 'sweet-modal-vue';
+import moment from 'moment-timezone';
 import * as WebAuthn from '../../../../vendor/asbiin/laravel-webauthn/resources/js/webauthn.js';
 
 export default {
@@ -379,7 +380,6 @@ export default {
     },
 
     formatTime(value) {
-      var moment = require('moment-timezone');
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
 

--- a/resources/js/stripe.js
+++ b/resources/js/stripe.js
@@ -5,7 +5,7 @@
  * building robust, powerful web applications using Vue and Laravel.
  */
 
-require('./bootstrap');
+import './bootstrap';
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to
@@ -14,30 +14,24 @@ require('./bootstrap');
  */
 
 import Vue from 'vue';
+import Notifications from 'vue-notification';
+import StripeSubscription from './components/settings/Subscription.vue';
+import FormInput from './components/partials/form/Input.vue';
+import ContactSearch from './components/people/ContactSearch.vue';
+import common from './common';
+
 window.Vue = Vue;
 
 // Notifications
-import Notifications from 'vue-notification';
 Vue.use(Notifications);
 
 // Custom components
-Vue.component(
-  'StripeSubscription',
-  require('./components/settings/Subscription.vue').default
-);
+Vue.component('StripeSubscription', StripeSubscription);
 
 // Form elements
-Vue.component(
-  'FormInput',
-  require('./components/partials/form/Input.vue').default
-);
+Vue.component('FormInput', FormInput);
 
-Vue.component(
-  'ContactSearch',
-  require('./components/people/ContactSearch.vue').default
-);
-
-var common = require('./common').default;
+Vue.component('ContactSearch', ContactSearch);
 
 common.loadLanguage(window.Laravel.locale, true).then((i18n) => {
   // the Vue appplication

--- a/resources/js/testing.js
+++ b/resources/js/testing.js
@@ -3,6 +3,8 @@
  * These are only active on local or testing environment.
  */
 
+import Vue from 'vue';
+
 function testingDirective(el, binding, vnode) {
   if (window.Laravel.env != 'production') {
     var value = '';

--- a/tests/cypress/component/Addresses.cy.js
+++ b/tests/cypress/component/Addresses.cy.js
@@ -1,0 +1,131 @@
+import Vue from 'vue';
+import _ from 'lodash';
+import Addresses from '../../../resources/js/components/people/Addresses.vue';
+
+const $t = (key, params) => (params ? `${key}:${JSON.stringify(params)}` : key);
+
+function makeAxiosStub() {
+  return {
+    get: cy.stub().callsFake((url) => {
+      if (url.endsWith('/addresses')) return Promise.resolve({ data: [] });
+      if (url === 'countries') return Promise.resolve({ data: [] });
+      return Promise.resolve({ data: [] });
+    }),
+    put: cy.stub().resolves({ data: {} }),
+    post: cy.stub().resolves({ data: {} }),
+    delete: cy.stub().resolves({ data: {} }),
+  };
+}
+
+function makeAddress(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Home',
+    street: '',
+    city: '',
+    province: '',
+    postal_code: '',
+    country: '',
+    latitude: 0,
+    longitude: 0,
+    edit: false,
+    ...overrides,
+  };
+}
+
+function mountAddresses() {
+  const SweetModalStub = { template: '<div><slot></slot></div>' };
+  const PassthroughInput = { template: '<input />' };
+  const PassthroughSelect = { template: '<select></select>' };
+  const ConfirmStub = { template: '<div></div>' };
+
+  return cy.mount(
+    {
+      name: 'AddressesHost',
+      template: `<Addresses ref="addresses" :hash="'abc'" />`,
+      components: { Addresses },
+      data() {
+        return { htmldir: 'ltr' };
+      },
+    },
+    {
+      stubs: {
+        SweetModal: SweetModalStub,
+        'sweet-modal': SweetModalStub,
+        FormInput: PassthroughInput,
+        'form-input': PassthroughInput,
+        FormSelect: PassthroughSelect,
+        'form-select': PassthroughSelect,
+        Confirm: ConfirmStub,
+        confirm: ConfirmStub,
+      },
+      mocks: { $t, $tc: $t },
+    },
+  ).as('mounted');
+}
+
+function withAddresses(callback) {
+  return cy.get('@mounted').then(({ wrapper }) =>
+    callback(wrapper.vm.$refs.addresses, wrapper)
+  );
+}
+
+describe('Addresses.vue regression coverage', () => {
+  beforeEach(() => {
+    // Production wires lodash + axios onto window from resources/js/bootstrap.js.
+    // Component tests don't load bootstrap.js, so set them up here — the SUT
+    // calls bare `_.forEach(...)` and `axios.get(...)` expecting the globals.
+    cy.window().then((win) => {
+      win._ = _;
+      win.axios = makeAxiosStub();
+    });
+  });
+
+  it('toggleEditExcept clears `edit` on all other addresses without throwing', () => {
+    // Regression coverage for PR #684 (require→import sweep). The PR rewrote
+    // `Vue.set(a, 'edit', false)` inside a non-arrow `_.forEach` callback to
+    // `this.$set(a, 'edit', false)`. The callback is a `function(a) { ... }`
+    // and lodash 4 does not pass a thisArg, so under strict mode (which all
+    // ESM-compiled SFC <script> blocks run in) `this` is `undefined` and the
+    // call throws TypeError.
+    //
+    // Reachable path: contact with ≥2 addresses → user clicks edit on one →
+    // `toggleEdit` → `toggleEditExcept` → throw.
+    mountAddresses();
+
+    const a1 = makeAddress({ id: 1, name: 'Home', edit: true });
+    const a2 = makeAddress({ id: 2, name: 'Work', edit: true });
+
+    withAddresses((addresses) => {
+      addresses.contactAddresses = [a1, a2];
+    });
+
+    withAddresses((addresses) => {
+      expect(() => addresses.toggleEditExcept(1)).to.not.throw();
+      expect(addresses.contactAddresses[1].edit).to.equal(false);
+      // The targeted address (id=1) is intentionally left untouched —
+      // toggleEditExcept only clears the OTHERS. toggleEdit() handles
+      // toggling the targeted one.
+      expect(addresses.contactAddresses[0].edit).to.equal(true);
+    });
+  });
+
+  it('toggleEdit on one of multiple addresses keeps siblings collapsed', () => {
+    // End-to-end of the same bug at the public API level: toggleEdit is what
+    // the v-on:click binding in the template actually calls.
+    mountAddresses();
+
+    const a1 = makeAddress({ id: 1, name: 'Home', edit: false });
+    const a2 = makeAddress({ id: 2, name: 'Work', edit: true });
+
+    withAddresses((addresses) => {
+      addresses.contactAddresses = [a1, a2];
+    });
+
+    withAddresses((addresses) => {
+      expect(() => addresses.toggleEdit(addresses.contactAddresses[0])).to.not.throw();
+      expect(addresses.contactAddresses[0].edit).to.equal(true);
+      expect(addresses.contactAddresses[1].edit).to.equal(false);
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,14 @@ export default defineConfig({
       ],
       refresh: true,
     }),
-    vue(),
+    vue({
+      template: {
+        // SFC templates reference public assets like <img src="/img/foo.svg"> that
+        // Laravel serves from public/. Don't try to resolve them as bundled modules.
+        // The Blade <base href="..."> tag handles URL resolution at runtime.
+        transformAssetUrls: false,
+      },
+    }),
   ],
   resolve: {
     alias: [
@@ -33,6 +40,8 @@ export default defineConfig({
       // cutover when webpack.mix.js is deleted and SCSS tildes go with it.
       { find: /^~(.+)$/, replacement: path.resolve(__dirname, 'node_modules/$1') },
     ],
+    // Match webpack/Mix's default: resolve .vue imports without explicit extension.
+    extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
   },
   build: {
     sourcemap: true,


### PR DESCRIPTION
## Summary

Converts the 87 `require()` calls in `resources/js` to static ESM `import` statements. Prep for the Mix → Vite cutover: esbuild-bundled Vite output runs as `<script type="module">` in the browser, which has no CommonJS `require()` symbol — so the existing `require('./Foo.vue').default` pattern needs to become `import Foo from './Foo.vue'`.

Webpack/Mix handles either form natively, so this PR is **forward-compatible with both bundlers**.

## Stack

PR **2 of 4**. Stacked on top of [PR-V₁](../pull/683) (Vite scaffolding).

## Why this matters

The PR-V₁ smoke caught a runtime failure when the Vite-built bundle was loaded in a browser:

```
ReferenceError: require is not defined
  at /build/assets/app-mvB2m2zn.js:2:36980
```

That's this PR's fix — convert the `require()` patterns wholesale so the same source compiles to runnable output under both bundlers.

## Changes

- **`app.js`** — 63 sites converted. Component imports hoisted to the top of the file with named identifiers, `Vue.component('Name', Component)` calls grouped below by domain. Same organisational comments preserved.
- **`stripe.js`** — 3 sites converted, same shape.
- **`bootstrap.js`** — lodash, jQuery, popper.js, axios, and 6 `bootstrap/js/dist/*` side-effect imports moved to ESM. `window.{_,$,jQuery,Popper,axios}` still set for the codebase's legacy globals. The Bootstrap 4 jQuery plugins import jQuery themselves; module-singleton semantics give them the same instance.
- **6 SFCs** (`ReminderTime`, `WebauthnConnector`, `StayInTouch`, `Tasks`, `DocumentList`, `Gift`) — `require('moment-timezone')` moved out of method bodies into top-of-script imports.
- **`common.js` + `testing.js`** — added explicit `import Vue from 'vue'` rather than relying on `window.Vue`. ESM hoisting evaluates all imports before any executable code, so `window.Vue = Vue` isn't set yet when these modules' top-level `Vue.use()` / `Vue.directive()` calls would run. Module-singleton semantics guarantee this is the same Vue instance `app.js` uses.
- **7 SFCs** (`Notes`, `Tasks`, `ContactInformation`, `Gifts`, `Pets`, `Addresses`, `ActivityList`) — `Vue.set(...)` → `this.$set(...)` (19 sites). Same API, but bound to the component instance rather than the global Vue object. Matches Vue's own recommendation (https://v2.vuejs.org/v2/api/#vm-set) and eliminates 19 globals.
- **`Radio.vue` / `Checkbox.vue` / `PInput` chain** — no longer `require('./PInput').default`; just `import input from './PInput'`.
- **5 SFCs** (`JournalList`, `DashboardLog`, `Tasks`, `Gifts`, `PhotoList`) — `src="img/..."` on `<img>` tags became `src="/img/..."`. Vite/Rollup's Vue template asset-URL transform was trying to resolve the relative paths as bundled modules. Absolute paths land in the rendered HTML unchanged, and `<base href="...">` in the Blade layout resolves them at runtime exactly like before for root-served deployments. (Note: this makes the 5 SFCs subpath-incompatible — tracked separately in #687, "Support subpath deployments".)

## `vite.config.js` tweaks

- Added `.vue` to `resolve.extensions` so extension-less imports of Vue SFCs still resolve (matches webpack's default behaviour).
- `vue()` plugin: passed `template: { transformAssetUrls: false }`. The codebase uses `public/` asset paths via `<base href>`, not bundled imports, so the transform is the wrong tool here.

## Review-cycle changes (post-initial-push)

1. **`Addresses.vue` runtime bug fix.** The original V₂ push rewrote `Vue.set(a, 'edit', false)` inside a non-arrow `_.forEach(...)` callback to `this.$set(a, 'edit', false)`. The callback is a `function(a) { ... }` and lodash 4 does not pass a `thisArg`, so under strict mode (which all ESM-compiled SFC `<script>` blocks run in) `this` is `undefined` and the call throws `TypeError: Cannot read properties of undefined (reading '$set')`. Reachable when a contact has ≥2 addresses and the user clicks edit on one. Fix: convert the inner callback to an arrow function. Covered by a new Cypress component test at `tests/cypress/component/Addresses.cy.js` — the test fails 2/2 on the pre-fix code with the exact predicted TypeError, passes 2/2 after the arrow fix.

2. **`bootstrap.js` `try/catch` removal**, on purpose. The wrapper was a Snyk-bot artifact from [`#2672`](https://github.com/monicahq/monica/pull/2672) (2019 Bootstrap 3 → 4 auto-upgrade). It silently swallowed module-resolution errors with zero logging. In ESM it's also structurally moot — `import` is parse-time, errors surface before any executable code runs. More importantly, during the modernization-ladder rungs we **want** module failures to surface loudly; silent error eaters mask exactly the regressions a dependency upgrade is meant to learn about.

## Test plan

- [x] `yarn run lint` clean
- [x] `yarn run dev` (Mix) builds; dashboard renders in browser, Vue 2.7.16 mounts with all components registered, jQuery + Bootstrap modal plugin available, 0 console errors
- [x] `yarn run vite:build` builds cleanly into `public/build/`. Blade temp-flipped to `@vite()`, output copied into container, dashboard renders, Vue 2.7.16 mounts (11 child components), 0 JS console errors. Blade revert verified clean.
- [x] The runtime blocker the PR-V₁ smoke caught (`ReferenceError: require is not defined`) is gone under both bundlers.
- [x] `tests/cypress/component/Addresses.cy.js` — 2/2 passing post-fix.

## Remaining cutover blockers (PR-V₄ scope, unchanged from PR-V₁)

- font-awesome 4 `url()` resolution still produces 404s under Vite
- PurgeCSS not yet wired into the Vite pipeline (addressed in PR-V₃)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
