### PR TITLE
build(css): wire postcss-purgecss into vite pipeline (phase 3 PR-V₃)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@cypress/vue2": "^2.1.1",
     "@cypress/webpack-dev-server": "^5.6.1",
     "@faker-js/faker": "^10.0.0",
+    "@fullhuman/postcss-purgecss": "^8.0.0",
     "@snyk/protect": "^1.1305.0",
     "@vitejs/plugin-vue2": "~2.3",
     "cross-env": "^10.1.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue2';
+import purgecss from '@fullhuman/postcss-purgecss';
 import path from 'node:path';
 
 // Mix → Vite phase 3 PR-V₁: additive only. Mix still owns production builds
@@ -10,7 +11,7 @@ import path from 'node:path';
 //
 // Vue 2 ceiling: @vitejs/plugin-vue2 is archived (2025-10-04, vitejs/vite-plugin-vue2)
 // and peers vite ^3–^7. Pin vite to ~7 until Vue 3 migration lifts the cap.
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     laravel({
       input: [
@@ -46,4 +47,46 @@ export default defineConfig({
   build: {
     sourcemap: true,
   },
-});
+  css: {
+    // PurgeCSS wired via Vite's css.postcss option rather than a postcss.config.js
+    // at the project root — that file would also be picked up by Mix's
+    // postcss-loader and double-purge. Production builds only; dev builds keep
+    // every selector for fast iteration. Safelist ported verbatim from
+    // webpack.mix.js. Removed in PR-V₄ when laravel-mix-purgecss exits.
+    postcss: {
+      plugins: mode === 'production' ? [
+        purgecss({
+          content: [
+            './resources/views/**/*.blade.php',
+            './resources/js/**/*.vue',
+            './resources/js/**/*.js',
+            './app/**/*.php',
+          ],
+          safelist: {
+            standard: [
+              /^autosuggest/,
+              /^fa-/,
+              /^vdp-datepicker/,
+              /^StripeElement/,
+              /^vgt/,
+              /^vue-tooltip/,
+              /^pretty/,
+              /^sweet-/,
+              /^vuejs-clipper-basic/,
+              /^vs__/,
+              /^sr-only/,
+            ],
+            deep: [
+              /^vdp-datepicker/,
+              /^vgt/,
+              /^vue-tooltip/,
+              /^pretty/,
+              /^sweet-/,
+              /^vs-/,
+            ],
+          },
+        }),
+      ] : [],
+    },
+  },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,6 +1353,13 @@
   dependencies:
     purgecss "^3.1.3"
 
+"@fullhuman/postcss-purgecss@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-8.0.0.tgz#b828aab4a7ff30882f7ad748e9d8cc275b72593b"
+  integrity sha512-fSRaBGf6+DYdfQMxedWfnIW8FSYE1LBpgy16jpK1L2vNb1HgeBRRZ+UX4UokNmW7YEAwPdvwkKdYtlkYpH+Aqg==
+  dependencies:
+    purgecss "^8.0.0"
+
 "@hokify/vuejs-datepicker@^2.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@hokify/vuejs-datepicker/-/vuejs-datepicker-2.0.2.tgz#17c747feb69696a70e224be450d48e9ea00f0160"
@@ -2948,6 +2955,13 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
@@ -3354,6 +3368,11 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
@@ -4568,6 +4587,17 @@ fast-glob@^3.0.3:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.2:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4633,6 +4663,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -6053,6 +6090,14 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -6925,6 +6970,14 @@ postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4, postcss-selector
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
+  integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-svgo@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.1.0.tgz#0a317400ced789f233a28826e77523f15857d80d"
@@ -6962,7 +7015,7 @@ postcss@^8.2.1, postcss@^8.2.15, postcss@^8.4.14:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.2.14, postcss@^8.5.15, postcss@^8.5.6:
+postcss@^8.2.14, postcss@^8.4.47, postcss@^8.5.15, postcss@^8.5.6:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
@@ -7083,6 +7136,16 @@ purgecss@^3.1.3:
     glob "^7.0.0"
     postcss "^8.2.1"
     postcss-selector-parser "^6.0.2"
+
+purgecss@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-8.0.0.tgz#4716eaeb398364aaefd6ab7808427a9e2621bbea"
+  integrity sha512-QFJyps9y5oHeXnNA3Ql1EaAqWBivNwQn19Pw1lt9RxfB+4e+bIyqCyuombk79D6Fxe+lPXggVfI1WtRGEBwgbQ==
+  dependencies:
+    commander "^12.1.0"
+    fast-glob "^3.3.2"
+    postcss "^8.4.47"
+    postcss-selector-parser "^7.0.0"
 
 pvtsutils@^1.3.6:
   version "1.3.6"


### PR DESCRIPTION
## Summary

Wires `@fullhuman/postcss-purgecss` into the Vite pipeline. CSS output drops from **521 KB → 226 KB (−57%)**, matching the existing Mix production output of ~225 KB.

Production builds only; dev builds keep every selector for fast iteration.

## Stack

PR **3 of 4**. Stacked on top of [PR-V₂](../pull/?) (require → import sweep).

## Key decision

PurgeCSS wired via `vite.config.js`'s `css.postcss` option, **NOT** a project-root `postcss.config.js`. A root config would be auto-discovered by Mix's `postcss-loader` too — and we'd double-purge under both bundlers during the parallel phase.

## Changes

- **`vite.config.js`** — `defineConfig` switched to mode-aware function (`({ mode }) => ({...})`) so PurgeCSS only runs in `vite build` (production), not `vite dev`. Safelist ported verbatim from `webpack.mix.js`'s `purgeCssOptions` — 11 `standard` regexes and 6 `deep` regexes. Content paths cover Blade templates, Vue SFCs, JS, and `app/**/*.php` controllers.
- **`package.json`** — `@fullhuman/postcss-purgecss@^8` added to devDeps.

## Safelist (verbatim port)

```
standard:
  /^autosuggest/, /^fa-/, /^vdp-datepicker/, /^StripeElement/,
  /^vgt/, /^vue-tooltip/, /^pretty/, /^sweet-/,
  /^vuejs-clipper-basic/, /^vs__/, /^sr-only/

deep:
  /^vdp-datepicker/, /^vgt/, /^vue-tooltip/, /^pretty/,
  /^sweet-/, /^vs-/
```

## Test plan

- [x] `yarn run vite:build` — CSS output 521 KB → 226 KB (−57%); matches Mix ~225 KB baseline. `app-ltr-*.css` and `app-rtl-*.css` both drop from 261 KB to 113 KB. JS output unchanged.
- [x] Blade temp-flipped to `@vite()`; dashboard + `/people` render cleanly. Navbar styled, contact list table styled, `bg-gray-monica` background, "Add someone" button, upgrade-account sidebar — all visually intact. 0 console errors from PurgeCSS over-aggression.
- [x] `yarn run dev` (Mix) still builds clean. No `postcss.config.js` at project root, so Mix's webpack pipeline is untouched.

## Remaining cutover blockers (PR-V₄ scope, unchanged)

- font-awesome 4 `url()` resolution under Vite (`/build/fonts/*.woff` 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
