### PR TITLE
fix(deps): bump symfony/polyfill-intl-idn to v1.38.1 (CVE-2026-46644)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9878,16 +9878,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -9941,7 +9941,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -9961,7 +9961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",


### PR DESCRIPTION
## Summary

Bumps `symfony/polyfill-intl-idn` from **v1.37.0** to **v1.38.1** to clear [CVE-2026-46644](https://symfony.com/cve-2026-46644), published 2026-05-26.

```
| Package           | symfony/polyfill-intl-idn                                                        |
| Advisory ID       | PKSA-dwsq-ppd2-mb1x                                                              |
| CVE               | CVE-2026-46644                                                                   |
| Title             | symfony/polyfill-intl-idn accepts xn-- labels whose Punycode                     |
|                   | payload decodes to ASCII-only: insecure equivalence                              |
| Affected versions | >=1.17.1, <1.38.1                                                                |
| Reported at       | 2026-05-26T08:00:00+00:00                                                        |
```

Closes #689.

## Why this PR

Caught by `composer audit` in the Build Assets workflow. The advisory was published yesterday, so every open PR (including the Mix→Vite migration stack at #683/#684/#685/#686) is now CI-red on Build Assets regardless of code changes. Landing this on `4.x` unblocks the queue.

Exposure analysis (full trace in #689): Monica never does `normalize-then-compare` on email/domain values — user lookups are exact-string MySQL equality, and the egulias validator's IDN code path is gated behind a non-ASCII-byte check that excludes the CVE's "ASCII-only Punycode payload" trigger. So this is `composer audit` hygiene rather than a patch against a live exploit on Monica's own surface. Still rung #4 (security patches against the current dependency graph).

## Change

Surgical update via `composer update symfony/polyfill-intl-idn`:

```
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading symfony/polyfill-intl-idn (v1.37.0 => v1.38.1)
```

No other packages touched. The spatie/ray suppression documented in CLAUDE.md's "Composer wrinkles" section is preserved (the `replace` block in `composer.json` is unchanged, and the lock still has no spatie/ray entries).

## Verification

```
$ composer audit
No security vulnerability advisories found.
```

## Test plan

- [x] `composer install` succeeds without reintroducing the suppressed spatie/ray transitive chain
- [x] `composer audit` returns 0 advisories post-update
- [ ] CI Build Assets passes (was failing on this advisory across every open PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
