### PR TITLE
chore(deps): bump vite-plugin-static-copy 2 → 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "laravel-vite-plugin": "~2.1",
     "postcss": "^8.5.15",
     "vite": "~7",
-    "vite-plugin-static-copy": "^2"
+    "vite-plugin-static-copy": "^3"
   },
   "dependencies": {
     "@hokify/vuejs-datepicker": "^2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,10 +822,10 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+chokidar@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -1425,7 +1425,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.3.2:
+fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -1541,15 +1541,6 @@ form-data@^4.0.5, form-data@~4.0.4:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
     mime-types "^2.1.12"
-
-fs-extra@^11.1.0:
-  version "11.3.5"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.5.tgz#07a44eff40bea53e719909a532f91a23bf0769ff"
-  integrity sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
 
 fs-extra@^9.1.0:
   version "9.1.0"
@@ -2245,7 +2236,7 @@ p-locate@^6.0.0:
   dependencies:
     p-limit "^4.0.0"
 
-p-map@^7.0.3:
+p-map@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-7.0.4.tgz#b81814255f542e252d5729dca4d66e5ec14935b8"
   integrity sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==
@@ -2898,16 +2889,15 @@ vite-plugin-full-reload@^1.1.0:
     picocolors "^1.0.0"
     picomatch "^2.3.1"
 
-vite-plugin-static-copy@^2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz#1b6be634c21541d6363dd72ab7870b1ce14bfa53"
-  integrity sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==
+vite-plugin-static-copy@^3:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-3.4.0.tgz#4338cc73be3340c4c5c83dadf58a7edbeb8ccbe1"
+  integrity sha512-ekryzCw0ouAOE8tw4RvVL/dfqguXzumsV3FBKoKso4MQ1MUUrUXtl5RI4KpJQUNGqFEsg9kxl4EvDl02YtA9VQ==
   dependencies:
-    chokidar "^3.5.3"
-    fast-glob "^3.2.11"
-    fs-extra "^11.1.0"
-    p-map "^7.0.3"
-    picocolors "^1.0.0"
+    chokidar "^3.6.0"
+    p-map "^7.0.4"
+    picocolors "^1.1.1"
+    tinyglobby "^0.2.15"
 
 vite@~7:
   version "7.3.3"


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-static-copy` from `^2` (currently 2.3.2) to `^3` (3.4.0) to clear the peer-dependency warning that's printed on every `yarn install` since PR-V₁ landed Vite 7:

```
warning " > vite-plugin-static-copy@2.3.2" has incorrect peer dependency "vite@^5.0.0 || ^6.0.0".
```

3.1.0 widened the peer constraint to include `vite@^7.0.0`. 3.4.0 is the latest 3.x.

## Why not v4

v4 bumps the bundled `chokidar` from 3 → 4 (which would also clear the `braces`/`picomatch` audit chain), but requires **Node 22+**. We're pinned to Node 20 via `.tool-versions` + `engines.node`. Node 20 → 22 is a bigger blast radius (Heroku, CI workflows, Docker images) and warrants its own PR.

## Audit impact

Unchanged: 31 vulnerabilities found / 471 packages audited (same as post-V₅). The `chokidar > braces` chain only clears with v4.

## What this plugin does in the repo

Copies font-awesome 4 webfonts from `node_modules/font-awesome/fonts/` into `public/build/assets/` at build time (replaces Mix's `webpack-resource-loader` behaviour for those files). Configured in `vite.config.js`.

## Verification

```
$ rm -rf public/build && yarn run production
[vite-plugin-static-copy] Copied 6 items.
✓ built in 6.15s

$ ls public/build/assets/ | grep -E 'fontawesome|FontAwesome'
fontawesome-webfont.eot
fontawesome-webfont.svg
fontawesome-webfont.ttf
fontawesome-webfont.woff
fontawesome-webfont.woff2
FontAwesome.otf

$ yarn install
# no peer-mismatch warning
```

## Test plan

- [x] `yarn run prod` builds clean with all 6 font-awesome files copied
- [x] No `incorrect peer dependency` warning on install
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
