### PR TITLE
ci: emit success on docs-only PRs from docker-dev workflow

### DIFF
--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -16,6 +16,16 @@
 #     must be able to run this job
 #   - no Docker layer cache — the whole point is to catch drift, and a stale
 #     cache can mask exactly the kind of regression this guard exists for
+#   - always triggers on every PR to 4.x (no workflow-level `paths-ignore`).
+#     The job ("Build dev docker image") is a required status check on the
+#     4.x branch protection rule; if the workflow itself is skipped, the
+#     check never appears and the PR is unmergeable (this happened to docs
+#     PR #696 — required check stayed pending forever and the PR had to be
+#     admin-merged). To preserve the original intent of skipping the
+#     expensive build on docs/tests/markdown/migration-only changes, the
+#     skip is now done at the *step* level inside this always-running job.
+#     The job still reports success on docs-only PRs; only the docker
+#     build step is gated.
 #
 # Scope: only the dev image (scripts/docker/Dockerfile via docker-compose.dev.yml).
 # Related: issue #584, discussion #581, PR #561, milestone "OOTB buildability".
@@ -27,19 +37,9 @@ on:
     branches:
       - 4.x
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - 'docs/**'
-      - 'tests/**'
-      - '*.md'
-      - '.migration/**'
   push:
     branches:
       - 4.x
-    paths-ignore:
-      - 'docs/**'
-      - 'tests/**'
-      - '*.md'
-      - '.migration/**'
 
 concurrency:
   group: OOTB Docker build ${{ github.ref }}
@@ -53,6 +53,54 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          # Full history so the diff step below can resolve the base SHA on
+          # both pull_request and push events without surprises.
+          fetch-depth: 0
+
+      - name: Detect docker-relevant changes
+        id: changes
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            head="${{ github.event.pull_request.head.sha }}"
+          else
+            base="${{ github.event.before }}"
+            head="${{ github.event.after }}"
+          fi
+
+          # First-push / branch-create may have no usable base. Err on the
+          # side of running the real build rather than silently passing.
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base SHA available — running build."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pathspec exclusions mirror the previous workflow-level
+          # paths-ignore set. ':(exclude,glob)' enables ** glob semantics so
+          # '**/*.md' matches markdown at any depth (including the root).
+          changed=$(git diff --name-only "$base" "$head" -- \
+            ':(exclude,glob)**/*.md' \
+            ':(exclude,glob)docs/**' \
+            ':(exclude,glob)tests/**' \
+            ':(exclude,glob).migration/**')
+
+          if [ -n "$changed" ]; then
+            echo "Docker-relevant changes detected:"
+            echo "$changed"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Only docs / tests / markdown / .migration changes — skipping build."
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build dev compose image
+        if: steps.changes.outputs.relevant == 'true'
         run: docker compose -f docker-compose.dev.yml build app
+
+      - name: Skipped (no docker-relevant changes)
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No files outside the skip set changed — reporting success without rebuilding."


### PR DESCRIPTION
## Summary

Fix the docs-only-PR merge footgun observed on PR #696: the `Build dev docker image` job is required by 4.x branch protection, but `docker-dev.yml` had `paths-ignore` for `docs/**`, `tests/**`, `*.md`, and `.migration/**`. When a PR only touched files in that set, GitHub correctly skipped the workflow, the required check never appeared, and the PR sat indefinitely pending — only mergeable via admin-bypass.

This PR moves the skip from the workflow level (invisible to branch protection) to the step level (job still runs and reports success, but the expensive docker build is gated by an `if:`). The "no Docker layer cache, no registry push" intent of the original workflow is preserved.

## Mechanics

- Drop both `paths-ignore` blocks. Workflow now triggers on every PR to 4.x and every push to 4.x.
- New `Detect docker-relevant changes` step uses `git diff --name-only` with `:(exclude,glob)` pathspec exclusions equivalent to the previous `paths-ignore` set. The `**/*.md` pattern matches markdown at any depth including repository root.
- `Build dev compose image` step now has `if: steps.changes.outputs.relevant == 'true'`. A paired notice step fires when the build skips so the run log states why.
- First-push / branch-create (`base = 0000…`) errs toward building rather than silently passing.
- `fetch-depth: 0` on checkout so the diff resolves base SHA reliably on both `pull_request` and `push` events.
- No new third-party action — the repo doesn't use any path-filter action and this keeps that posture.

## Verification

Replayed the pathspec logic against the two most recent merges to 4.x:

| Base / Head SHA | Workflow says | What it should say |
| --- | --- | --- |
| `3700ede38^...3700ede38` (composer bumps) | `composer.json`, `composer.lock`, `phpunit.xml` → `relevant=true` → build runs | ✓ |
| `beae1ef78^...beae1ef78` (docs PR) | (no output) → `relevant=false` → build skips, job passes | ✓ |

Both CLAUDE.md and README.md (root-level `.md` files) were correctly excluded by `**/*.md`, confirming `**` crosses depths including depth zero in git's `:(exclude,glob)` pathspec.

This PR itself touches `.github/workflows/docker-dev.yml`, which is **not** in the skip set, so the real docker build will run when CI exercises it — that's the natural test for the unchanged "real build" path.

## Test plan

- [ ] CI passes including the `Build dev docker image` job (proves the real build still works on a non-doc change)
- [ ] After merge, file a docs-only follow-up (e.g. tweak CLAUDE.md or any `.md`) and confirm the workflow shows up as `Build dev docker image: pass` with a "Skipped (no docker-relevant changes)" step, and the PR is mergeable without `--admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
