### PR TITLE
fix: restore Cypress E2E stability

### DIFF
--- a/app/Console/Commands/SetPremiumAccount.php
+++ b/app/Console/Commands/SetPremiumAccount.php
@@ -29,8 +29,7 @@ class SetPremiumAccount extends Command
     public function handle(): void
     {
         $account = Account::findOrFail($this->argument('accountId'));
-        $account->update([
-            'has_access_to_paid_version_for_free' => true,
-        ]);
+        $account->has_access_to_paid_version_for_free = true;
+        $account->save();
     }
 }

--- a/resources/js/components/people/ContactList.vue
+++ b/resources/js/components/people/ContactList.vue
@@ -109,11 +109,13 @@
 </template>
 
 <script>
+import { VueGoodTable } from 'vue-good-table';
 import ContactItem from './partials/ContactItem.vue';
 
 export default {
 
   components: {
+    VueGoodTable,
     ContactItem,
   },
 
@@ -234,9 +236,11 @@ export default {
     _loadNewItems(urlParam, after) {
       axios.get('people/list'+urlParam)
         .then(response => {
+          const contacts = response.data.contacts.data || response.data.contacts;
+
           if (_.isFunction(after)) {
             after(
-              _.uniqBy(response.data.contacts, entry => _.uniqueId()),
+              _.uniqBy(contacts, entry => _.uniqueId()),
               response.data.totalRecords
             );
           }

--- a/tests/cypress/e2e/settings/activity_types.cy.js
+++ b/tests/cypress/e2e/settings/activity_types.cy.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 
 describe('Settings: activity types', function () {
   afterEach(function () {
-    cy.clearCachedConfig();
+    cy.setRequiresSubscription(false);
   });
 
   it('doesn\'t let you manage activity types if user is not premium', function () {
@@ -14,6 +14,7 @@ describe('Settings: activity types', function () {
   });
 
   it('lets you manage an activity type category and activity type', function () {
+    cy.setRequiresSubscription(true);
     cy.login();
     cy.visit('/');
 
@@ -91,6 +92,7 @@ describe('Settings: activity types', function () {
   });
 
   it('lets you add an activity type and use it', function () {
+    cy.setRequiresSubscription(true);
     cy.login();
     cy.visit('/');
 


### PR DESCRIPTION
## Summary
- register VueGoodTable in the contact list and handle resource-envelope contact responses
- make the test premium-account command bypass mass-assignment filtering
- reset subscription config between activity type Cypress tests and explicitly enable it where needed

## Test Plan
- [x] CYPRESS_USE_DOCKER=true CYPRESS_BASE_URL=http://localhost:8082 fnm exec --using=20 yarn run e2e