### PR TITLE
fix(settings): restore /settings/api token + client management UI (#703)

### DIFF
--- a/app/Http/Controllers/Passport/AuthorizedAccessTokenController.php
+++ b/app/Http/Controllers/Passport/AuthorizedAccessTokenController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Passport;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Passport\Token;
+use Laravel\Passport\TokenRepository;
+
+/**
+ * Re-implements the legacy /oauth/tokens endpoints that Passport v11+ removed.
+ * Lists tokens issued to third-party clients only — first-party and personal
+ * access tokens are filtered out (the latter live on /oauth/personal-access-
+ * tokens). See #703.
+ */
+class AuthorizedAccessTokenController extends Controller
+{
+    public function __construct(
+        protected TokenRepository $tokenRepository,
+    ) {
+    }
+
+    public function forUser(Request $request): Collection
+    {
+        return $this->tokenRepository->forUser($request->user())
+            ->load('client')
+            ->reject(fn (Token $token): bool => $token->client->revoked || $token->client->firstParty())
+            ->values();
+    }
+
+    public function destroy(Request $request, string $tokenId): Response
+    {
+        $token = $this->tokenRepository->findForUser($tokenId, $request->user());
+
+        if (is_null($token)) {
+            return new Response('', 404);
+        }
+
+        $token->revoke();
+        $token->refreshToken?->revoke();
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Passport/ClientController.php
+++ b/app/Http/Controllers/Passport/ClientController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Passport;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Http\Rules\RedirectRule;
+
+/**
+ * Re-implements the legacy /oauth/clients endpoints that Passport v11+ removed
+ * alongside the Passport::routes() macro. See #703.
+ *
+ * v13 stores secrets hashed and redirect URIs as an array; the legacy Vue
+ * (Clients.vue) was written against unhashed secrets and a single `redirect`
+ * URL. transform() reshapes responses so the existing UI keeps working without
+ * pulling its v2 components into this PR. Newly-created clients still surface
+ * their plain secret in the create response; existing clients return secret
+ * null (it's not recoverable from a hashed column).
+ */
+class ClientController extends Controller
+{
+    public function __construct(
+        protected ClientRepository $clients,
+        protected RedirectRule $redirectRule,
+    ) {
+    }
+
+    public function forUser(Request $request): array
+    {
+        return $this->ownedClients($request)
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Client $client): array => $this->transform($client))
+            ->all();
+    }
+
+    public function store(Request $request): array
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'redirect' => ['required', $this->redirectRule],
+        ]);
+
+        $client = $this->clients->createAuthorizationCodeGrantClient(
+            $request->name,
+            [$request->redirect],
+            true,
+            $request->user(),
+        );
+
+        return $this->transform($client);
+    }
+
+    public function update(Request $request, string $clientId): Response|array
+    {
+        $client = $this->ownedClients($request)->find($clientId);
+
+        if (! $client) {
+            return new Response('', 404);
+        }
+
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'redirect' => ['required', $this->redirectRule],
+        ]);
+
+        $this->clients->update($client, $request->name, [$request->redirect]);
+
+        return $this->transform($client->fresh());
+    }
+
+    public function destroy(Request $request, string $clientId): Response
+    {
+        $client = $this->ownedClients($request)->find($clientId);
+
+        if (! $client) {
+            return new Response('', 404);
+        }
+
+        $this->clients->delete($client);
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Lookup the owned clients via the polymorphic owner_id/owner_type schema
+     * introduced by Passport v13. Bypasses ClientRepository::forUser/findForUser
+     * which still query the dropped `user_id` column (see the v13 fork migration
+     * 2026_05_26_000001_upgrade_oauth_clients_for_passport_13).
+     */
+    private function ownedClients(Request $request)
+    {
+        return $request->user()->oauthApps()->where('revoked', false);
+    }
+
+    private function transform(Client $client): array
+    {
+        // Access via getAttribute() / public property rather than the magic
+        // snake_case names — Passport defines them as Attribute accessor
+        // methods which phpstan can't see through.
+        $redirectUris = $client->getAttribute('redirect_uris') ?? [];
+
+        return [
+            'id' => $client->getKey(),
+            'name' => $client->name,
+            'redirect' => $redirectUris[0] ?? '',
+            'secret' => $client->plainSecret,
+            'revoked' => $client->revoked,
+        ];
+    }
+}

--- a/app/Http/Controllers/Passport/PersonalAccessTokenController.php
+++ b/app/Http/Controllers/Passport/PersonalAccessTokenController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Passport;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+use Laravel\Passport\Passport;
+use Laravel\Passport\Token;
+use Laravel\Passport\TokenRepository;
+
+/**
+ * Re-implements the legacy /oauth/personal-access-tokens endpoints that
+ * Passport v11+ removed alongside the Passport::routes() macro. The Vue
+ * components under resources/js/components/passport/ still expect this
+ * surface; see #703 for the wider context.
+ */
+class PersonalAccessTokenController extends Controller
+{
+    public function __construct(
+        protected TokenRepository $tokenRepository,
+    ) {
+    }
+
+    public function forUser(Request $request): Collection
+    {
+        return $this->tokenRepository->forUser($request->user())
+            ->filter(fn (Token $token): bool => ! $token->client->revoked && $token->client->hasGrantType('personal_access'))
+            ->values();
+    }
+
+    public function store(Request $request): array
+    {
+        $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'scopes' => ['array', Rule::in(Passport::scopeIds())],
+        ]);
+
+        $result = $request->user()->createToken($request->name, $request->scopes ?: []);
+
+        // Vue PersonalAccessTokens.vue expects {token, accessToken}. The v13
+        // PersonalAccessTokenResult only serialises {accessTokenId, accessToken,
+        // tokenType, expiresIn} via toArray(); the Token model is on the magic
+        // ->token property. We reshape it here to keep the legacy contract.
+        return [
+            'token' => $result->getToken(),
+            'accessToken' => $result->accessToken,
+        ];
+    }
+
+    public function destroy(Request $request, string $tokenId): Response
+    {
+        $token = $this->tokenRepository->findForUser($tokenId, $request->user());
+
+        if (is_null($token)) {
+            return new Response('', 404);
+        }
+
+        $token->revoke();
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Http/Controllers/Passport/ScopeController.php
+++ b/app/Http/Controllers/Passport/ScopeController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Passport;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Collection;
+use Laravel\Passport\Passport;
+
+/**
+ * Re-implements the legacy /oauth/scopes endpoint that Passport v11+ removed.
+ * See #703. Returns whatever Passport::tokensCan() / addScope() registered
+ * at boot — for this fork that's an empty collection unless customised.
+ */
+class ScopeController extends Controller
+{
+    public function all(): Collection
+    {
+        return Passport::scopes();
+    }
+}

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -1,3 +1,18 @@
+<style scoped>
+    .access-key {
+        border: 1px solid #cacaca;
+        border-radius: 3px;
+        padding: 10px 10px 0;
+        background-color: #fafafa;
+    }
+
+    pre {
+        font-size: 12px;
+        word-wrap: break-word;
+        white-space: pre-wrap;
+    }
+</style>
+
 <template>
   <div>
     <notifications group="passport-clients" position="top middle" :duration="5000" width="400" />
@@ -136,6 +151,35 @@
         </a>
       </div>
     </sweet-modal>
+
+    <!--
+      Client Secret Modal — surfaces the plain secret once on creation.
+      Passport v13 hashes oauth_clients.secret at insertion, so plain_secret
+      only exists in the create response. Mirrors the PersonalAccessTokens
+      access-token one-shot pattern.
+    -->
+    <sweet-modal ref="modalClientSecret" overlay-theme="dark" tabindex="-1" role="dialog"
+                 :title="$t('settings.api_oauth_secret_title')"
+    >
+      <p>{{ $t('settings.api_oauth_secret_help') }}</p>
+
+      <div class="flex-auto access-key overflow-y-scroll" cy-name="client-secret-display"
+           style="max-height: 400px;" @click.prevent="copyIntoClipboard(clientSecret)"
+      >
+        <pre><code>{{ clientSecret }}</code></pre>
+      </div>
+
+      <div slot="button">
+        <a class="btn btn-primary" :title="$t('settings.dav_copy_help')" href=""
+           @click.prevent="copyIntoClipboard(clientSecret)"
+        >
+          {{ $t('app.copy') }}
+        </a>
+        <a class="btn" href="" @click.prevent="closeSecretModal">
+          {{ $t('app.close') }}
+        </a>
+      </div>
+    </sweet-modal>
   </div>
 </template>
 
@@ -157,6 +201,7 @@ export default {
   data() {
     return {
       clients: [],
+      clientSecret: null,
 
       form: {
         errors: [],
@@ -248,15 +293,27 @@ export default {
 
     /**
      * Persist the client to storage using the given form.
+     *
+     * On create, the response carries `secret` = the plain client secret
+     * (Passport v13 hashes it at insertion, so it's only available here).
+     * Push the new client into the in-memory list so the row appears, and
+     * surface the plain secret in a one-shot modal — same pattern as
+     * PersonalAccessTokens.vue. On update, refetch the list as before
+     * (no secret in the response).
      */
     persistClient(method, uri, form) {
+      const isCreate = method === 'post';
       form.errors = [];
 
       axios[method](uri, form)
         .then(response => {
-          this.getClients();
-
-          this.closeModal();
+          if (isCreate) {
+            this.clients.push(response.data);
+            this.showClientSecret(response.data.secret);
+          } else {
+            this.getClients();
+            this.closeModal();
+          }
         })
         .catch(error => {
           if (typeof error.response.data === 'object') {
@@ -265,6 +322,24 @@ export default {
             form.errors = [this.$t('app.error_try_again')];
           }
         });
+    },
+
+    /**
+     * Show the plain client secret in a one-shot modal after create.
+     */
+    showClientSecret(secret) {
+      this.$refs.modalClient.close();
+      this.clientSecret = secret;
+      this.$refs.modalClientSecret.open();
+    },
+
+    /**
+     * Close the secret modal and clear in-memory state.
+     */
+    closeSecretModal() {
+      this.$refs.modalClientSecret.close();
+      this.clientSecret = null;
+      this.resetField();
     },
 
     /**

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -368,6 +368,8 @@ return [
     'api_oauth_create' => 'Create Client',
     'api_oauth_redirecturl' => 'Redirect URL',
     'api_oauth_redirecturl_help' => 'Your application’s authorization callback URL.',
+    'api_oauth_secret_title' => 'Client Secret',
+    'api_oauth_secret_help' => 'Here is the client secret for the OAuth client you just created. Copy it now — for security, this is the only time it will be shown.',
 
     'api_authorized_clients' => 'List of authorized clients',
     'api_authorized_clients_desc' => 'This section lists all the clients you’ve authorized to access your application data. You can revoke this authorization at anytime.',

--- a/routes/web.php
+++ b/routes/web.php
@@ -299,6 +299,25 @@ Route::middleware(['auth', 'verified', 'mfa'])->group(function () {
         });
 
         Route::get('/settings/api', 'SettingsController@api')->name('api');
+
+        // /settings/api Vue UI back-end. Re-implements the legacy
+        // Passport::routes() endpoints that v11+ removed; see #703.
+        Route::name('passport.')->group(function () {
+            Route::get('/oauth/personal-access-tokens', 'Passport\\PersonalAccessTokenController@forUser')->name('personal-access-tokens.index');
+            Route::post('/oauth/personal-access-tokens', 'Passport\\PersonalAccessTokenController@store')->name('personal-access-tokens.store');
+            Route::delete('/oauth/personal-access-tokens/{token_id}', 'Passport\\PersonalAccessTokenController@destroy')->name('personal-access-tokens.destroy');
+
+            Route::get('/oauth/clients', 'Passport\\ClientController@forUser')->name('clients.index');
+            Route::post('/oauth/clients', 'Passport\\ClientController@store')->name('clients.store');
+            Route::put('/oauth/clients/{client_id}', 'Passport\\ClientController@update')->name('clients.update');
+            Route::delete('/oauth/clients/{client_id}', 'Passport\\ClientController@destroy')->name('clients.destroy');
+
+            Route::get('/oauth/tokens', 'Passport\\AuthorizedAccessTokenController@forUser')->name('tokens.index');
+            Route::delete('/oauth/tokens/{token_id}', 'Passport\\AuthorizedAccessTokenController@destroy')->name('tokens.destroy');
+
+            Route::get('/oauth/scopes', 'Passport\\ScopeController@all')->name('scopes.index');
+        });
+
         Route::get('/settings/dav', 'SettingsController@dav')->name('dav');
 
         Route::post('/settings/updateDefaultProfileView', 'SettingsController@updateDefaultProfileView');

--- a/tests/Feature/PassportControllersTest.php
+++ b/tests/Feature/PassportControllersTest.php
@@ -1,0 +1,351 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Laravel\Passport\Client;
+use Laravel\Passport\ClientRepository;
+use Laravel\Passport\Passport;
+use Laravel\Passport\Token;
+use Tests\FeatureTestCase;
+
+/**
+ * Coverage for the in-tree replacements of the legacy Passport::routes()
+ * management endpoints (#703). The OAuth server is unaffected; these tests
+ * lock down the shape of the four endpoints the /settings/api Vue surface
+ * consumes:
+ *
+ *   - /oauth/personal-access-tokens (index, store, destroy)
+ *   - /oauth/clients                 (index, store, update, destroy)
+ *   - /oauth/tokens                  (index, destroy) — 3rd-party authorized
+ *   - /oauth/scopes                  (index)
+ *
+ * The most important contract here is that ClientController@store returns
+ * the plain client secret in the response — Passport v13 hashes it at
+ * insertion and the Vue (Clients.vue) shows it once in a modal after create.
+ */
+class PassportControllersTest extends FeatureTestCase
+{
+    use WithFaker;
+
+    /**
+     * Seed a personal-access client so $user->createToken(...) works inside
+     * tests. The factory side of Passport (PersonalAccessTokenFactory)
+     * resolves the personal access client by looking for an oauth_clients
+     * row with grant_types containing 'personal_access'. We create one
+     * per test for isolation.
+     */
+    private function ensurePersonalAccessClient(): Client
+    {
+        return app(ClientRepository::class)->createPersonalAccessGrantClient('Test Personal Access Client');
+    }
+
+    // -------------------------------------------------------------------------
+    // PersonalAccessTokenController
+    // -------------------------------------------------------------------------
+
+    public function test_personal_access_tokens_index_returns_only_personal_tokens_for_the_user(): void
+    {
+        $this->ensurePersonalAccessClient();
+        $user = $this->signIn();
+
+        $user->createToken('alpha');
+        $user->createToken('beta');
+
+        $response = $this->getJson('/oauth/personal-access-tokens');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(2, $data);
+        $names = collect($data)->pluck('name')->all();
+        sort($names);
+        $this->assertSame(['alpha', 'beta'], $names);
+    }
+
+    public function test_personal_access_tokens_index_isolates_users(): void
+    {
+        $this->ensurePersonalAccessClient();
+
+        $other = factory(User::class)->create();
+        $other->createToken('other-user-token');
+
+        $user = $this->signIn();
+        $user->createToken('mine');
+
+        $response = $this->getJson('/oauth/personal-access-tokens');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data);
+        $this->assertSame('mine', $data[0]['name']);
+    }
+
+    public function test_personal_access_tokens_store_returns_token_and_access_token(): void
+    {
+        // v13's PersonalAccessTokenResult::toArray() doesn't include the
+        // `token` model — only camelCase primitives. The controller reshapes
+        // to {token, accessToken} so the legacy Vue (which pushes
+        // response.data.token into its in-memory list) keeps working.
+        $this->ensurePersonalAccessClient();
+        $this->signIn();
+
+        $response = $this->postJson('/oauth/personal-access-tokens', [
+            'name' => 'my-token',
+            'scopes' => [],
+        ]);
+
+        $response->assertStatus(200);
+        $body = $response->json();
+        $this->assertArrayHasKey('token', $body);
+        $this->assertArrayHasKey('accessToken', $body);
+        $this->assertSame('my-token', $body['token']['name']);
+        $this->assertIsString($body['accessToken']);
+        $this->assertGreaterThan(100, strlen($body['accessToken']), 'accessToken should be a JWT-sized string');
+    }
+
+    public function test_personal_access_tokens_store_validates_name(): void
+    {
+        $this->ensurePersonalAccessClient();
+        $this->signIn();
+
+        $response = $this->postJson('/oauth/personal-access-tokens', ['name' => '']);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_personal_access_tokens_destroy_revokes_the_token(): void
+    {
+        $this->ensurePersonalAccessClient();
+        $user = $this->signIn();
+
+        $result = $user->createToken('to-revoke');
+        $tokenId = $result->getToken()->id;
+
+        $response = $this->deleteJson('/oauth/personal-access-tokens/'.$tokenId);
+
+        $response->assertStatus(204);
+        $this->assertTrue(Token::find($tokenId)->revoked);
+    }
+
+    public function test_personal_access_tokens_destroy_other_users_token_returns_404(): void
+    {
+        $this->ensurePersonalAccessClient();
+
+        $other = factory(User::class)->create();
+        $otherResult = $other->createToken('not-yours');
+        $otherTokenId = $otherResult->getToken()->id;
+
+        $this->signIn();
+
+        $response = $this->deleteJson('/oauth/personal-access-tokens/'.$otherTokenId);
+
+        $response->assertStatus(404);
+        $this->assertFalse(Token::find($otherTokenId)->revoked);
+    }
+
+    // -------------------------------------------------------------------------
+    // ClientController
+    // -------------------------------------------------------------------------
+
+    public function test_oauth_clients_index_returns_only_users_own_clients(): void
+    {
+        $user = $this->signIn();
+        $other = factory(User::class)->create();
+
+        app(ClientRepository::class)->createAuthorizationCodeGrantClient('mine', ['https://a.test/cb'], true, $user);
+        app(ClientRepository::class)->createAuthorizationCodeGrantClient('theirs', ['https://b.test/cb'], true, $other);
+
+        $response = $this->getJson('/oauth/clients');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data);
+        $this->assertSame('mine', $data[0]['name']);
+    }
+
+    public function test_oauth_clients_store_returns_plain_secret_in_response(): void
+    {
+        // This is the contract that #703's UI fix hangs on: the create
+        // response carries the plain secret so the Vue can surface it in a
+        // one-shot modal. Passport v13 hashes the persisted secret, so the
+        // plain value never appears again — index/update returns null/empty.
+        $this->signIn();
+
+        $response = $this->postJson('/oauth/clients', [
+            'name' => 'new-client',
+            'redirect' => 'https://example.com/cb',
+        ]);
+
+        $response->assertStatus(200);
+        $body = $response->json();
+        $this->assertSame('new-client', $body['name']);
+        $this->assertSame('https://example.com/cb', $body['redirect']);
+        $this->assertNotNull($body['secret']);
+        $this->assertGreaterThanOrEqual(40, strlen($body['secret']), 'plain secret should be ~40 chars');
+    }
+
+    public function test_oauth_clients_store_persists_hashed_secret(): void
+    {
+        // Defence-in-depth: even though the controller returns the plain
+        // secret in the response, the persisted column MUST be hashed in v13.
+        // If a future change disables hashing, this test catches the regression.
+        $this->signIn();
+
+        $response = $this->postJson('/oauth/clients', [
+            'name' => 'hash-check',
+            'redirect' => 'https://example.com/cb',
+        ]);
+
+        $response->assertStatus(200);
+        $plainSecret = $response->json('secret');
+        $clientId = $response->json('id');
+
+        $persisted = Client::find($clientId);
+        $this->assertNotNull($persisted);
+
+        $persistedSecret = $persisted->getAttributes()['secret'];
+        $this->assertNotSame($plainSecret, $persistedSecret, 'persisted secret should not equal plain secret');
+        $this->assertTrue(\Hash::check($plainSecret, $persistedSecret), 'persisted secret should be a hash of the plain secret');
+    }
+
+    public function test_oauth_clients_store_validates_name_and_redirect(): void
+    {
+        $this->signIn();
+
+        $this->postJson('/oauth/clients', ['name' => '', 'redirect' => 'https://x.test/cb'])
+            ->assertStatus(422);
+
+        $this->postJson('/oauth/clients', ['name' => 'ok', 'redirect' => 'not-a-url'])
+            ->assertStatus(422);
+    }
+
+    public function test_oauth_clients_update_changes_name_and_redirect(): void
+    {
+        $user = $this->signIn();
+        $client = app(ClientRepository::class)->createAuthorizationCodeGrantClient(
+            'before-name', ['https://before.test/cb'], true, $user
+        );
+
+        $response = $this->putJson('/oauth/clients/'.$client->id, [
+            'name' => 'after-name',
+            'redirect' => 'https://after.test/cb',
+        ]);
+
+        $response->assertStatus(200);
+        $body = $response->json();
+        $this->assertSame('after-name', $body['name']);
+        $this->assertSame('https://after.test/cb', $body['redirect']);
+    }
+
+    public function test_oauth_clients_update_other_users_client_returns_404(): void
+    {
+        $other = factory(User::class)->create();
+        $client = app(ClientRepository::class)->createAuthorizationCodeGrantClient(
+            'theirs', ['https://x.test/cb'], true, $other
+        );
+
+        $this->signIn();
+
+        $response = $this->putJson('/oauth/clients/'.$client->id, [
+            'name' => 'hacked',
+            'redirect' => 'https://attacker.test/cb',
+        ]);
+
+        $response->assertStatus(404);
+        $this->assertSame('theirs', $client->fresh()->name);
+    }
+
+    public function test_oauth_clients_destroy_marks_client_revoked(): void
+    {
+        $user = $this->signIn();
+        $client = app(ClientRepository::class)->createAuthorizationCodeGrantClient(
+            'to-revoke', ['https://x.test/cb'], true, $user
+        );
+
+        $response = $this->deleteJson('/oauth/clients/'.$client->id);
+
+        $response->assertStatus(204);
+        $this->assertTrue($client->fresh()->revoked);
+    }
+
+    public function test_oauth_clients_destroy_other_users_client_returns_404(): void
+    {
+        $other = factory(User::class)->create();
+        $client = app(ClientRepository::class)->createAuthorizationCodeGrantClient(
+            'theirs', ['https://x.test/cb'], true, $other
+        );
+
+        $this->signIn();
+
+        $response = $this->deleteJson('/oauth/clients/'.$client->id);
+
+        $response->assertStatus(404);
+        $this->assertFalse($client->fresh()->revoked);
+    }
+
+    // -------------------------------------------------------------------------
+    // AuthorizedAccessTokenController
+    // -------------------------------------------------------------------------
+
+    public function test_authorized_tokens_index_returns_empty_for_fresh_user(): void
+    {
+        $this->signIn();
+
+        $response = $this->getJson('/oauth/tokens');
+
+        $response->assertStatus(200);
+        $response->assertJson([]);
+    }
+
+    public function test_authorized_tokens_index_filters_personal_access_tokens(): void
+    {
+        // Authorized-tokens lists 3rd-party-issued tokens only; personal
+        // access tokens belong to the other endpoint. Verify the filter
+        // by issuing a PAT and confirming it doesn't appear here.
+        $this->ensurePersonalAccessClient();
+        $user = $this->signIn();
+        $user->createToken('a-personal-token');
+
+        $response = $this->getJson('/oauth/tokens');
+
+        $response->assertStatus(200);
+        $response->assertJson([]);
+    }
+
+    // -------------------------------------------------------------------------
+    // ScopeController
+    // -------------------------------------------------------------------------
+
+    public function test_scopes_index_returns_passport_scopes(): void
+    {
+        $this->signIn();
+
+        // Stash any existing scopes, register a known scope, then restore.
+        $existing = Passport::scopes();
+        Passport::tokensCan(['read-contacts' => 'Read your contacts']);
+
+        try {
+            $response = $this->getJson('/oauth/scopes');
+
+            $response->assertStatus(200);
+            $data = $response->json();
+            $ids = collect($data)->pluck('id')->all();
+            $this->assertContains('read-contacts', $ids);
+        } finally {
+            Passport::tokensCan($existing->mapWithKeys(fn ($scope) => [$scope->id => $scope->description])->all());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth boundary
+    // -------------------------------------------------------------------------
+
+    public function test_endpoints_require_authentication(): void
+    {
+        $this->getJson('/oauth/personal-access-tokens')->assertStatus(401);
+        $this->getJson('/oauth/clients')->assertStatus(401);
+        $this->getJson('/oauth/tokens')->assertStatus(401);
+        $this->getJson('/oauth/scopes')->assertStatus(401);
+    }
+}

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -281,6 +281,48 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     expect(Array.isArray(listJson.contacts)).toBe(true);
   });
 
+  test('oauth client create flow: secret modal surfaces the plain secret once', async ({ page }) => {
+    // Locks down the #703 fix: Clients.vue captures the create-response,
+    // pushes the new client into the list locally, and opens a one-shot
+    // <sweet-modal> showing the plain secret. v13 hashes secrets at
+    // insertion so the plain value is only available in that response —
+    // the previous "refetch the index" path silently dropped it.
+    await login(page);
+    await page.goto('/settings/api');
+
+    const marker = `smoke client ${Date.now()}`;
+
+    // Open the Create Client modal.
+    await page.getByRole('link', { name: 'Create New Client' }).click();
+    const createModal = page.locator('.sweet-modal-overlay').filter({ hasText: 'Create Client' });
+    await expect(createModal).toBeVisible();
+
+    // Fill name + redirect, submit.
+    await createModal.locator('input[name="client-name"]').fill(marker);
+    await createModal.locator('input[name="redirect-url"]').fill('https://example.com/oauth/cb');
+    await createModal.getByRole('link', { name: 'Create', exact: true }).click();
+
+    // Create modal closes, Client Secret modal opens with the plain value.
+    await expect(createModal).toBeHidden();
+    const secretModal = page.locator('.sweet-modal-overlay').filter({ hasText: 'Client Secret' });
+    await expect(secretModal).toBeVisible();
+
+    const secretText = (await secretModal.locator('[cy-name="client-secret-display"] code').textContent())?.trim() ?? '';
+    expect(secretText.length).toBeGreaterThanOrEqual(40);
+    // Passport generates Str::random(40) for the secret — alphanumeric only.
+    expect(secretText).toMatch(/^[A-Za-z0-9]+$/);
+
+    // Close the secret modal. The new client should still be in the list.
+    await secretModal.getByRole('link', { name: 'Close', exact: true }).click();
+    await expect(secretModal).toBeHidden();
+    await expect(page.locator('body')).toContainText(marker);
+
+    // Cleanup so the dev DB doesn't accumulate clients across smoke runs.
+    const row = page.locator('.dt-row', { hasText: marker });
+    await row.locator('em.fa-trash-o').click();
+    await expect(page.locator('.dt-row', { hasText: marker })).toHaveCount(0);
+  });
+
   test('logout clears session', async ({ page }) => {
     await login(page);
     await page.goto('/logout');


### PR DESCRIPTION
Closes #703.

## Summary

Restores the `/settings/api` in-app management UI by porting four thin controllers into `app/Http/Controllers/Passport/`, replacing the legacy `Passport::routes()` endpoints that Laravel Passport dropped in v11+ (the now-archived `laravel/passport-ui` SPA backplane).

| Endpoint | Was | Now |
|---|---|---|
| `GET/POST/DELETE /oauth/personal-access-tokens` | 404 | `PersonalAccessTokenController` |
| `GET/POST/PUT/DELETE /oauth/clients` | 404 | `ClientController` |
| `GET/DELETE /oauth/tokens` | 404 | `AuthorizedAccessTokenController` |
| `GET /oauth/scopes` | 404 | `ScopeController` |

All wired under the existing `auth + verified + mfa` middleware in `routes/web.php`.

The OAuth server itself (`/oauth/authorize`, `/oauth/token`, `/oauth/login`, device flow, 2FA paths) was never broken — only the in-app management chrome was.

## Notable details

- **`PersonalAccessTokenResult::toArray()`** in v13 only serialises the camelCase primitive attributes (`accessTokenId`, `accessToken`, `tokenType`, `expiresIn`) — not the `Token` model the legacy Vue pushes into the in-memory list. `store()` reshapes to `{token, accessToken}` to match the contract.
- **`ClientRepository::forUser/findForUser`** still query `$user->clients()` which uses the dropped `user_id` column. Owned-clients lookups go through `$user->oauthApps()` (the v13 polymorphic `morphMany`) instead. Fork migration `2026_05_26_000001_upgrade_oauth_clients_for_passport_13` is what made the rename necessary.
- **Hashed client secrets**: v13 hashes `oauth_clients.secret` at insertion, so the plain value only exists in the create response. The legacy `Clients.vue` immediately re-fetched the index (discarding it), so the secret cell stayed blank forever — the user had no way to see what they'd just generated. Fixed in this PR by mirroring the `PersonalAccessTokens.vue` one-shot pattern in `Clients.vue`: capture the create response, push the client into the in-memory list locally, surface the plain secret in a second `<sweet-modal>`. (Earlier commit message conflated this with the Vue 3 cutover — retracted; hashing is server-side, the modal is a pure Vue 2 fix.)

## Verification

### Feature tests (CI)

`tests/Feature/PassportControllersTest.php` — **18 new tests, 51 assertions, all passing**. Coverage per controller:

- **PersonalAccessTokenController**: index returns user's personal tokens only, index isolates per-user, store returns `{token, accessToken}` shape, store validates name, destroy revokes the token, destroy returns 404 for other-user tokens.
- **ClientController**: index returns user's own clients only, store returns the plain secret in the response, store **persists a hash of the plain secret in DB** (defence-in-depth via `Hash::check`), store validates name + redirect URL, update changes name + redirect, update returns 404 for other-user clients, destroy marks revoked, destroy returns 404 for other-user clients.
- **AuthorizedAccessTokenController**: index returns empty for fresh user, index filters out personal access tokens (3rd-party tokens only).
- **ScopeController**: index returns `Passport::scopes()`.
- **Auth boundary**: all 4 endpoints 401 without authentication.

Full Feature suite passes 189/189 (171 pre-existing + 18 new). `phpstan analyse` clean.

### Playwright smoke (local)

`tests/playwright/specs/dependency-upgrade-smoke.spec.ts` — new scenario drives the create flow through the Vue: opens Create Client modal, fills name + redirect, submits, asserts the Client Secret modal opens with a 40-char alphanumeric secret, then cleans up. Suite: 13/13 passing.

### Manual end-to-end through Playwright MCP

1. PAT create → JWT shown in the "Personal Access Tokens" modal, name in list, console clean.
2. PAT revoke → list empty.
3. Client create → Client Secret modal opens with the plain secret, row in list, console clean.
4. Client revoke → list empty.
5. Authorized tokens / scopes index → both 200 with `[]`.

## Test plan

- [ ] Reviewer runs `php artisan passport:install` on their dev DB if they haven't, navigates to `/settings/api`, confirms the page loads with zero console errors.
- [ ] Reviewer creates a PAT, confirms the JWT shown in the modal authenticates against the API (`xh GET .../api/contacts "Authorization:Bearer <token>"`).
- [ ] Reviewer creates an OAuth client, confirms the Client Secret modal pops with a 40-char alphanumeric string, confirms the row is visible in the list, confirms after page reload the secret column is empty (consistent with hashed-secret storage).

## Follow-up (not in this PR)

After this merges, rebase #704 (pr-t1) and drop the four `oauth/*` entries from `KNOWN_CONSOLE_NOISE` since the endpoints now return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
