### PR TITLE
chore(deps): bump symfony/http-foundation + symfony/routing for CVE patches

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8854,16 +8854,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/bc354f47c62301e990b7874fa662326368508e2c",
+                "reference": "bc354f47c62301e990b7874fa662326368508e2c",
                 "shasum": ""
             },
             "require": {
@@ -8912,7 +8912,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8932,7 +8932,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -10612,16 +10612,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.12",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
-                "reference": "3b04a5ec4887a8135a12ebf0f4cbc5b8fc8ee204",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -10673,7 +10673,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.12"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -10693,7 +10693,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:20:23+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -17135,5 +17135,5 @@
     "platform-overrides": {
         "php": "8.4.21"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Two upstream Symfony CVEs disclosed 2026-05-26 affect transitive deps in `4.x`'s composer.lock:

| CVE | Package | From | To | Severity |
|---|---|---|---|---|
| [CVE-2026-48736](https://symfony.com/cve-2026-48736) | `symfony/http-foundation` | v7.4.8 | v7.4.13 | SSRF bypass in `NoPrivateNetworkHttpClient` — `IpUtils::PRIVATE_SUBNETS` omits IPv6 transition forms (6to4 / NAT64 / Teredo / IPv4-compat). |
| [CVE-2026-48784](https://symfony.com/cve-2026-48784) | `symfony/routing` | v7.4.12 | v7.4.13 | UrlGenerator dot-segment encoding skips every other chained `../` or `./`, generated URL collapses off-route under RFC 3986 normalisation. |

Both pulled transitively (no direct constraint in `composer.json`), so a `composer update <pkg> --with-dependencies` inside the existing `^7` range is enough. Diff is exactly the two target packages — no co-dependent moves.

## Why this blocks every open PR today

The `Build Assets` workflow's `composer audit --abandoned=ignore` step (replaces the dropped roave/security-advisories install-time gate, per `extra.fork-notes`) rightly fails on the new advisories. The workflow is `pull_request`-triggered only, so direct pushes to `4.x` skipped it — which is why the branch itself stayed green while new PRs (#704, #705) couldn't pass.

## Test plan

- [x] `composer audit --abandoned=ignore` clean
- [x] `vendor/bin/phpunit --testsuite Feature` — 171/171 passing
- [ ] CI green (composer audit + full PHPUnit testsuite split)

Once this merges, #704 and #705 rebase on top to pick up the new lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
