### PR TITLE
fix(webauthn): restore security-key registration under vite (#707)

### DIFF
--- a/resources/js/components/settings/WebauthnConnector.vue
+++ b/resources/js/components/settings/WebauthnConnector.vue
@@ -176,7 +176,7 @@
 <script>
 import { SweetModal } from 'sweet-modal-vue';
 import moment from 'moment-timezone';
-import * as WebAuthn from '../../../../vendor/asbiin/laravel-webauthn/resources/js/webauthn.js';
+import WebAuthn from '../../../../vendor/asbiin/laravel-webauthn/resources/js/webauthn.js';
 
 export default {
 

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -33,8 +33,6 @@ const KNOWN_CONSOLE_NOISE: { match: RegExp; issue: string }[] = [
   { match: /Unknown custom element: <error>/, issue: '#625' },
   // #626 — PWA manifest missing url/id in related_applications
   { match: /Manifest: one of 'url' or 'id' is required/, issue: '#626' },
-  // #707 — WebauthnConnector: `import * as WebAuthn` against UMD module breaks under Vite
-  { match: /TypeError: WebAuthn\$1 is not a constructor/, issue: '#707' },
 ];
 
 type UnknownConsole = { type: string; text: string; url: string };

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -560,6 +560,89 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     assertNoUnknownConsoleErrors(unknown, '/settings/security');
   });
 
+  test('webauthn registration baseline: virtual authenticator drives the register wire shape (pre-swap contract for #710)', async ({ page, context }) => {
+    // BASELINE — locks in the current (post-#709 stopgap) JS client's wire
+    // shape so the @simplewebauthn/browser swap (#710) can verify it produces
+    // the same request body. The swap PR keeps this test green as its contract.
+    //
+    // What this exercises:
+    //   1. POST /webauthn/keys/options  (server generates challenge + opts) → 200
+    //   2. navigator.credentials.create() via a CDP-supplied virtual authenticator
+    //   3. POST /webauthn/keys           (registration request body)
+    //
+    // We deliberately do NOT assert /webauthn/keys returns 201 — the dev stack
+    // is HTTP, and `web-auth/webauthn-lib`'s CheckOrigin rejects non-HTTPS
+    // origins unless `localhost` is in `securedRelyingPartyId`. asbiin/laravel-webauthn
+    // doesn't expose that knob (the wire-up is commented out in its service
+    // provider). So the request body — not the response status — is the
+    // swap contract: id, rawId, response (with attestationObject + clientDataJSON),
+    // type, and the user-supplied name field. Those are the fields
+    // WebauthnKeyController::store($request->only([...])) consumes.
+    //
+    // If/when a dev-side localhost RP override lands, this test can flip its
+    // assertion to a 201 check without changing the swap contract — the
+    // request-body shape is independent of server-side validation.
+    const cdp = await context.newCDPSession(page);
+    await cdp.send('WebAuthn.enable');
+    const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+      options: {
+        protocol: 'ctap2',
+        transport: 'internal',
+        hasResidentKey: true,
+        hasUserVerification: true,
+        isUserVerified: true,
+        automaticPresenceSimulation: true,
+      },
+    });
+
+    try {
+      await login(page);
+      await page.goto('/settings/security');
+
+      await page.getByRole('link', { name: 'Add a new security key' }).click();
+
+      // The modal is a <sweet-modal-overlay>; scope by "Key name" body copy —
+      // the underlying page also has a "Security key …" <h3>, which we'd
+      // rather not collide with.
+      const modal = page.locator('.sweet-modal-overlay').filter({ hasText: 'Key name' }).first();
+      await expect(modal).toBeVisible();
+
+      // form-input wraps the <input>, generating an id like `keyName<n>`
+      // (Vue _uid suffix). Locate by accessible role/label instead.
+      const keyName = `smoke vkey ${Date.now()}`;
+      await modal.getByRole('textbox', { name: /Key name/i }).fill(keyName);
+
+      // Capture the options + register POST round-trips.
+      const optionsResp = page.waitForResponse((r) =>
+        r.url().endsWith('/webauthn/keys/options') && r.request().method() === 'POST');
+      const storeReq = page.waitForRequest((r) =>
+        /\/webauthn\/keys$/.test(r.url()) && r.method() === 'POST');
+
+      await modal.getByRole('link', { name: 'Next' }).click();
+
+      expect((await optionsResp).status()).toBe(200);
+
+      // The swap contract: the client must POST these exact fields to
+      // /webauthn/keys. WebauthnKeyController::store does
+      // $request->only(['id', 'rawId', 'response', 'type']) plus
+      // $request->input('name'), so any drift in field names or nesting
+      // here will silently break registration after the swap.
+      const requestBody = JSON.parse((await storeReq).postData() ?? '{}');
+      expect(requestBody.name).toBe(keyName);
+      expect(typeof requestBody.id).toBe('string');
+      expect(typeof requestBody.rawId).toBe('string');
+      expect(requestBody.type).toBe('public-key');
+      expect(requestBody.response).toBeTruthy();
+      expect(typeof requestBody.response.attestationObject).toBe('string');
+      expect(typeof requestBody.response.clientDataJSON).toBe('string');
+    } finally {
+      // Detach the virtual authenticator. (No DB row to clean up because the
+      // server rejects the registration with 422 — see note above.)
+      await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
+      await cdp.detach();
+    }
+  });
+
   test('settings/dav mounts dav-resources with the base URL input', async ({ page }) => {
     // DavResources renders the WebDAV / CardDAV / CalDAV headings + the
     // base-URL readonly input populated from the dav-route prop. If the

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,15 +10,23 @@ import path from 'node:path';
 // Vue 2 ceiling: @vitejs/plugin-vue2 is archived (2025-10-04,
 // vitejs/vite-plugin-vue2) and peers vite ^3–^7. Pin vite to ~7 until the
 // Vue 3 migration lifts the cap.
+// STOPGAP — retires when #710 lands.
+//
 // asbiin/laravel-webauthn ships its browser client as a UMD file
-// (vendor/asbiin/laravel-webauthn/resources/js/webauthn.js) — the `WebAuthn`
+// (vendor/asbiin/laravel-webauthn/resources/js/webauthn.js) — the WebAuthn
 // constructor is exposed through `!function(e,t){...module.exports=t...}(this, WebAuthn)`.
 // Rollup's static analysis can't trace that into a default export from outside
-// node_modules, so `import WebAuthn from '...'` fails to build. Strip the UMD
-// wrapper and append an explicit ESM default export only for this one file —
-// pulling in @rollup/plugin-commonjs would do the same job but globally, and
-// the surface area isn't worth it for a single 220-line vendor script.
-// See #707 for the regression history.
+// node_modules, so `import WebAuthn from '...'` fails to build. This plugin
+// strips the UMD wrapper and appends an explicit ESM default export, scoped
+// to that one file path only.
+//
+// This is debt. The proper fix is #710: drop the vendored UMD client entirely
+// and use @simplewebauthn/browser (ESM-native, maintained, ~10KB). The
+// virtual-authenticator Playwright test in dependency-upgrade-smoke.spec.ts
+// (search "WebAuthn registration baseline") locks the registration flow's
+// behaviour so the swap PR can verify equivalence.
+//
+// See #707 (root regression), #709 (this stopgap), #710 (proper swap).
 const webauthnUmdToEsm = {
   name: 'fork:webauthn-umd-to-esm',
   enforce: 'pre',

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,33 @@ import path from 'node:path';
 // Vue 2 ceiling: @vitejs/plugin-vue2 is archived (2025-10-04,
 // vitejs/vite-plugin-vue2) and peers vite ^3–^7. Pin vite to ~7 until the
 // Vue 3 migration lifts the cap.
+// asbiin/laravel-webauthn ships its browser client as a UMD file
+// (vendor/asbiin/laravel-webauthn/resources/js/webauthn.js) — the `WebAuthn`
+// constructor is exposed through `!function(e,t){...module.exports=t...}(this, WebAuthn)`.
+// Rollup's static analysis can't trace that into a default export from outside
+// node_modules, so `import WebAuthn from '...'` fails to build. Strip the UMD
+// wrapper and append an explicit ESM default export only for this one file —
+// pulling in @rollup/plugin-commonjs would do the same job but globally, and
+// the surface area isn't worth it for a single 220-line vendor script.
+// See #707 for the regression history.
+const webauthnUmdToEsm = {
+  name: 'fork:webauthn-umd-to-esm',
+  enforce: 'pre',
+  transform(code, id) {
+    if (!id.endsWith('/asbiin/laravel-webauthn/resources/js/webauthn.js')) return null;
+    return {
+      code: code.replace(
+        /!function\(e,t\)\{[^}]+\}\(this,\s*WebAuthn\);?\s*$/,
+        '\nexport default WebAuthn;\n',
+      ),
+      map: null,
+    };
+  },
+};
+
 export default defineConfig(({ mode }) => ({
   plugins: [
+    webauthnUmdToEsm,
     laravel({
       input: [
         'resources/js/app.js',


### PR DESCRIPTION
## Summary

**Stopgap** for #707 — `<webauthn-connector>` throws `TypeError: WebAuthn$1 is not a constructor` on mount, so the "Add a new security key" button is silently a no-op. Surfaced by pr-t2's mount coverage smoke (#708).

The proper fix is filed as **#710** (swap the vendored UMD client for `@simplewebauthn/browser`). This PR's job is to unblock that work — keep WebAuthn registration working today, and add a baseline test that locks in the current wire shape so the swap can verify equivalence.

## What's in this PR

1. **Vite plugin `fork:webauthn-umd-to-esm`** (`vite.config.js`, ~10 lines, scoped to the single vendor file path) — rewrites the UMD wrapper on `vendor/asbiin/laravel-webauthn/.../webauthn.js` to `export default WebAuthn` so Rollup can produce a default import. Explicitly marked as STOPGAP in the comment block; retires when #710 lands.
2. **`WebauthnConnector.vue`** import-site change — `import * as WebAuthn` → `import WebAuthn`.
3. **Removed the `#707` entry from `KNOWN_CONSOLE_NOISE`** — the noise tolerance is no longer needed; the page is now clean.
4. **Baseline Playwright test** — drives the registration flow with a CDP virtual authenticator and asserts the request body shape on POST `/webauthn/keys`. This is the contract #710 must preserve.

## Why the regex-transform plugin (and not `@rollup/plugin-commonjs`)

`@rollup/plugin-commonjs` would solve the same problem globally. For a single 220-line vendor script that we're already planning to delete (#710), the broader plugin's surface area + dep weight isn't worth it. The fork plugin is path-scoped — it touches nothing else. The comment block calls it out as debt + links the proper fix.

## Why not test full register success (201)?

The dev stack runs on HTTP (`localhost:8082`). `web-auth/webauthn-lib`'s `CheckOrigin` ceremony step rejects non-HTTPS origins unless `localhost` is in `securedRelyingPartyId` — a knob `asbiin/laravel-webauthn` doesn't expose (the wire-up is commented out in its service provider, see `WebauthnServiceProvider.php:185`). So registration always 422s on the dev stack regardless of client correctness.

Filed **#711** to lift the dev stack to HTTPS via mkcert. Once that lands, the baseline test's last assertion can flip from "request body shape" to "201 status + key persisted + key cleanup via DELETE" without changing the swap contract — the wire shape is independent of server-side validation.

## Verification

- `yarn run prod` builds cleanly (5.85s).
- `docker cp public/build monica-app-1:/var/www/html/public/` to refresh the dev container.
- `cd tests/playwright && yarn run smoke` — 27/27 green.
- `yarn run smoke --grep mounts` — 8/8 green (no allowlist tolerance for #707 needed).
- `yarn run smoke --grep "webauthn registration baseline"` — 1/1 green; virtual authenticator drives create+register, request body has the expected fields.

## Sequence

1. ✅ #708 (pr-t2 mount smoke) — landed at `dabedbb7c`.
2. 👉 **This PR (#709)** — stopgap + baseline lock-in.
3. ⏭ #710 — swap vendored client for `@simplewebauthn/browser`; remove the vite plugin; remove the import path; keep the baseline test green.
4. ⏭ #711 — HTTPS dev stack; strengthen the baseline test to assert 201 + DB row.

## Test plan

- [x] Build clean (`yarn run prod`)
- [x] Container assets refreshed
- [x] Full smoke green (27/27)
- [x] Baseline test green (request body fields present)
- [x] No allowlist entry for #707
- [ ] Manual: log in, click "Add a new security key", confirm modal opens (no virtual-auth path means we don't go further than modal open in manual)

Closes #707
References #710, #711

🤖 Generated with [Claude Code](https://claude.com/claude-code)
