### PR TITLE
refactor(webauthn): swap vendored UMD for @simplewebauthn/browser (#710)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@hokify/vuejs-datepicker": "^2.0",
+    "@simplewebauthn/browser": "^13.3.0",
     "animate.css": "^4.1",
     "axios": "^1.16",
     "bootstrap": "^4.6",

--- a/resources/js/components/settings/WebauthnConnector.vue
+++ b/resources/js/components/settings/WebauthnConnector.vue
@@ -176,7 +176,7 @@
 <script>
 import { SweetModal } from 'sweet-modal-vue';
 import moment from 'moment-timezone';
-import WebAuthn from '../../../../vendor/asbiin/laravel-webauthn/resources/js/webauthn.js';
+import { startRegistration, startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
 
 export default {
 
@@ -219,8 +219,6 @@ export default {
       keyToTrash: '',
       keyName: '',
       registerTab: '',
-      data: null,
-      webauthn: null,
     };
   },
 
@@ -232,11 +230,7 @@ export default {
   methods: {
     prepareComponent() {
       this.currentkeys = this.keys;
-      this.data = this.registerdata;
-
-      this.webauthn = new WebAuthn((name, message) => {
-        this.errorMessage = this._errorMessage(name, message);
-      });
+      this.isSupported = browserSupportsWebAuthn();
     },
 
     _errorMessage(name, message) {
@@ -251,32 +245,27 @@ export default {
     },
 
     notSupportedMessage() {
-      return this.$t('settings.webauthn_'+this.webauthn.notSupportedMessage());
+      if (! window.isSecureContext && window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
+        return this.$t('settings.webauthn_not_secured');
+      }
+      return this.$t('settings.webauthn_not_supported');
     },
 
     start() {
-      var self = this;
       this.errorMessage = '';
 
-      if (! this.webauthn.webAuthnSupport()) {
+      if (! browserSupportsWebAuthn()) {
         this.isSupported = false;
         this.errorMessage = this.notSupportedMessage();
+        return;
       }
 
       switch(this.method) {
       case 'register':
-        setTimeout(function () {
-          self.webauthn.register(
-            self.publicKey,
-            function (datas) { self.webauthnRegisterCallback(datas, true); }
-          );
-        }, 10);
+        setTimeout(() => this.doRegister(this.publicKey, true), 10);
         break;
       case 'login':
-        this.webauthn.sign(
-          this.publicKey,
-          function (data) { self.webauthnLoginCallback(data); }
-        );
+        this.doLogin(this.publicKey);
         break;
       }
     },
@@ -295,21 +284,14 @@ export default {
     },
 
     startRegister() {
-      var self = this;
       this.errorMessage = '';
       axios.post('webauthn/keys/options')
         .then(response => {
-          if (self.registerTab === '2') {
-            var data = response.data.publicKey;
-            setTimeout(function () {
-              self.webauthn.register(
-                data,
-                function (datas) { self.webauthnRegisterCallback(datas, false); }
-              );
-            }, 10);
+          if (this.registerTab === '2') {
+            setTimeout(() => this.doRegister(response.data.publicKey, false), 10);
           }
         }).catch(error => {
-          self.notify(error.response.data.message, false);
+          this.notify(error.response?.data?.message ?? error.message, false);
         });
     },
 
@@ -318,43 +300,51 @@ export default {
       this.showRegisterModalTab('');
     },
 
-    webauthnRegisterCallback(data, redirect) {
-      var self = this;
-      axios.post('webauthn/keys', {
-        ...data,
-        name: self.keyName,
-      }).then(response => {
-        self.success = true;
-        self.notify(self.$t('settings.webauthn_success'), true);
-        self.currentkeys.push({
-          id: response.result.id,
-          name: response.result.name,
+    async doRegister(publicKey, redirect) {
+      let attResp;
+      try {
+        attResp = await startRegistration({ optionsJSON: publicKey });
+      } catch (error) {
+        this.errorMessage = this._errorMessage(error.name, error.message);
+        return;
+      }
+      try {
+        const response = await axios.post('webauthn/keys', {
+          ...attResp,
+          name: this.keyName,
         });
-      }).then(response => {
+        this.success = true;
+        this.notify(this.$t('settings.webauthn_success'), true);
+        this.currentkeys.push({
+          id: response.data.result.id,
+          name: response.data.result.name,
+        });
         if (redirect) {
-          setTimeout(function () {
-            window.location = response.data.callback;
-          }, 100);
+          setTimeout(() => { window.location = response.data.callback; }, 100);
         } else {
-          self.closeRegisterModal();
+          this.closeRegisterModal();
         }
-      }).catch(error => {
-        self.errorMessage = error.message ? error.message : error.response.data.message;
-      });
+      } catch (error) {
+        this.errorMessage = error.message ? error.message : error.response.data.message;
+      }
     },
 
-    webauthnLoginCallback(data) {
-      var self = this;
-      axios.post('webauthn/auth', {
-        ...data
-      }).then(response => {
-        self.success = true;
-        self.notify(self.$t('settings.webauthn_success'), true);
-
+    async doLogin(publicKey) {
+      let assertionResp;
+      try {
+        assertionResp = await startAuthentication({ optionsJSON: publicKey });
+      } catch (error) {
+        this.errorMessage = this._errorMessage(error.name, error.message);
+        return;
+      }
+      try {
+        const response = await axios.post('webauthn/auth', { ...assertionResp });
+        this.success = true;
+        this.notify(this.$t('settings.webauthn_success'), true);
         window.location = response.data.callback;
-      }).catch(error => {
-        self.errorMessage = error.message ? error.message : error.response.data.message;
-      });
+      } catch (error) {
+        this.errorMessage = error.message ? error.message : error.response.data.message;
+      }
     },
 
     webauthnRemove(id) {

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -69,6 +69,18 @@ async function login(page: Page): Promise<void> {
   await page.waitForURL('**/dashboard');
 }
 
+// Base64url-no-padding decode. The PHP server (web-auth/webauthn-lib) decodes
+// `clientDataJSON` and `id` via ParagonIE\ConstantTime\Base64UrlSafe::decodeNoPadding,
+// which is strict — it only accepts the base64url charset (`-`, `_`) and rejects
+// any string ending in `=`. Mirroring that exact contract here lets the test
+// fail loudly if the client ever regresses to plain base64.
+function decodeBase64UrlNoPadding(value: string): Uint8Array {
+  if (/[^A-Za-z0-9_-]/.test(value)) throw new Error(`not base64url: ${value.slice(0, 32)}…`);
+  if (value.endsWith('=')) throw new Error('base64url-no-padding required, got padding');
+  const pad = value.length % 4 === 0 ? '' : '='.repeat(4 - (value.length % 4));
+  return Uint8Array.from(Buffer.from(value.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64'));
+}
+
 test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
   test('login lands on dashboard with expected nav', async ({ page }) => {
     const { unknown } = attachConsoleCapture(page);
@@ -560,28 +572,32 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     assertNoUnknownConsoleErrors(unknown, '/settings/security');
   });
 
-  test('webauthn registration baseline: virtual authenticator drives the register wire shape (pre-swap contract for #710)', async ({ page, context }) => {
-    // BASELINE — locks in the current (post-#709 stopgap) JS client's wire
-    // shape so the @simplewebauthn/browser swap (#710) can verify it produces
-    // the same request body. The swap PR keeps this test green as its contract.
+  test('webauthn registration: virtual authenticator drives the register wire shape (swap contract for #710)', async ({ page, context }) => {
+    // SWAP CONTRACT — locks in @simplewebauthn/browser's POST /webauthn/keys
+    // wire shape against what web-auth/webauthn-lib's PHP server expects.
     //
     // What this exercises:
     //   1. POST /webauthn/keys/options  (server generates challenge + opts) → 200
     //   2. navigator.credentials.create() via a CDP-supplied virtual authenticator
     //   3. POST /webauthn/keys           (registration request body)
     //
-    // We deliberately do NOT assert /webauthn/keys returns 201 — the dev stack
-    // is HTTP, and `web-auth/webauthn-lib`'s CheckOrigin rejects non-HTTPS
-    // origins unless `localhost` is in `securedRelyingPartyId`. asbiin/laravel-webauthn
-    // doesn't expose that knob (the wire-up is commented out in its service
-    // provider). So the request body — not the response status — is the
-    // swap contract: id, rawId, response (with attestationObject + clientDataJSON),
-    // type, and the user-supplied name field. Those are the fields
-    // WebauthnKeyController::store($request->only([...])) consumes.
+    // Semantic asserts below mirror the server's decoder chain:
+    //   - id            → Base64UrlSafe::decodeNoPadding   (strict)
+    //   - rawId         → Util\Base64::decode              (tolerant)
+    //   - clientDataJSON → Base64UrlSafe::decodeNoPadding  (strict; then JSON parse)
+    //   - attestationObject → Util\Base64::decode          (tolerant; then CBOR)
     //
-    // If/when a dev-side localhost RP override lands, this test can flip its
-    // assertion to a 201 check without changing the swap contract — the
-    // request-body shape is independent of server-side validation.
+    // The "strict" decoder rejects `+`/`/` (plain-base64) characters and any
+    // string ending in `=`. SimpleWebAuthn always emits base64url-no-padding,
+    // which round-trips cleanly through both paths.
+    //
+    // We deliberately do NOT assert /webauthn/keys returns 201 — the dev stack
+    // is HTTP and web-auth/webauthn-lib's CheckOrigin step rejects non-HTTPS
+    // origins unless `localhost` is in `securedRelyingPartyId`, a knob
+    // asbiin/laravel-webauthn doesn't expose. The wire shape IS the contract;
+    // server-side acceptance is gated independently. If/when a dev-side
+    // localhost RP override lands (e.g. #711), this test can flip the final
+    // assertion to a 201 check without touching the semantic checks.
     const cdp = await context.newCDPSession(page);
     await cdp.send('WebAuthn.enable');
     const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
@@ -620,21 +636,44 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
 
       await modal.getByRole('link', { name: 'Next' }).click();
 
-      expect((await optionsResp).status()).toBe(200);
+      const optionsResponse = await optionsResp;
+      expect(optionsResponse.status()).toBe(200);
+      const optionsBody = await optionsResponse.json();
+      const serverChallenge = optionsBody.publicKey.challenge;
+      expect(typeof serverChallenge).toBe('string');
 
-      // The swap contract: the client must POST these exact fields to
-      // /webauthn/keys. WebauthnKeyController::store does
-      // $request->only(['id', 'rawId', 'response', 'type']) plus
-      // $request->input('name'), so any drift in field names or nesting
-      // here will silently break registration after the swap.
       const requestBody = JSON.parse((await storeReq).postData() ?? '{}');
+
+      // Field presence + the keyName the user typed.
       expect(requestBody.name).toBe(keyName);
+      expect(requestBody.type).toBe('public-key');
       expect(typeof requestBody.id).toBe('string');
       expect(typeof requestBody.rawId).toBe('string');
-      expect(requestBody.type).toBe('public-key');
-      expect(requestBody.response).toBeTruthy();
-      expect(typeof requestBody.response.attestationObject).toBe('string');
-      expect(typeof requestBody.response.clientDataJSON).toBe('string');
+      expect(typeof requestBody.response?.attestationObject).toBe('string');
+      expect(typeof requestBody.response?.clientDataJSON).toBe('string');
+
+      // Strict-base64url contract for the two fields the server decodes strictly.
+      const idBytes = decodeBase64UrlNoPadding(requestBody.id);
+      const rawIdBytes = decodeBase64UrlNoPadding(requestBody.rawId);
+      // W3C spec: PublicKeyCredential.id is base64url(rawId).
+      expect(Buffer.from(idBytes).equals(Buffer.from(rawIdBytes))).toBe(true);
+
+      // clientDataJSON: decode + parse + verify type/challenge/origin all line up.
+      const clientDataBytes = decodeBase64UrlNoPadding(requestBody.response.clientDataJSON);
+      const clientData = JSON.parse(new TextDecoder().decode(clientDataBytes));
+      expect(clientData.type).toBe('webauthn.create');
+      expect(clientData.challenge).toBe(serverChallenge);
+      const expectedOrigin = new URL(optionsResponse.url()).origin;
+      expect(clientData.origin).toBe(expectedOrigin);
+
+      // attestationObject: decodes as base64url AND begins with a CBOR map
+      // tag. web-auth's AttestationObjectDenormalizer feeds this into a CBOR
+      // decoder expecting `{fmt, attStmt, authData}` — so the top-level byte
+      // must be a major-type-5 (map) marker (0xa0–0xb7 short form, or 0xb8
+      // followed by a length byte).
+      const attBytes = decodeBase64UrlNoPadding(requestBody.response.attestationObject);
+      const major = attBytes[0] >> 5;
+      expect(major).toBe(5);
     } finally {
       // Detach the virtual authenticator. (No DB row to clean up because the
       // server rejects the registration with 422 — see note above.)

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,41 +10,9 @@ import path from 'node:path';
 // Vue 2 ceiling: @vitejs/plugin-vue2 is archived (2025-10-04,
 // vitejs/vite-plugin-vue2) and peers vite ^3–^7. Pin vite to ~7 until the
 // Vue 3 migration lifts the cap.
-// STOPGAP — retires when #710 lands.
-//
-// asbiin/laravel-webauthn ships its browser client as a UMD file
-// (vendor/asbiin/laravel-webauthn/resources/js/webauthn.js) — the WebAuthn
-// constructor is exposed through `!function(e,t){...module.exports=t...}(this, WebAuthn)`.
-// Rollup's static analysis can't trace that into a default export from outside
-// node_modules, so `import WebAuthn from '...'` fails to build. This plugin
-// strips the UMD wrapper and appends an explicit ESM default export, scoped
-// to that one file path only.
-//
-// This is debt. The proper fix is #710: drop the vendored UMD client entirely
-// and use @simplewebauthn/browser (ESM-native, maintained, ~10KB). The
-// virtual-authenticator Playwright test in dependency-upgrade-smoke.spec.ts
-// (search "WebAuthn registration baseline") locks the registration flow's
-// behaviour so the swap PR can verify equivalence.
-//
-// See #707 (root regression), #709 (this stopgap), #710 (proper swap).
-const webauthnUmdToEsm = {
-  name: 'fork:webauthn-umd-to-esm',
-  enforce: 'pre',
-  transform(code, id) {
-    if (!id.endsWith('/asbiin/laravel-webauthn/resources/js/webauthn.js')) return null;
-    return {
-      code: code.replace(
-        /!function\(e,t\)\{[^}]+\}\(this,\s*WebAuthn\);?\s*$/,
-        '\nexport default WebAuthn;\n',
-      ),
-      map: null,
-    };
-  },
-};
 
 export default defineConfig(({ mode }) => ({
   plugins: [
-    webauthnUmdToEsm,
     laravel({
       input: [
         'resources/js/app.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,11 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz#da4f1676d87e2bdf744291b504b0ab79550c3e61"
   integrity sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==
 
+"@simplewebauthn/browser@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@simplewebauthn/browser/-/browser-13.3.0.tgz#e12153e71f4a8f4f8f17f94ca9c5161115306239"
+  integrity sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==
+
 "@snyk/protect@^1.1305.0":
   version "1.1305.0"
   resolved "https://registry.yarnpkg.com/@snyk/protect/-/protect-1.1305.0.tgz#a21da9c5ec17bdbeaf2ed23c0b9e69cc3b53ffdf"


### PR DESCRIPTION
## Summary

Closes #710. Retires the `fork:webauthn-umd-to-esm` vite plugin introduced as a stopgap in #709.

- `resources/js/components/settings/WebauthnConnector.vue` rewritten on `@simplewebauthn/browser@13.3.0` using `startRegistration({optionsJSON})` / `startAuthentication({optionsJSON})` (v11+ API). Both `register-modal` and `login` branches migrated — rewriting both was the only way to satisfy #710's acceptance criterion 2 (full removal of the vite plugin).
- `fork:webauthn-umd-to-esm` deleted from `vite.config.js`. No `vendor/asbiin/laravel-webauthn/...` import remains in `resources/js/`.
- **Side bug fixed inline:** the post-registration optimistic-UI push read `response.result.id` / `response.result.name` where it should read `response.data.result.id` / `response.data.result.name` (axios wraps the body in `.data`). Newly-registered keys appeared in the list as `{id: undefined, name: undefined}` until a page reload. Fix lives in the rewritten callback.

## Test plan

- [x] `yarn run lint` clean
- [x] `yarn run prod` builds; no UMD-interop warnings
- [x] `yarn run smoke` 27/27 green
- [x] Baseline test from #709 strengthened to a semantic contract (see "Verification")
- [x] End-to-end server acceptance confirmed via a throwaway vendor patch (reverted; not in this PR)

## Verification

### Wire-shape contract

The pre-swap baseline test (`webauthn registration baseline`, #709) is now the **swap contract**. Strengthened from type-level (`typeof rawId === 'string'`) to semantic correctness, mirroring `web-auth/webauthn-lib`'s decoder chain:

| Field | Server decoder | Test asserts |
|---|---|---|
| `id` | `Base64UrlSafe::decodeNoPadding` (strict) | base64url-no-padding, equals `rawId` per W3C spec |
| `rawId` | `Util\Base64::decode` (tolerant) | base64url-no-padding |
| `clientDataJSON` | `Base64UrlSafe::decodeNoPadding` (strict) | base64url-no-padding; parses as JSON; `type === 'webauthn.create'`; `challenge` round-trips against the server-issued challenge; `origin` matches the page origin |
| `attestationObject` | `Util\Base64::decode` (tolerant) | base64url-no-padding; first byte is CBOR major-type-5 (map) marker — what `AttestationObjectDenormalizer` consumes |

`Base64UrlSafe::decodeNoPadding` only accepts the base64url charset (`-`, `_`) and rejects strings ending in `=`. SimpleWebAuthn emits base64url-no-padding uniformly, which round-trips cleanly through both the strict and tolerant decoders.

### End-to-end server acceptance

Confirmed by temporarily patching `vendor/asbiin/laravel-webauthn/src/WebauthnServiceProvider.php` to add `setSecuredRelyingPartyId(['localhost'])`, bypassing `CheckOrigin`'s HTTPS gate on the HTTP dev stack. With the patch in place:

```
[local.INFO]  Checking the authenticator attestation response { ... }
[local.INFO]  The attestation is valid
[local.DEBUG] Credential Record { ... complete attested credential data ... }
```

i.e. the new wire passes the entire ceremony (`CheckOrigin → CheckChallenge → CheckRelyingPartyIdIdHash → CheckUserVerification → CheckAlgorithm → CheckAttestationFormat → CheckCredentialId`). Patch reverted before commit.

That same end-to-end run surfaced an **unrelated upstream `TypeError` in `asbiin/laravel-webauthn`** itself: it declares `:PublicKeyCredentialSource` returns where `web-auth/webauthn-lib` v5 returns the parent class `CredentialRecord`. Filed at [asbiin/laravel-webauthn#522](https://github.com/asbiin/laravel-webauthn/issues/522). Not blocking this PR — exists on `4.x` independent of which JS client emits the wire.

## Spec-compliance note

`@simplewebauthn/browser` emits base64url-no-padding uniformly. The previous vendored client emitted `clientDataJSON` as base64-with-`=`-stripped (still containing `+`/`/`), which would have been **strictly invalid** under `Base64UrlSafe::decodeNoPadding` for any input whose base64 encoding included `+` or `/`. This swap is **more spec-compliant** with the PHP server than the previous client, not less.

## Followups

- If/when #711 (HTTPS dev stack via mkcert) lands, the wire-shape test can be tightened from "request body shape" to "201 + DB row" without changing the contract assertions — the wire is independent of server-side acceptance gating.
