### PR TITLE
chore(deps): remove unused vue-checkbox-radio

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "tachyons": "^4.12",
     "vue": "^2.7",
     "vue-autosuggest": "^2.2",
-    "vue-checkbox-radio": "^0.6",
     "vue-clipboard2": "^0.3",
     "vue-cropperjs": "^4.2.0",
     "vue-directive-tooltip": "^1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2796,11 +2796,6 @@ vue-autosuggest@^2.2:
   resolved "https://registry.yarnpkg.com/vue-autosuggest/-/vue-autosuggest-2.2.0.tgz#0202b9aaeeef6a3a4357bf401a73be2ecbe166f1"
   integrity sha512-cHgEakpoRUOaqXXEo8RcRrbSTM3eAaCu9b55ZXiKbaS6IUD8ewqffQrMy/A1DXqHSQbyEEGui4oAsCbRge29Jg==
 
-vue-checkbox-radio@^0.6:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/vue-checkbox-radio/-/vue-checkbox-radio-0.6.0.tgz#616d83aaab60dbcad9ae18ffb7d9d471f4746f76"
-  integrity sha512-qaXzRR9Mji5onbYPvxXbXdCSHkJmauMirCWnHYG4uNLy7xXNoSBJOtetMnuE2KkVL6DbLycFe/uCLmx7LrXoNg==
-
 vue-clipboard2@^0.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz#331fec85f9d4f175eb0d4feaef4d77338562af36"


### PR DESCRIPTION
## Summary

- `vue-checkbox-radio` has been in `package.json` since 2018-02-11 (#890) and has never been imported. `git log --diff-filter=AD -S "vue-checkbox-radio" -- resources/` returns no commits.
- `yarn.lock` lists it only as a top-level entry — no transitive callers, not a peer dep.
- Vue 3 migration plan (`docs/plans/2026-05-27-vue3-migration-design.md`) called this out as part of tranche pr-1b assuming a refactor was needed; the audit found it was a straight manifest removal.

## Test plan

- [x] `yarn remove vue-checkbox-radio` cleanly updates `package.json` + `yarn.lock`
- [x] `yarn run prod` builds with no new warnings
- [x] Full Playwright smoke (31/31) passes — confirms nothing in the bundle was relying on it transitively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
