### PR TITLE
refactor(clipboard): swap vue-clipboard2 for native navigator.clipboard (pr-1a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "tachyons": "^4.12",
     "vue": "^2.7",
     "vue-autosuggest": "^2.2",
-    "vue-clipboard2": "^0.3",
     "vue-cropperjs": "^4.2.0",
     "vue-directive-tooltip": "^1.6",
     "vue-good-table": "^2.21",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -16,7 +16,6 @@ import './bootstrap';
 import Vue from 'vue';
 import Notifications from 'vue-notification';
 import Tooltip from 'vue-directive-tooltip';
-import VueClipboard from 'vue-clipboard2';
 
 // Custom components — Passport
 import PassportClients from './components/passport/Clients.vue';
@@ -104,10 +103,6 @@ Vue.use(Notifications);
 
 // Tooltip
 Vue.use(Tooltip, { delay: 0 });
-
-// Copy text from clipboard
-VueClipboard.config.autoSetContainer = true;
-Vue.use(VueClipboard);
 
 // Custom components
 Vue.component('PassportClients', PassportClients);

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -372,10 +372,11 @@ export default {
      * Copy text into clipboard
      */
     copyIntoClipboard(text) {
-      this.$copyText(text)
-        .then(response => {
+      navigator.clipboard.writeText(text)
+        .then(() => {
           this.notify(this.$t('settings.dav_clipboard_copied'), true);
-        });
+        })
+        .catch(() => { /* silent on permission denial / non-secure context */ });
     },
 
     notify(text, success) {

--- a/resources/js/components/passport/PersonalAccessTokens.vue
+++ b/resources/js/components/passport/PersonalAccessTokens.vue
@@ -319,10 +319,11 @@ export default {
      * Copy text into clipboard
      */
     copyIntoClipboard(text) {
-      this.$copyText(text)
-        .then(response => {
+      navigator.clipboard.writeText(text)
+        .then(() => {
           this.notify(this.$t('settings.dav_clipboard_copied'), true);
-        });
+        })
+        .catch(() => { /* silent on permission denial / non-secure context */ });
     },
 
     notify(text, success) {

--- a/resources/js/components/settings/DAVResources.vue
+++ b/resources/js/components/settings/DAVResources.vue
@@ -109,10 +109,11 @@ export default {
   methods: {
 
     copyIntoClipboard(text) {
-      this.$copyText(text)
-        .then(response => {
+      navigator.clipboard.writeText(text)
+        .then(() => {
           this.notify(this.$t('settings.dav_clipboard_copied'), true);
-        });
+        })
+        .catch(() => { /* silent on permission denial / non-secure context */ });
     },
 
     notify(text, success) {

--- a/resources/js/components/settings/RecoveryCodes.vue
+++ b/resources/js/components/settings/RecoveryCodes.vue
@@ -106,10 +106,11 @@ export default {
     },
 
     copyIntoClipboard() {
-      this.$copyText(this.getDataStream())
-        .then(response => {
+      navigator.clipboard.writeText(this.getDataStream())
+        .then(() => {
           this.notify(this.$t('settings.recovery_clipboard'), true);
-        });
+        })
+        .catch(() => { /* silent on permission denial / non-secure context */ });
     },
 
     getDataStream() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,15 +913,6 @@ cli-truncate@^5.0.0:
     slice-ansi "^8.0.0"
     string-width "^8.2.0"
 
-clipboard@^2.0.0:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.11.tgz#62180360b97dd668b6b3a84ec226975762a70be5"
-  integrity sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==
-  dependencies:
-    good-listener "^1.2.2"
-    select "^1.1.2"
-    tiny-emitter "^2.0.0"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1111,11 +1102,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-delegate@^3.1.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
-  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 detect-libc@^2.0.3:
   version "2.1.2"
@@ -1641,13 +1627,6 @@ globals@^17.6.0:
   version "17.6.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
   integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
-
-good-listener@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
-  integrity sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==
-  dependencies:
-    delegate "^3.1.2"
 
 gopd@^1.2.0:
   version "1.2.0"
@@ -2448,11 +2427,6 @@ sass@^1.99.0:
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
 
-select@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
-  integrity sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==
-
 semver@^7.6.3, semver@^7.7.3:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
@@ -2650,11 +2624,6 @@ throttleit@^1.0.0:
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.1.tgz#304ec51631c3b770c65c6c6f76938b384000f4d5"
   integrity sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==
 
-tiny-emitter@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
 tinyglobby@^0.2.15:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -2795,13 +2764,6 @@ vue-autosuggest@^2.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vue-autosuggest/-/vue-autosuggest-2.2.0.tgz#0202b9aaeeef6a3a4357bf401a73be2ecbe166f1"
   integrity sha512-cHgEakpoRUOaqXXEo8RcRrbSTM3eAaCu9b55ZXiKbaS6IUD8ewqffQrMy/A1DXqHSQbyEEGui4oAsCbRge29Jg==
-
-vue-clipboard2@^0.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/vue-clipboard2/-/vue-clipboard2-0.3.3.tgz#331fec85f9d4f175eb0d4feaef4d77338562af36"
-  integrity sha512-aNWXIL2DKgJyY/1OOeITwAQz1fHaCIGvUFHf9h8UcoQBG5a74MkdhS/xqoYe7DNZdQmZRL+TAdIbtUs9OyVjbw==
-  dependencies:
-    clipboard "^2.0.0"
 
 vue-cropperjs@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Summary

Tranche **pr-1a** of the Vue 3 migration plan (`docs/plans/2026-05-27-vue3-migration-design.md`). Swaps the abandoned `vue-clipboard2` (wraps the unmaintained `clipboard.js` legacy `document.execCommand('copy')` path) for the native `navigator.clipboard.writeText` API across the four call sites.

Pre-cutover on Vue 2 — no Vue 3 surface touched.

### Call sites

| file | before | after |
|---|---|---|
| `settings/DAVResources.vue:111` | `this.$copyText(text)` | `navigator.clipboard.writeText(text)` |
| `settings/RecoveryCodes.vue:108` | `this.$copyText(this.getDataStream())` | `navigator.clipboard.writeText(this.getDataStream())` |
| `passport/PersonalAccessTokens.vue:321` | `this.$copyText(text)` | `navigator.clipboard.writeText(text)` |
| `passport/Clients.vue:374` | `this.$copyText(text)` | `navigator.clipboard.writeText(text)` |

Plus removal of the global `Vue.use(VueClipboard)` registration in `app.js` and the `vue-clipboard2` package from `package.json` / `yarn.lock`.

Each handler gains an explicit `.catch(() => {})` to swallow the `NotAllowedError` rejection that `navigator.clipboard.writeText` raises on permission denial. `vue-clipboard2` silently swallowed the equivalent failure inside `clipboard.js`; the explicit catch preserves that UX without leaking unhandled-rejection warnings into the console (and into `attachConsoleCapture`).

## Non-secure context note

`navigator.clipboard.writeText` requires a secure context (HTTPS or localhost). Self-hosted Monica deployments running over plain HTTP will no longer see the "Value copied into your clipboard" toast — `clipboard.js` worked over HTTP because `execCommand` isn't permission-gated. This matches modern browser direction; users behind HTTPS or accessing via localhost are unaffected. README's stability/security posture explicitly accepts modern-browser baselines.

## Test plan

- [x] **pr-1a smoke guard** ([#714](https://github.com/brycehans/monica/pull/714)) — `settings/dav copy button surfaces success toast` — green against refactored bundle
- [x] Full Playwright smoke suite — 31/31 green
- [x] `yarn run prod` — clean build, no new warnings
- [x] `grep -rn "vue-clipboard\|VueClipboard\|\$copyText" resources/` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
