### PR TITLE
refactor(forms): swap pretty-checkbox-vue for native input + pretty-checkbox css

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "moment": "^2.30",
     "moment-timezone": "^0.5.48",
     "popper.js": "^1.16",
-    "pretty-checkbox-vue": "^1.1",
+    "pretty-checkbox": "^3.0.3",
     "rx-js": "^0.0.0",
     "sass": "^1.99.0",
     "sweet-modal-vue": "^2.0",

--- a/resources/js/components/partials/form/PInput.vue
+++ b/resources/js/components/partials/form/PInput.vue
@@ -1,21 +1,22 @@
 <template>
   <div :class="dclass">
-    <div>
-      <p-input
+    <div :class="wrapperClass">
+      <input
         ref="input"
-        v-model.lazy="prop"
-        :name="name"
         :type="_type"
-        :class="inputClass"
-        :color="inputColor"
+        :name="name"
         :value="value"
+        :checked="shouldBeChecked"
         :disabled="disabled"
         :required="required"
-        @change="$emit('change', $event)"
-      >
-        <slot></slot>
-        <slot slot="extra" name="inputextra"></slot>
-      </p-input>
+        @change="onChange"
+      />
+      <div :class="stateClass">
+        <slot name="inputextra"></slot>
+        <label>
+          <slot></slot>
+        </label>
+      </div>
     </div>
     <div class="pointer" @click="select()">
       <label v-if="hasSlot('label')" class="pointer">
@@ -27,13 +28,7 @@
 </template>
 
 <script>
-import PInput from 'pretty-checkbox-vue/input';
-
 export default {
-
-  components: {
-    PInput
-  },
 
   model: {
     prop: 'modelValue',
@@ -79,12 +74,6 @@ export default {
     }
   },
 
-  data() {
-    return {
-      prop: null
-    };
-  },
-
   computed: {
     _type() {
       if (this.$options.input_type) {
@@ -98,39 +87,47 @@ export default {
     inputColor() {
       return this.color !== '' ? this.color : 'primary-o';
     },
-  },
-
-  watch: {
-    modelValue(val) {
-      this.prop = val;
+    wrapperClass() {
+      return ['pretty', this.inputClass];
+    },
+    stateClass() {
+      return ['state', `p-${this.inputColor}`];
+    },
+    shouldBeChecked() {
+      if (this._type === 'radio') {
+        return this.modelValue === this.value;
+      }
+      return typeof this.modelValue === 'string' ? this.modelValue !== '' : !!this.modelValue;
     },
   },
 
-  mounted() {
-    this.prop = this.modelValue;
-  },
-
   methods: {
+    onChange(event) {
+      if (this._type === 'radio') {
+        this.$emit('change', this.value);
+        return;
+      }
+      this.$emit('change', event.target.checked);
+    },
     select() {
       if (this.disabled) {
         return;
       }
-      switch (this._type)
-      {
+      switch (this._type) {
       case 'checkbox':
-        this.$refs.input.$refs.input.checked = ! this.$refs.input.$refs.input.checked;
-        this.$emit('change', this.$refs.input.$refs.input.checked);
+        this.$refs.input.checked = ! this.$refs.input.checked;
+        this.$emit('change', this.$refs.input.checked);
         break;
       case 'radio':
-        this.$refs.input.$refs.input.checked = true;
+        this.$refs.input.checked = true;
         this.$emit('change', this.value);
         break;
       case 'input':
-          //this.$refs.input.$refs.input.focus();
+          //this.$refs.input.focus();
       }
     },
     hasSlot (name = 'default') {
-      return !!this.$slots[ name ] || !!this.$scopedSlots[ name ];
+      return !!this.$slots[ name ];
     }
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2256,13 +2256,6 @@ pretty-bytes@^5.6.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
-pretty-checkbox-vue@^1.1:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/pretty-checkbox-vue/-/pretty-checkbox-vue-1.1.9.tgz#2d4bfc7f20c54a0e7b94b3d205641dbf8f390fb4"
-  integrity sha512-45HOanzF+BUTD5prwCoNrtEFYVzWtASTIIPtPQxGCajC097pFD/9mbyjEjoTsu8Tk4/rSyA7RNk6JpFWVHpLag==
-  dependencies:
-    pretty-checkbox "^3.0.3"
-
 pretty-checkbox@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/pretty-checkbox/-/pretty-checkbox-3.0.3.tgz#d49c8013a8fc08ee0c2d6ebde453464bfdbc428e"


### PR DESCRIPTION
## Summary

- Phase 1 / pr-1b of the Vue 3 migration plan (#702). Drops `pretty-checkbox-vue` without changing visuals: `PInput.vue` now emits the same wrapper-div + native-input + state-div DOM shape `pretty-checkbox-vue`'s `<p-input>` was producing, so the existing `@import "pretty-checkbox/src/pretty-checkbox"` rules in `resources/sass/app-ltr.scss` keep painting it bit-for-bit.
- Promotes the CSS-only `pretty-checkbox` package from a transitive (via `pretty-checkbox-vue`) to a direct dependency so the SCSS import keeps resolving. Phase 2 cutover removes that import + the direct dep together.
- `$scopedSlots` reference dropped from `hasSlot` (Vue 2-only; was always paired with `$slots`).

## Why

The Vue 3 migration plan (`docs/plans/2026-05-27-vue3-migration-design.md`) lists `pretty-checkbox-vue` under Phase 1 plugin stripping. The package's last release was 1.1.9 in 2019; it's a thin Vue 2 wrapper over a CSS-only library. Going to a native `<input>` element now removes the only `$scopedSlots` callsite in the tree (Phase 2 had to address it regardless) and gets one less Vue 2 plugin onto the cutover plate.

## Design fork: thin wrapper vs. inline

The handoff identified two reasonable shapes. Going with **option (a) — keep `PInput.vue` as a thin wrapper around a native `<input>`, preserve the external API for `FormCheckbox` / `FormRadio`**:

- `Checkbox.vue` and `Radio.vue` were already one-line re-exports of `PInput` with `input_type`/`input_iclass` overrides — that pattern is the entire reason `PInput` exists. Inlining would duplicate the slot / v-model / `select()` plumbing.
- The pr-1b smoke guard at `dependency-upgrade-smoke.spec.ts:902-937` deliberately clicks the native input directly and notes _"avoids depending on pretty-checkbox-vue's wrapper DOM, which the post-cutover swap will restructure"_ — so the contract is the native input + name + checked round-trip, exactly what (a) preserves.
- Matches the "no architectural refactors" constraint in CLAUDE.md.

## What changes in `PInput.vue`

The pretty styling isn't in the native control — `pretty-checkbox.scss` hides the input (`.pretty input` → `position:absolute; opacity:0`) and paints a sibling `<div class="state">` as the visible widget. The rewrite mirrors `pretty-checkbox-vue`'s DOM shape so the same SCSS keeps applying:

```html
<div class="pretty p-default p-curve p-thick">    <!-- inherited classes drive size/corner -->
  <input type="checkbox" name="…" :checked="…">   <!-- native, hidden by pretty-checkbox CSS -->
  <div class="state p-primary-o">                  <!-- painted by pretty-checkbox CSS -->
    <label>…slot…</label>
  </div>
</div>
```

External API preserved: same props, same `model: { prop: 'modelValue', event: 'change' }`, same `select()` method, same slots (`default`, `inputextra`, `label`, `extra`). `Checkbox.vue` and `Radio.vue` are unchanged.

## Verification

- `yarn run prod` clean
- `yarn run lint` clean
- `yarn run smoke` — **31 / 31** green, including the two pr-1b guards added in #714:
  - `relationship/create: form-checkbox toggles checked state (pr-1b FormCheckbox guard)` (PInput's v-model + slot wiring via `FormCheckbox`)
  - `contact detail: log-a-call form persists with LL-formatted date (pr-1b form-radio + pr-1c |moment guard)` (FormRadio via PhoneCallList)
- Visual spot-check on `/people/h:<contact>/relationships/create`: pretty styling unchanged on both the age radios and the `realContact` checkbox.

## Test plan

- [ ] CI Build Assets passes
- [ ] CI 6 PHPUnit testsuites pass (unaffected — JS-only change)
- [ ] CI phpstan passes
- [ ] Local `yarn run smoke` post-merge against 4.x stays green
- [ ] Manual: `php artisan monica:seed-regression-demo` walk — confirm form-checkbox / form-radio surfaces (settings/users/add invite checkbox, relationship/new realContact checkbox, relationship/edit age radios, gifts CreateGift recipient radios, SetAvatar radios, SpecialDate radios, log-a-call form, dashboard debts/calls mark-done checkboxes, contact Tasks complete checkboxes) all toggle and round-trip.

Tracks #702. Follows #715 (pr-1a) in the Phase 1 ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
