### PR TITLE
refactor(filters): lift Vue 2 date filters into methods

### DIFF
--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -38,12 +38,6 @@ import 'moment/locale/vi';
 import 'moment/locale/zh-cn';
 import 'moment/locale/zh-tw';
 
-Vue.filter('formatDate', function(value) {
-  if (value) {
-    return moment(String(value)).format('LL');
-  }
-});
-
 // Markdown
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';

--- a/resources/js/components/dashboard/DashboardLog.vue
+++ b/resources/js/components/dashboard/DashboardLog.vue
@@ -115,7 +115,7 @@
         <ul v-if="debts.length !== 0">
           <li v-for="debt in debts" :key="debt.id" class="pb2">
             <span class="black-50 mr1 f6">
-              {{ debt.created_at | formatDate }}
+              {{ formatDate(debt.created_at) }}
             </span>
             <span class="mr1 black-50">
               •
@@ -276,6 +276,7 @@
 </template>
 
 <script>
+import moment from 'moment';
 import Avatar from '../partials/Avatar.vue';
 
 export default {
@@ -324,6 +325,11 @@ export default {
   methods: {
     prepareComponent() {
       this.setActiveTab(this.defaultActiveTab);
+    },
+
+    formatDate(value) {
+      if (!value) return;
+      return moment(String(value)).format('LL');
     },
 
     setActiveTab(view) {

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -59,7 +59,7 @@
               <ul class="list">
                 <!-- HAPPENED AT -->
                 <li class="di" :class="[ dirltr ? 'mr3' : 'ml3' ]">
-                  {{ activity.happened_at | moment }}
+                  {{ formatMomentLL(activity.happened_at) }}
                 </li>
 
                 <!-- PARTICIPANT LIST -->
@@ -146,12 +146,6 @@ export default {
     CreateActivity
   },
 
-  filters: {
-    moment: function (date) {
-      return moment.utc(date).format('LL');
-    }
-  },
-
   props: {
     hash: {
       type: String,
@@ -200,6 +194,10 @@ export default {
     prepareComponent() {
       this.getActivities();
       this.todayDate = moment().format('YYYY-MM-DD');
+    },
+
+    formatMomentLL(date) {
+      return moment.utc(date).format('LL');
     },
 
     compiledMarkdown (text) {

--- a/resources/js/components/people/activity/CreateActivity.vue
+++ b/resources/js/components/people/activity/CreateActivity.vue
@@ -139,12 +139,6 @@ export default {
     Participant,
   },
 
-  filters: {
-    moment: function (date) {
-      return moment.utc(date).format('LL');
-    }
-  },
-
   props: {
     hash: {
       type: String,

--- a/resources/js/components/people/calls/PhoneCallList.vue
+++ b/resources/js/components/people/calls/PhoneCallList.vue
@@ -209,7 +209,7 @@
         <div class="pa2 cf bt b--black-10 br--bottom f7 lh-copy">
           <div class="w-70" :class="[ dirltr ? 'fl' : 'fr' ]">
             <span :class="[ dirltr ? 'mr3' : 'ml3' ]">
-              {{ call.called_at | moment }}
+              {{ formatMomentLL(call.called_at) }}
             </span>
             <span :class="[ dirltr ? 'mr3' : 'ml3' ]">
               {{ call.contact_called ? $t('people.call_he_called', { name : name }) : $t('people.call_you_called') }}
@@ -263,12 +263,6 @@ export default {
     Emotion,
   },
 
-  filters: {
-    moment: function (date) {
-      return moment.utc(date).format('LL');
-    }
-  },
-
   props: {
     hash: {
       type: String,
@@ -320,6 +314,10 @@ export default {
       this.getCalls();
       this.todayDate = moment().format('YYYY-MM-DD');
       this.newCall.called_at = this.todayDate;
+    },
+
+    formatMomentLL(date) {
+      return moment.utc(date).format('LL');
     },
 
     compiledMarkdown (text) {

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -988,6 +988,58 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     assertNoUnknownConsoleErrors(unknown, '/people/h:<contact> (log-a-call + |moment filter)');
   });
 
+  test('contact detail: log-an-activity form persists with LL-formatted date (pr-1c ActivityList |moment guard)', async ({ page }) => {
+    // Guards the `filters: { moment }` block on ActivityList.vue that renders
+    // `{{ activity.happened_at | moment }}` in LL format ("Month D, YYYY").
+    // pr-1c lifts this to a formatMomentLL method; the assertion below
+    // verifies a freshly-saved activity still renders with an LL date string.
+    //
+    // Cleans up the created activity so repeated smoke runs don't accumulate.
+    const { unknown } = attachConsoleCapture(page);
+
+    await login(page);
+    await page.goto('/people');
+    await page.locator('a[href*="/people/h:"]').first().click();
+    await page.waitForURL(/\/people\/h:[A-Za-z0-9]+$/);
+
+    // Open the Log Activity form. ActivityList.vue toggles displayLogActivity
+    // which v-if-mounts CreateActivity.vue. The trigger has v-cy-name="add-activity-button".
+    await page.locator('[cy-name="add-activity-button"]').click();
+
+    // CreateActivity.vue renders a FormInput with id="summary"; FormInput
+    // passes :name="id" through to the underlying <input>, so input[name="summary"]
+    // is a stable selector that survives the FormInput internals.
+    const summaryInput = page.locator('input[name="summary"]');
+    await expect(summaryInput).toBeVisible();
+    const marker = `smoke activity ${Date.now()}`;
+    await summaryInput.fill(marker);
+
+    // Save via v-cy-name="save-activity-button".
+    await page.locator('[cy-name="save-activity-button"]').click();
+
+    // Match the freshly-saved row directly via its cy-name. We deliberately
+    // avoid scoping under `[cy-name="activities-body"]` because ActivityList.vue
+    // has two unkeyed bare-<div> siblings (the blank-state wrapper at line 25
+    // and the activities-body div at line 46). When the activities array
+    // transitions 1 → 0 on cleanup, Vue 2's vdom diff reuses the wrappers and
+    // can leave the `cy-name="activities-body"` attribute attached to two DOM
+    // nodes simultaneously — a Vue 2 quirk unrelated to the filter refactor.
+    // Row-level locators sidestep it cleanly.
+    const activityRow = page.locator('[cy-name^="activity-body-"]').filter({ hasText: marker });
+    await expect(activityRow).toHaveCount(1);
+    // moment LL = "MMMM D, YYYY" in English.
+    await expect(activityRow).toContainText(/(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}/);
+
+    // Cleanup: click the row's delete button, then the confirm link. The
+    // confirm-delete-activity v-cy-name is not row-suffixed (it's a shared
+    // name with v-show gated per-row), so we scope inside the activity row.
+    await activityRow.locator('[cy-name^="delete-activity-button-"]').click();
+    await activityRow.locator('[cy-name="confirm-delete-activity"]').click();
+    await expect(activityRow).toHaveCount(0);
+
+    assertNoUnknownConsoleErrors(unknown, '/people/h:<contact> (log-an-activity + |moment filter)');
+  });
+
   test('dashboard debts tab: formatDate filter renders LL date (pr-1c global formatDate guard)', async ({ page }) => {
     // Guards the global `Vue.filter('formatDate')` registration in
     // resources/js/common.js. Its only consumer is DashboardLog.vue:118


### PR DESCRIPTION
## Summary

Phase 1 / pr-1c of the Vue 3 migration plan (#702). Vue 3 drops `filters` and `{{ value | filter }}` syntax — this PR converts the four remaining date-filter sites in the codebase to ordinary methods, preserving the rendered output exactly so the dependency-upgrade smoke guards stay green.

- **`resources/js/common.js`** — drop the global `Vue.filter('formatDate', …)`. Its single consumer (DashboardLog.vue debts tab) gets a local `formatDate(value)` method that keeps the falsy-passthrough behaviour of the old filter.
- **`PhoneCallList.vue`** and **`ActivityList.vue`** — replace `filters: { moment }` with `formatMomentLL(date)` methods. Renamed to avoid shadowing the imported `moment` symbol.
- **`CreateActivity.vue`** — its `filters: { moment }` block was orphaned at file creation in #2299. `git log -G 'moment'` confirms no `| moment` consumer has ever existed in that template. Block deleted entirely.

The Vue 3 ladder still has #710 / pr-1b foundations to land before the framework cutover (pr-2). After pr-1c, Phase 1 (Vue-2 idiom removal) is complete and pr-2 (`vue@^3 + @vue/compat`) can proceed.

## Test coverage

- A new playwright smoke guard for `ActivityList.vue` is added alongside the existing PhoneCallList one — `dependency-upgrade-smoke.spec.ts` was previously missing coverage for `{{ activity.happened_at | moment }}` and would not have caught a regression there.
- The post-cleanup assertion uses row-level cy-name locators rather than scoping to `[cy-name="activities-body"]`. ActivityList.vue has two adjacent unkeyed `<div>` siblings (the blank-state wrapper and the activities-body container); Vue 2's vdom reuses them when the activities array transitions back to empty, which leaves `cy-name="activities-body"` attached to two DOM nodes simultaneously and breaks playwright's strict-mode locators. Sidestepping it via row-level locators is robust and unrelated to the filter refactor — fixing the underlying vdom-reuse issue would mean adding `:key` to ActivityList.vue:25/46, which is out of scope here and a one-line follow-up if we ever care to remove the dead `cy-name` attribute.
- All 32 smoke tests pass against the dev seed (`php artisan setup:test`):
  - pr-1c PhoneCallList `|moment` guard ✅
  - pr-1c ActivityList `|moment` guard ✅ (new)
  - pr-1c global `formatDate` guard ✅

## Test plan

- [x] `yarn run prod` clean
- [x] `cd tests/playwright && yarn run smoke --grep "pr-1c"` (3/3 green)
- [x] `cd tests/playwright && yarn run smoke` (32/32 green)
- [ ] Manual: open the dashboard Debts tab, a contact's Calls section, a contact's Activities section — confirm dates still render as LL (`Month D, YYYY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
