### PR TITLE
fix(js): resolve moment to its ESM build so locale registrations land on the consumer instance

### DIFF
--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -13,30 +13,32 @@ Vue.use(VueI18n);
 
 // Moments
 import moment from 'moment';
-// Register moment locale data. Mix's webpack handled this automatically because
-// it follows moment's dynamic require(), and `moment-locales-webpack-plugin`
-// (now removed) filtered the 138 bundled locales down to the 17 we ship below.
-// Rollup/Vite doesn't follow that dynamic require, so without these explicit
-// side-effect imports the bundle would ship moment + English-only and every
-// `moment.locale(this._i18n.locale)` call would silently no-op. Keep this list
-// in sync with `config/lang.php` / Crowdin and the old Mix allowlist.
-import 'moment/locale/ar';
-import 'moment/locale/de';
-import 'moment/locale/el';
-import 'moment/locale/en-gb';
-import 'moment/locale/es';
-import 'moment/locale/fr';
-import 'moment/locale/he';
-import 'moment/locale/id';
-import 'moment/locale/it';
-import 'moment/locale/nl';
-import 'moment/locale/pt-br';
-import 'moment/locale/ru';
-import 'moment/locale/sv';
-import 'moment/locale/tr';
-import 'moment/locale/vi';
-import 'moment/locale/zh-cn';
-import 'moment/locale/zh-tw';
+// Register moment locale data for the 17 languages we ship (keep in sync with
+// `config/lang.php` / Crowdin). Imports go through `moment/dist/locale/*`,
+// not `moment/locale/*` — the dist/ files are ESM modules whose top-level
+// `moment.defineLocale(...)` call registers against the moment instance from
+// `moment/dist/moment.js`. The vite.config.js alias forces `import moment from
+// 'moment'` to that same ESM build, so the registrations reach the consumer-
+// facing moment. The UMD-wrapped `moment/locale/*.js` files leave Rollup in
+// `factory(global.moment)` fallback mode — the calls execute but land on an
+// orphan moment, which is why #718 happened.
+import 'moment/dist/locale/ar';
+import 'moment/dist/locale/de';
+import 'moment/dist/locale/el';
+import 'moment/dist/locale/en-gb';
+import 'moment/dist/locale/es';
+import 'moment/dist/locale/fr';
+import 'moment/dist/locale/he';
+import 'moment/dist/locale/id';
+import 'moment/dist/locale/it';
+import 'moment/dist/locale/nl';
+import 'moment/dist/locale/pt-br';
+import 'moment/dist/locale/ru';
+import 'moment/dist/locale/sv';
+import 'moment/dist/locale/tr';
+import 'moment/dist/locale/vi';
+import 'moment/dist/locale/zh-cn';
+import 'moment/dist/locale/zh-tw';
 
 // Markdown
 import { marked } from 'marked';

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -534,6 +534,68 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     assertNoUnknownConsoleErrors(unknown, '/settings (locale switch)');
   });
 
+  test('moment locale registers fr — Vue-rendered dates use French month names under fr (regression guard for #718)', async ({ page }) => {
+    // Guards the Vite-cutover regression where `moment/locale/<lang>` UMD
+    // wrappers landed their `defineLocale(...)` calls on an orphan moment
+    // instance, leaving `moment.locale('fr')` a silent no-op. After the fix
+    // (resolve.alias `moment` → `moment/dist/moment.js` + `moment/dist/locale/*`
+    // imports), the consumer-facing moment shares its instance with the
+    // locale registrations and Vue-rendered dates honour the user's locale.
+    //
+    // We assert the user-visible behaviour: a freshly-added activity renders
+    // its happened_at date with a French month name (e.g. "mai") rather than
+    // an English one ("May"). Probing `moment.locales()` directly would be
+    // bundle-path dependent (the hash changes each build); the DOM assertion
+    // is bundle-agnostic.
+    const { unknown } = attachConsoleCapture(page);
+
+    const setLocale = async (lang: 'en' | 'fr'): Promise<void> => {
+      await page.goto('/settings');
+      await page.locator('select#locale').selectOption(lang);
+      await page.locator('form[action*="/settings"] button[type="submit"]').first().click();
+      await page.waitForURL('**/settings');
+    };
+
+    await login(page);
+    try {
+      await setLocale('fr');
+
+      await page.goto('/people');
+      // vue-good-table mounts the contact list asynchronously — wait for the
+      // first row before clicking. Under fr the perPage strings hydrate
+      // slower than the table chrome, so click-before-wait races.
+      await expect(page.locator('table.vgt-table tbody tr').first()).toBeVisible();
+      await page.locator('table.vgt-table tbody a[href*="/people/h:"]').first().click();
+      await page.waitForURL(/\/people\/h:[A-Za-z0-9]+$/);
+
+      // Open Log Activity form (button label is now French, but the cy-name
+      // selector is locale-agnostic).
+      await page.locator('[cy-name="add-activity-button"]').click();
+      const summaryInput = page.locator('input[name="summary"]');
+      await expect(summaryInput).toBeVisible();
+      const marker = `smoke fr activity ${Date.now()}`;
+      await summaryInput.fill(marker);
+      await page.locator('[cy-name="save-activity-button"]').click();
+
+      const activityRow = page.locator('[cy-name^="activity-body-"]').filter({ hasText: marker });
+      await expect(activityRow).toHaveCount(1);
+
+      // moment LL in French = "D MMMM YYYY" e.g. "28 mai 2026". Match on
+      // French month names — if moment.locale('fr') is a no-op the date
+      // renders as "May 28, 2026" and this regex misses.
+      await expect(activityRow).toContainText(/\d{1,2}\s+(janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre)\s+\d{4}/);
+
+      // Cleanup.
+      await activityRow.locator('[cy-name^="delete-activity-button-"]').click();
+      await activityRow.locator('[cy-name="confirm-delete-activity"]').click();
+      await expect(activityRow).toHaveCount(0);
+    } finally {
+      await setLocale('en');
+    }
+
+    assertNoUnknownConsoleErrors(unknown, '/people/h:<contact> (fr locale moment guard)');
+  });
+
   test('logout clears session', async ({ page }) => {
     await login(page);
     await page.goto('/logout');

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,6 +45,14 @@ export default defineConfig(({ mode }) => ({
     alias: [
       // Runtime + template compiler build (templates are compiled at runtime).
       { find: /^vue$/, replacement: path.resolve(__dirname, 'node_modules/vue/dist/vue.esm.js') },
+      // Force `import moment from 'moment'` to resolve to the ESM build at
+      // dist/moment.js. The package's main field points at the UMD bundle,
+      // whose UMD wrapper Rollup can't reliably rewrite — locale side-effect
+      // modules then register on a separate (orphan) moment instance and
+      // `moment.locale('fr')` becomes a silent no-op (#718). The ESM build
+      // shares one instance with `moment/dist/locale/*`, so registrations
+      // reach the consumer-facing moment.
+      { find: /^moment$/, replacement: path.resolve(__dirname, 'node_modules/moment/dist/moment.js') },
     ],
     // Match webpack/Mix's default: resolve .vue imports without explicit extension.
     extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],


### PR DESCRIPTION
## Summary

Closes #718.

The locale-imports fix in `9deced518` (May 26) didn't actually work at runtime — the 17 `import 'moment/locale/<lang>'` side-effect modules execute and the locale data is embedded in the bundle, but each module's UMD wrapper hits Rollup in the `factory(global.moment)` browser-fallback branch. The `defineLocale(...)` calls land on an orphan `moment` placeholder, the consumer-facing moment instance never sees the registrations, and `moment.locale('fr')` has been a silent no-op since the Vite cutover (#686). Every Vue-rendered date renders in English regardless of the user's locale.

Two-line fix:

- **`vite.config.js`** — alias `'moment'` → `node_modules/moment/dist/moment.js`. The dist path is moment's ESM build (`export default hooks`); locale modules at `moment/dist/locale/*.js` import from this same path, so the consumer and the registration callsite now share a single moment instance.
- **`resources/js/common.js`** — swap the 17 `moment/locale/<lang>` imports for `moment/dist/locale/<lang>`. These dist files are clean ESM (`import moment from '../moment'; ...; export default moment.defineLocale('fr', {...})`) — no UMD wrapper, no branching, top-level side-effect runs against the shared instance.

Bundle size on the `common-*.js` chunk drops 761 kB → 695 kB because the duplicate moment instance goes away.

## Validation

Verified by directly importing the built chunk and probing the consumer-facing moment:

```
moment.locales()                         → ['ar', 'de', ..., 'zh-tw']   (was ['en'])
moment.locale('fr')                      → 'fr'                         (was 'en')
moment.utc('2026-05-28').format('LL')    → '28 mai 2026'                (was 'May 28, 2026')
```

A new playwright smoke guard switches the auth user's locale to `fr`, creates an activity via the same flow as the pr-1c `ActivityList` guard, asserts the rendered `happened_at` date contains a French month name (`/\d{1,2}\s+(janvier|février|…|décembre)\s+\d{4}/`), then deletes the activity and reverts the locale.

**Mutation-validated:** stashing the fix and rebuilding, the new guard fails precisely on the date regex — receiving `"May 28, 2026"` while the surrounding UI strings (`"Éditer"`, `"Supprimer"`, `"Êtes-vous sûr(e) ?"`) are correctly translated. That confirms vue-i18n was working the whole time but moment never switched. With the fix the guard passes.

## Test plan

- [x] `yarn run prod` clean
- [x] `cd tests/playwright && yarn run smoke --grep "moment locale registers fr"` — 1/1 green
- [x] `cd tests/playwright && yarn run smoke` — 33/33 green (including the pre-existing locale-switch test, the pr-1c filter guards, and the subscription-flow spec)
- [x] Mutation-validated: with the fix reverted, the new guard fails on the date regex
- [ ] Manual: log in as a user with `locale=fr` and confirm dashboard debts tab + a contact's calls + a contact's activities all render dates with French month names

🤖 Generated with [Claude Code](https://claude.com/claude-code)
