### PR TITLE
fix(passport): close device-code grant left half-installed by #677

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -22,6 +22,30 @@ class AuthServiceProvider extends ServiceProvider
      *
      * @return void
      */
+    public function register()
+    {
+        parent::register();
+
+        // Passport 13 ships the RFC 8628 device-authorization grant enabled by
+        // default and registers /oauth/device, /oauth/device/code, and
+        // /oauth/device/authorize. Monica's mobile/API clients use only the
+        // password and authorization-code grants, so the device-grant surface
+        // is unused — and the companion `oauth_device_codes` table was not
+        // published alongside the other Passport migrations in #677, which
+        // means DeviceCodeRepository would hit a missing-table 500 on every
+        // request to those endpoints. Disabling the grant suppresses the
+        // routes entirely. The migration is still shipped (this same PR) so
+        // the schema stays coherent if the grant is ever re-enabled.
+        //
+        // The flag MUST be set in register(), not boot(): Passport is
+        // auto-discovered via Composer's `extra.laravel.providers`, which
+        // schedules its boot ahead of the application providers despite the
+        // ordering in config/app.php. Setting it here runs in the registration
+        // phase, which completes before any provider's boot() — guaranteeing
+        // the flag is false by the time Passport's routes/web.php is loaded.
+        Passport::$deviceCodeGrantEnabled = false;
+    }
+
     public function boot(Request $request)
     {
         $this->registerPolicies();

--- a/database/migrations/2024_06_01_000001_create_oauth_device_codes_table.php
+++ b/database/migrations/2024_06_01_000001_create_oauth_device_codes_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('oauth_device_codes', function (Blueprint $table) {
+            $table->char('id', 80)->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('client_id')->index();
+            $table->char('user_code', 8)->unique();
+            $table->text('scopes');
+            $table->boolean('revoked');
+            $table->dateTime('user_approved_at')->nullable();
+            $table->dateTime('last_polled_at')->nullable();
+            $table->dateTime('expires_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('oauth_device_codes');
+    }
+
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/tests/Feature/PassportDeviceCodeGrantDisabledTest.php
+++ b/tests/Feature/PassportDeviceCodeGrantDisabledTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Passport;
+use Tests\FeatureTestCase;
+
+/**
+ * Verifies that the RFC 8628 device-authorization grant is suppressed.
+ *
+ * Passport 13 ships the device-code grant enabled by default and registers
+ * /oauth/device, /oauth/device/code, and /oauth/device/authorize. Monica
+ * doesn't use that flow (mobile/API clients use password + auth-code), and
+ * the companion oauth_device_codes table was omitted from the migrations
+ * published in #677. Until both sides land in lockstep, the safe state is
+ * "grant off, routes absent".
+ *
+ * If this test fails, either the toggle in AuthServiceProvider has been
+ * removed/regressed, or Passport's defaults have shifted in a way that
+ * requires a different disable path. Don't paper over the failure by
+ * deleting the test — re-confirm the schema (oauth_device_codes exists +
+ * the DeviceCodeRepository round-trips) before re-enabling.
+ */
+class PassportDeviceCodeGrantDisabledTest extends FeatureTestCase
+{
+    public function test_device_code_grant_static_is_disabled(): void
+    {
+        $this->assertFalse(Passport::$deviceCodeGrantEnabled);
+    }
+
+    public function test_device_user_code_route_is_not_registered(): void
+    {
+        $this->assertFalse(Route::has('passport.device'));
+        $this->assertFalse(Route::has('passport.device.code'));
+        $this->assertFalse(Route::has('passport.device.authorizations.authorize'));
+    }
+
+    public function test_device_user_code_endpoint_returns_404(): void
+    {
+        $this->get('/oauth/device')->assertStatus(404);
+    }
+
+    public function test_device_code_token_endpoint_returns_404(): void
+    {
+        $this->postJson('/oauth/device/code')->assertStatus(404);
+    }
+
+    public function test_device_authorize_endpoint_returns_404_when_signed_in(): void
+    {
+        $this->signIn();
+
+        $this->get('/oauth/device/authorize')->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## Summary

- Disables the RFC 8628 device-authorization grant that Passport 13 ships enabled by default but Monica doesn't use.
- Ships the published `oauth_device_codes` migration that PR #677 omitted, so the schema stays coherent if anyone re-enables the grant later.
- Adds a feature test that locks in the disabled-grant route shape so this can't regress silently.

## Why

PR #677 (Laravel 11 → 12, Passport 12 → 13) shipped the `oauth_clients` upgrade migration but didn't publish the new `oauth_device_codes` table that Passport 13 added for the device-code grant. Result on every install upgraded via #677:

- `/oauth/device`, `/oauth/device/code`, `/oauth/device/authorize` are registered and live (the grant is on by default — `Passport::$deviceCodeGrantEnabled = true`).
- `DeviceCodeRepository` points at a table that doesn't exist.
- Any request to those endpoints hits a missing-table SQL exception and 500s.

Monica's mobile + API clients use `password` and `authorization_code` only, so the right fix is "disable the surface we don't use" rather than "stand up a device-grant flow we don't need." The migration is still shipped (byte-identical to the vendor copy, matching how every other Passport table is vendored under `database/migrations/`) so re-enabling the grant in future is a one-line flip without a schema gap.

This is the third bug in the same family as the ones cleaned up in #705 and the `ClientRepository::forUser` finding — Passport 13's upgrade surface left more sharp edges than #677's verification caught.

## Why `register()` and not `boot()`

The first cut put `Passport::$deviceCodeGrantEnabled = false` in `boot()`. Tests passed (in test context routes weren't registered) but `php artisan route:list` still showed the device routes live. Root cause: Passport is auto-discovered via Composer's `extra.laravel.providers`, which schedules its boot ahead of `App\Providers\*` despite the order in `config/app.php`. By the time `AuthServiceProvider::boot()` runs, Passport's `routes/web.php` has already been parsed against `$deviceCodeGrantEnabled = true`.

Moving the flag to `register()` puts it in the registration phase, which completes before any provider's `boot()` runs — guaranteeing the flag is false before Passport loads its routes.

## Test plan

- [x] `vendor/bin/phpunit --testsuite Feature --filter Passport` — 23/23 green (5 new + 18 from #705's controller suite).
- [x] `vendor/bin/phpstan analyse app/Providers/AuthServiceProvider.php tests/Feature/PassportDeviceCodeGrantDisabledTest.php` — no errors.
- [x] `php artisan route:list | grep oauth/device` — empty (was 5 routes before).
- [x] `php artisan migrate:status` — `2024_06_01_000001_create_oauth_device_codes_table` lists as Ran; table columns match the vendor schema.
- [ ] Reviewer: walk `/settings/api` end-to-end (PAT create / Client create / token revoke) to confirm the unrelated Passport surface is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
