### PR TITLE
chore(dev): mount public/build for host-side iteration; drop stale public/hot from image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,11 @@ persist/
 .phpunit.result.cache
 Procfile
 public/storage
+# Vite dev-server marker file. Written on the host by `yarn run dev`; if it
+# bakes into the image, laravel/framework's Vite::isRunningHot() returns
+# true and every blade page serves asset URLs from a non-existent
+# localhost:5173 instead of the production manifest.
+public/hot
 resources/vendor/
 results/
 .sass-lint.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,11 @@ yarn run e2e-gui             # cypress interactive
 
 Local dev via Docker:
 ```
+yarn install && yarn run prod                 # populate public/build/ on the host first (see note below)
 docker compose -f docker-compose.dev.yml up   # app on :8082, phpmyadmin :3000, mailhog :8025/:1025
 ```
+
+The dev compose mounts `./public/build:/var/www/html/public/build`, so the container's Apache serves whatever the host last built. **`yarn run prod` is a cold-start prereq** — without it the mount overlays the image's baked-in assets with an empty directory and every blade page 500s on the missing `manifest.json`. For iteration, `yarn run watch` rebuilds incrementally on file change.
 
 ## Architecture
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,14 @@ services:
       - ./database:/var/www/html/database
       - ./resources:/var/www/html/resources
       - ./routes:/var/www/html/routes
+      # Surface host-side Vite builds to the container's Apache without a
+      # `docker cp` step. The narrow scope (just `public/build`) leaves the
+      # image-baked `public/storage` symlink + `public/js/langs/` untouched.
+      # Cold-start prereq: run `yarn install && yarn run prod` on the host
+      # before `docker compose up` — otherwise the mount overlays the
+      # image's built assets with an empty directory and every blade page
+      # 500s trying to read `public/build/manifest.json`.
+      - ./public/build:/var/www/html/public/build
 
   mysql:
     image: mysql:8.0

--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -9,9 +9,16 @@ your image to run.
 
 Edit `.env` to set `DB_HOST=mysql` (as `mysql` is the creative name of the MySQL container).
 
-Then run:
+The dev compose mounts `./public/build:/var/www/html/public/build`, so the
+container's Apache serves whatever the host last built. Run `yarn install`
++ `yarn run prod` on the host before bringing the stack up — otherwise the
+mount overlays the image's baked-in assets with an empty directory and
+every blade page 500s on the missing `manifest.json`. After the cold
+start, `yarn run watch` rebuilds incrementally on file change.
 
 ```sh
+yarn install
+yarn run prod
 docker-compose -f docker-compose.dev.yml build
 docker-compose -f docker-compose.dev.yml up
 ```

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -13,21 +13,33 @@ Standalone Playwright suite for verifying the user-facing app after a dependency
 From the **`docker-compose.dev.yml` rig running on `localhost:8082`**:
 
 ```bash
-# 1) Bring up the dev stack
+# 1) Build the Vite assets on the host. The dev compose mounts
+#    ./public/build:/var/www/html/public/build, so the container's Apache
+#    serves whatever the host last built. Without this step, the mount
+#    overlays the image's baked-in assets with an empty directory and
+#    every blade page 500s trying to read public/build/manifest.json.
+yarn install
+yarn run prod
+
+# 2) Bring up the dev stack
 docker compose -f docker-compose.dev.yml up -d
 
-# 2) Seed an admin account + 20 contacts.
+# 3) Seed an admin account + 20 contacts.
 #    --user www-data avoids the trap documented in #629 (php artisan as root
 #    leaves storage/logs/laravel.log root-owned, breaking subsequent web reqs).
 docker compose -f docker-compose.dev.yml exec --user www-data app \
   sh -c 'printf "yes\n20\n" | php artisan setup:test'
 
-# 3) Run the smoke from this directory
+# 4) Run the smoke from this directory
 cd tests/playwright
 yarn install
 npx playwright install chromium   # first run only
 yarn run smoke
 ```
+
+When iterating on Vue/JS sources, re-run `yarn run prod` (or `yarn run watch`
+for incremental rebuilds) on the host — the container picks up the new
+bundle on the next request. No `docker cp` step needed.
 
 Other targets:
 


### PR DESCRIPTION
## Summary

Surfaced while verifying the pr-t3 smoke guards (#721): a host-side
`yarn run prod` doesn't reflect in the dev container because
`docker-compose.dev.yml` doesn't mount `public/`. Two related fixes:

### 1. Mount `./public/build:/var/www/html/public/build`

Vite builds on the host now reflect in the container without a
`docker cp` round-trip. Picked the **narrow** `public/build`-only mount
over a whole-`public/` mount or a Sail-style whole-project mount:

| Approach | Cost | Wins | Decision |
|---|---|---|---|
| Narrow `public/build` mount | 1 extra cold-start step (`yarn run prod`) | host-side Vite builds reflect | ✅ this PR |
| Whole `public/` mount | 2 extra steps (also `php artisan storage:link`) | + lang regen reflects, + HMR via `public/hot` | deferred |
| Sail migration | rewrite compose + harness + CI | standard convention | overkill for fork |

If lang-iteration or HMR turns out to matter in practice during the Vue
3 cutover work, follow-up to whole-`public/` mount.

### 2. Drop stale `public/hot` from the dev image

Adding the build mount surfaced a latent image bug: a stale `public/hot`
file (written by a past `yarn run dev` on the host before the image
was built, then captured by `COPY . ./` in the Dockerfile) had baked
into `monica:dev`. That file tells `laravel/framework`'s
`Vite::isRunningHot()` to serve every asset URL from
`http://[::1]:5173` — a Vite dev server that doesn't exist when
running the smoke. Pre-existing containers happened to be running on
an older image layer that didn't have the stale file, so this PR's
`down + up` cycle was the first time the bug actually surfaced.

Fix: add `public/hot` to `.dockerignore` so it's never picked up by
`COPY . ./` again, regardless of host state at image-build time.

## Cold-start workflow change

**Before this PR**: `docker compose up` was enough to bring up a working
stack — assets came from inside the image.

**After this PR**: run `yarn install && yarn run prod` once on the host
before `docker compose up`, otherwise the mount overlays
`public/build/manifest.json` with an empty dir and every blade page
500s. README + CLAUDE.md updated to call this out at the top of the
dev-stack instructions.

For iteration: `yarn run watch` rebuilds incrementally on file change;
the container picks up the new bundle on the next request.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml build app` → image has no `public/hot`
- [x] `docker compose up` → blade renders `<link href="...build/assets/app-ltr-*.css">` (production manifest, not `localhost:5173`)
- [x] Full Playwright smoke (39 tests) passes
- [x] Edit-build-test loop: mutate `SetFavorite.vue` v-tooltip → `yarn run prod` on host → smoke guard correctly **fails** → revert + rebuild → smoke guard **passes**, all without any `docker cp` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
