### PR TITLE
chore(dev): make `yarn run test` work out of the box on the dev stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -70,6 +70,9 @@ services:
       - MYSQL_PASSWORD=secret
     volumes:
       - /var/lib/mysql
+      # First-boot init: creates monica_test and grants homestead so
+      # `docker exec monica-app-1 yarn run test` works out of the box.
+      - ./scripts/docker/mysql-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
 
   stripe-mock:
     image: stripe/stripe-mock:v0.199.0

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "delete:reports": "rm results/cypress/* || true",
     "pree2e": "yarn run delete:reports",
     "migrate": "DB_CONNECTION=testing php artisan migrate:fresh && DB_CONNECTION=testing php artisan db:seed",
-    "pretest": "yarn run migrate",
+    "pretest": "php artisan config:clear && yarn run migrate",
     "test": "vendor/bin/phpunit",
     "posttest": "vendor/bin/phpstan analyse",
     "composer update": "COMPOSER_MEMORY_LIMIT=-1 composer update"

--- a/scripts/docker/mysql-init.sql
+++ b/scripts/docker/mysql-init.sql
@@ -1,0 +1,12 @@
+-- Auto-create the testing database referenced by .env.dev (DB_TEST_DATABASE=monica_test).
+-- Mounted into mysql:8.0 at /docker-entrypoint-initdb.d/init.sql; runs once on first
+-- volume init. Without this, `docker exec monica-app-1 yarn run test` errors with
+-- "1146 Table 'monica_test.accounts' doesn't exist" because the testing connection
+-- has nowhere to migrate.
+CREATE DATABASE IF NOT EXISTS monica_test
+    CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+GRANT ALL PRIVILEGES ON monica_test.* TO 'homestead'@'%';
+
+FLUSH PRIVILEGES;


### PR DESCRIPTION
## Summary

Make `docker exec monica-app-1 yarn run test` work cleanly on a stock dev stack-up. Two surgical fixes:

- `scripts/docker/mysql-init.sql` mounted at `/docker-entrypoint-initdb.d/init.sql` on the mysql service → auto-creates `monica_test` (idempotent across rebuilds, runs on first volume init only).
- `php artisan config:clear` prepended to the `pretest` script in `package.json` → defensive against a cached `bootstrap/cache/config.php` swallowing phpunit.xml's `<env force="true">` overrides (which would otherwise produce ~170 phpunit failures: subscription paywall 302s, CSRF mismatches, DAV 501s, etc., all from `REQUIRES_SUBSCRIPTION=false` and similar overrides never reaching `config()`).

CI is unaffected — `.github/workflows/tests.yml` invokes phpunit directly, not via `yarn run test`, and CI's `.env.mysql` already points the testing connection at the same `monica` DB it preloads.

Surfaced while running the phpunit gate on the Vue 3 cutover branch. The cutover branch touches zero PHP files, so locally-failing tests were entirely environmental.

## One-time migration for existing dev volumes

The mysql data dir is already initialized in established dev stacks, so the new mount won't auto-run. Either run this once:

```bash
docker exec monica-mysql-1 mysql -uroot -psekret_root_password -e "
  CREATE DATABASE IF NOT EXISTS monica_test
    CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
  GRANT ALL PRIVILEGES ON monica_test.* TO 'homestead'@'%';
  FLUSH PRIVILEGES;"
```

…or do a `docker compose -f docker-compose.dev.yml down -v && docker compose -f docker-compose.dev.yml up` to re-init the mysql volume (the init script then runs automatically).

A stale `bootstrap/cache/config.php` heals itself on the next `yarn run test` via the new pretest hook — no manual cleanup needed.

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml config` parses (verified locally)
- [ ] `jq . package.json` parses (verified locally)
- [ ] On a fresh dev stack (`down -v && up`): `docker exec monica-app-1 yarn run test` runs phpunit + phpstan green with no manual setup
- [ ] On an existing dev stack after the one-time DB creation above: same as fresh
- [ ] CI "Unit tests" workflow stays green on this PR (unchanged code path)
