### PR TITLE
fix(export): notification failure no longer poisons export status (#738)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,11 @@ MAIL_PORT=2525
 MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=
-# Outgoing emails will be sent with these identity
-MAIL_FROM_ADDRESS=
+# Outgoing emails will be sent with these identity. MAIL_FROM_ADDRESS
+# must be non-empty — Symfony Mime rejects messages without a From or
+# Sender header, which makes every outbound notification throw at send
+# time. Replace the placeholder with your own monitored address.
+MAIL_FROM_ADDRESS=noreply@monica.local
 MAIL_FROM_NAME="Monica instance"
 # New registration notification sent to this email
 APP_EMAIL_NEW_USERS_NOTIFICATION=

--- a/app/Jobs/ExportAccount.php
+++ b/app/Jobs/ExportAccount.php
@@ -8,9 +8,11 @@ use Illuminate\Bus\Queueable;
 use App\Helpers\StorageHelper;
 use App\Models\Account\ExportJob;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use App\Notifications\ExportAccountDone;
 use Illuminate\Foundation\Bus\Dispatchable;
 use App\Services\Account\Settings\SqlExportAccount;
 use App\Services\Account\Settings\JsonExportAccount;
@@ -75,12 +77,31 @@ class ExportAccount implements ShouldQueue
             $this->exportJob->end();
         } catch (Throwable $e) {
             $this->fail($e);
+
+            return;
         } finally {
             // delete old file from temp folder
             $storage = Storage::disk('local');
             if ($storage->exists($tempFileName)) {
                 $storage->delete($tempFileName);
             }
+        }
+
+        // The export is committed (status=done, file on disk) before the
+        // user-facing notification is dispatched. A notification failure
+        // (mail misconfig, SMTP outage, …) is logged but does NOT roll the
+        // status back — the artifact stays recoverable from the exports
+        // list. With QUEUE_CONNECTION=sync (Monica's default) the notify
+        // call runs inline, so the catch is what protects status from a
+        // synchronous throw; on a real queue driver the notification is
+        // already isolated and this catch is a no-op. See #738.
+        try {
+            $this->exportJob->user->notify(new ExportAccountDone($this->exportJob));
+        } catch (Throwable $e) {
+            Log::warning('Export notification dispatch failed', [
+                'export_job_id' => $this->exportJob->id,
+                'exception' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/Models/Account/ExportJob.php
+++ b/app/Models/Account/ExportJob.php
@@ -5,7 +5,6 @@ namespace App\Models\Account;
 use App\Traits\HasUuid;
 use App\Models\User\User;
 use Illuminate\Database\Eloquent\Model;
-use App\Notifications\ExportAccountDone;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -141,7 +140,5 @@ class ExportJob extends Model
         $this->status = self::EXPORT_DONE;
         $this->ended_at = now();
         $this->save();
-
-        $this->user->notify(new ExportAccountDone($this));
     }
 }

--- a/tests/Unit/Services/Account/Settings/ExportAccountTest.php
+++ b/tests/Unit/Services/Account/Settings/ExportAccountTest.php
@@ -8,10 +8,12 @@ use Mockery\MockInterface;
 use App\Jobs\ExportAccount;
 use App\Models\Contact\Contact;
 use App\Models\Account\ExportJob;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use App\Notifications\ExportAccountDone;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Testing\AssertableJsonString;
+use Illuminate\Contracts\Notifications\Dispatcher;
 use App\Services\Account\Settings\SqlExportAccount;
 use App\Services\Account\Settings\JsonExportAccount;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -82,6 +84,48 @@ class ExportAccountTest extends TestCase
         Notification::assertSentTo(
             [$job->user], ExportAccountDone::class
         );
+    }
+
+    #[Test]
+    public function it_keeps_export_status_done_when_post_completion_notification_throws()
+    {
+        // Regression test for #738. Pre-fix, a thrown notification (empty
+        // MAIL_FROM_ADDRESS, SMTP outage, etc.) propagated back into
+        // ExportAccount::handle()'s broad try/catch and flipped status to
+        // FAILED — even though the export file had already landed on disk.
+        Storage::fake();
+        $fake = Storage::fake('local');
+        $fake->put('temp/test.json', 'null');
+
+        $job = ExportJob::factory()->create();
+
+        $this->mock(JsonExportAccount::class, function (MockInterface $mock) use ($job) {
+            $mock->shouldReceive('execute')
+                ->once()
+                ->with([
+                    'account_id' => $job->account_id,
+                    'user_id' => $job->user_id,
+                ])
+                ->andReturn('temp/test.json');
+        });
+
+        // Swap the notification dispatcher binding for one that throws on
+        // send(). Notifiable::notify() resolves through
+        // app(Dispatcher::class), so this short-circuits the actual mail
+        // pipeline at the right seam.
+        $this->mock(Dispatcher::class, function (MockInterface $mock) {
+            $mock->shouldReceive('send')
+                ->once()
+                ->andThrow(new \RuntimeException('Simulated mail failure'));
+        });
+
+        Log::shouldReceive('warning')->once();
+
+        ExportAccount::dispatchSync($job);
+        $job->refresh();
+
+        $this->assertEquals(ExportJob::EXPORT_DONE, $job->status);
+        Storage::disk('public')->assertExists($job->filename);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #738.

## Summary

- Move the `ExportAccountDone` notification dispatch out of `ExportJob::end()` and into `ExportAccount::handle()`, outside the existing `try/catch` and behind its own catch-and-log.
- A thrown notification (empty `MAIL_FROM_ADDRESS`, SMTP outage, etc.) is now logged but does **not** roll the export status back from `DONE` to `FAILED`. The artifact stays recoverable from the exports list.
- Patches `.env.example`'s empty `MAIL_FROM_ADDRESS=` — that was the default that made the notification throw out of the box on fresh self-hoster installs.

## Why

`ExportAccountDone` already implements `ShouldQueue`, but Monica ships with `QUEUE_CONNECTION=sync` (the Laravel default), so the notification runs inline rather than going to a worker. Pre-fix, an inline throw propagated back into `ExportAccount::handle()`'s broad `try/catch` and called `$this->fail($e)` — flipping the status to `FAILED` even though the file had already landed on disk. The UI only renders a Download link when `status === EXPORT_DONE`, so users couldn't recover their data.

Self-hosters on a real queue driver (database/redis) weren't affected (the notification is genuinely async there). Sync-queue (default) and any zero-queue posture **were** affected.

## Fix shape

`ExportJob::end()` is now purely a status flip:

```php
public function end(): void
{
    $this->status = self::EXPORT_DONE;
    $this->ended_at = now();
    $this->save();
}
```

`ExportAccount::handle()` dispatches the notification after the success path closes:

```php
try {
    // file write, end()
} catch (Throwable $e) {
    $this->fail($e);
    return;
} finally {
    // tempfile cleanup
}

try {
    $this->exportJob->user->notify(new ExportAccountDone($this->exportJob));
} catch (Throwable $e) {
    Log::warning('Export notification dispatch failed', [...]);
}
```

## Tests

- **New regression:** `it_keeps_export_status_done_when_post_completion_notification_throws` (`tests/Unit/Services/Account/Settings/ExportAccountTest.php`) — swaps the `Illuminate\Contracts\Notifications\Dispatcher` binding for a mock that throws on `send()`, dispatches the job, asserts `status === EXPORT_DONE` and that the file exists on storage. Pre-fix, this fails (status flips to `FAILED`).
- All 10 existing `ExportAccount` feature + unit tests stay green.
- PHPStan clean on both touched application files.

## Manual verification

Against the `docker-compose.dev.yml` stack with `.env.dev`'s `MAIL_FROM_ADDRESS=` empty (the state that surfaced this on the #731 A.4 spec):

- **Pre-fix:** `php artisan tinker --execute='App\Jobs\ExportAccount::dispatch($job)'` → `status=failed` + file present on disk.
- **Post-fix:** same command → `status=done` + file present on disk + a `local.WARNING: Export notification dispatch failed` entry in `storage/logs/laravel.log` with the export job id and exception message.

## Cross-references

- Surfaced by [#731 A.4](https://github.com/brycehans/monica/issues/731) — the playwright account-export spec ([#739](https://github.com/brycehans/monica/pull/739)) couldn't pass without working around this defect via a `.env.dev` `MAIL_FROM_ADDRESS` workaround in that PR. This PR is the upstream fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
