### PR TITLE
fix(gifts): vm is not defined in CreateGift error handler (closes #732)

### DIFF
--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -388,6 +388,11 @@ export default {
       const method = this.gift ? 'put' : 'post';
       const url = `people/${this.hash}/gifts${this.gift ? '/'+this.gift.id : ''}`;
 
+      // vue-i18n legacy mode installs $t per component instance (not on a
+      // shared prototype like vue 2 did), so it dies with the proxy once
+      // vm.close() emits 'cancel' and the parent flips its v-if. Resolve
+      // the toast string here while the proxy is still alive.
+      const successTitle = this.$t('people.gifts_add_success');
 
       const vm = this;
       axios[method](url, this.newGift)
@@ -395,7 +400,6 @@ export default {
           return vm.storePhoto(response);
         })
         .then(response => {
-          //this.update(response);
           vm.close();
           vm.$emit('update', response.data.data);
           return response;
@@ -403,7 +407,7 @@ export default {
         .then(() => {
           this.$notify({
             group: 'main',
-            title: vm.$t('people.gifts_add_success'),
+            title: successTitle,
             text: '',
             type: 'success'
           });
@@ -433,7 +437,7 @@ export default {
       if (error.response && typeof error.response.data === 'object') {
         this.errors = _.flatten(_.toArray(error.response.data));
       } else {
-        this.errors = [vm.$t('app.error_try_again'), error.message];
+        this.errors = [this.$t('app.error_try_again'), error.message];
       }
     },
 

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -109,11 +109,7 @@ Specs fail on **any unexpected** Vue or browser console error or `pageerror` —
 
 When one of those issues is closed, drop its entry from `KNOWN_CONSOLE_NOISE` in `support/console-gate.ts`.
 
-Surface-specific noise — bugs that fire on a single Vue component, where a global allowlist would risk swallowing unrelated regressions with the same message text — should be registered per-spec via `consoleGate.allow(pattern, issue)` at the top of the test. Current spec-scoped entries:
-
-| Spec | Pattern | Issue |
-| --- | --- | --- |
-| `gift-crud.spec.ts` | `vm is not defined` | [#732](https://github.com/brycehans/monica/issues/732) |
+Surface-specific noise — bugs that fire on a single Vue component, where a global allowlist would risk swallowing unrelated regressions with the same message text — should be registered per-spec via `consoleGate.allow(pattern, issue)` at the top of the test. No spec-scoped entries are currently active.
 
 ## What this is NOT
 

--- a/tests/playwright/specs/gift-crud.spec.ts
+++ b/tests/playwright/specs/gift-crud.spec.ts
@@ -30,14 +30,6 @@ import { createContact } from '../support/contacts';
 
 test.describe('Monica v4 — gift CRUD', () => {
   test('create + edit + delete a gift on the contact detail page', async ({ page, consoleGate }) => {
-    // CreateGift._errorHandle's else-branch references undeclared `vm`
-    // (filed as #732). It fires twice per gift save when $refs.upload is
-    // undefined — i.e., every save that doesn't open the photo-upload
-    // panel, which includes this test. Scope the allowlist to this spec
-    // so a `vm is not defined` regression anywhere else in the app keeps
-    // failing the gate.
-    consoleGate.allow(/vm is not defined/, '#732');
-
     await loginAsFreshUser(page);
     await createContact(page, 'John', 'Doe', 'Man');
 


### PR DESCRIPTION
## Summary

Fixes #732. `CreateGift._errorHandle`'s else branch referenced an undeclared `vm` (typo from #3342, latent since Jan 2020 because the else branch only fires for non-422 errors). Fixing the typo surfaced a deeper lifecycle race introduced by the Vue 3 cutover (#730): `vm.close() → next .then → vm.$t(...)` worked in Vue 2 because `$t` lived on `Vue.prototype`, but vue-i18n@10 legacy mode binds `$t` per-component-instance via a `Vue.mixin`, so it dies with the proxy once Vue flushes the unmount between microtasks. The success toast on every gift create/edit has been silently failing since #730.

Fix:

- Resolve the toast title to a local before the async chain, so the post-unmount `.then` doesn't need a live proxy.
- Replace `vm` with `this` in `_errorHandle` for the genuine non-422 error path.
- Drop the gift-crud spec's `consoleGate.allow(/vm is not defined/)` and the matching README row — a regression should fail the gate, not be allowlisted again.

Audited the rest of the codebase: CreateGift is the only file with the close()-then-next-microtask-then-$t() shape. CreateActivity does similar work but keeps `$emit + $notify + $t` in a single `.then` body (synchronous, runs before Vue flushes), so it's safe.

## Follow-ups filed

- **#743** — review rule for the broader proxy-after-unmount pattern, with the codebase audit table.
- **#744** — migrate vue-i18n from legacy mode to Composition API before legacy mode is removed in vue-i18n v12. That migration makes the #743 class of bug go away for good.

See the commit message for the full three-layer breakdown.

## Test plan

- [x] `npx playwright test gift-crud` passes (3.0s, 1 spec)
- [x] `npx eslint resources/js/components/people/gifts/CreateGift.vue` — 0 errors
- [x] Manual verification via Playwright MCP — gift create + edit + delete on the contact page works, success toast appears, no console errors
- [ ] CI green
