### PR TITLE
chore: gitignore .playwright-mcp/ and docs/mem-proposals/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tests/cypress/videos
 test-results/
 playwright-report/
+.playwright-mcp/
 /vendor
 .composer
 .env
@@ -37,3 +38,4 @@ yarn-error.log
 CLAUDE_CONTINUE.md
 tmp/
 toolgate.config.local.ts
+docs/mem-proposals/


### PR DESCRIPTION
Adds two local-tooling directories that shouldn't be tracked:

- `.playwright-mcp/` — playwright MCP session traces (snapshots, console logs), grouped next to the existing `test-results/` / `playwright-report/` entries
- `docs/mem-proposals/` — local mem skill drafts, grouped with the existing fork-specific local-tooling section (alongside `CLAUDE_CONTINUE.md`, `tmp/`, `toolgate.config.local.ts`)

No source changes. Two-line addition to .gitignore.