### PR TITLE
refactor(i18n): flip vue-i18n to composition API mode (phase 1 of #744)

### DIFF
--- a/resources/js/common.js
+++ b/resources/js/common.js
@@ -47,25 +47,31 @@ import pluralization from './pluralization.js';
 
 export default {
   i18n: createI18n({
-    legacy: true,
+    legacy: false,
+    // Keeps `$t` / `$tc` injected on every component instance so Options API
+    // call sites work during the Phase 2 per-component migration to
+    // `useI18n()`. Default is already true; pinned explicitly to make the
+    // intent visible while the legacy surface is being walked down (#744).
+    globalInjection: true,
     locale: 'en',
     fallbackLocale: 'en',
     messages: {'en': messages},
-    pluralizationRules: pluralization,
+    // Composition mode renames `pluralizationRules` → `pluralRules`.
+    pluralRules: pluralization,
   }),
 
   loadedLanguages : ['en'], // our default language that is preloaded
 
   _setI18nLanguage (lang) {
-    // Legacy-mode locale is a plain string property, not a ref — direct
-    // assignment (not `.value`). Composition mode is the `.value` shape.
-    this.i18n.global.locale = lang;
+    // Composition mode: `global.locale` is a ref, so assign via `.value`.
+    // (Legacy mode treated it as a plain string property.)
+    this.i18n.global.locale.value = lang;
     axios.defaults.headers.common['Accept-Language'] = lang;
     document.querySelector('html').setAttribute('lang', lang);
   },
 
   _loadLanguageAsync (lang) {
-    if (this.i18n.global.locale !== lang) {
+    if (this.i18n.global.locale.value !== lang) {
       if (!this.loadedLanguages.includes(lang)) {
         return axios.get(`js/langs/${lang}.json`).then(msgs => {
           this.i18n.global.setLocaleMessage(lang, msgs.data);


### PR DESCRIPTION
## Summary

Phase 1 of #744 — flip `createI18n` from legacy to composition API mode. Three required edits in `resources/js/common.js`:

- `legacy: true` → `legacy: false`, plus `globalInjection: true` pinned explicitly as the Options API backstop while Phase 2 walks down the `this.$t` surface across 36 `.vue` files.
- `pluralizationRules` → `pluralRules`. Composition mode renames the option (vue-i18n typedef: `vue-i18n.d.ts:790` vs `:2778`); without the rename, custom plural rules silently stop applying.
- `i18n.global.locale = lang` → `.locale.value = lang`. In composition mode the global locale is a `WritableComputedRef<Locale>`, not a string property. Same change for the read in `_loadLanguageAsync`.

The two remaining `i18n.global.locale` reads (`app.js:108`, `stripe.js:28`) land inside a Vue 3 `data()` return, where `reactive()` auto-unwraps refs at the top level — `this.$root.locale` keeps returning the unwrapped string. The six `.vue` files reading `this.$i18n.locale` for `moment.locale(...)` also keep working: `globalInjection: true` installs a `$i18n` wrapper whose getter unwraps via `desc.value.value` (`vue-i18n.mjs:2380`).

A behaviour improvement falls out: `$root.locale` becomes a live binding to the underlying ref, where legacy mode left it as an at-mount snapshot. Children consuming `:locale="$root.locale"` now reflect subsequent locale switches without remount.

## Why now

vue-i18n v12 will remove legacy mode entirely (it's deprecated in v11). Beyond the deadline, legacy mode is the root cause of the proxy-after-unmount footgun class documented in #743 / #732 — `$t` is bound per-instance and dies with the component proxy. Composition mode keeps `t` as a setup-scoped closure that survives teardown; that footgun goes away for good once Phase 2 lands.

## Phase 2 is separate

This PR ships the config flip alone so we get an independent rollback signal if anything regresses. Phase 2 — replacing `this.$t` with `useI18n()` across the 36 `.vue` files identified in the issue — opens its own PR.

## Test plan

- [x] `yarn run lint` — 0 errors (pre-existing warnings only)
- [x] `yarn run prod` — builds clean
- [x] `tests/playwright/dependency-upgrade-smoke.spec.ts` — 42/42 (one re-run for a pre-existing AJAX/`count()` race on `/people`, unrelated to this change)
- [x] `tests/playwright` feature specs (16) — 16/16
- [x] Direct i18n behaviour covered by `smoke:458` (locale switch fr → en revert) and `smoke:1385` (`$tc` plural-rewrite guard) — both pass under composition mode

Per the issue, expect to file follow-ups for any latent bugs surfaced by stricter composition-mode binding (similar shape to #732). None observed during this run.

Closes #744 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
