### PR TITLE
fix(gifts): re-key familyContacts to array so vue prop type-check passes (closes #679)

### DIFF
--- a/resources/views/people/gifts/index.blade.php
+++ b/resources/views/people/gifts/index.blade.php
@@ -8,7 +8,7 @@
           'id' => $familyRelationship->ofContact->id,
           'name' => $familyRelationship->ofContact->first_name,
       ];
-    }) }}"
+    })->values() }}"
     :reach-limit="{{ \Safe\json_encode($hasReachedAccountStorageLimit) }}"
   >
   </contact-gift>


### PR DESCRIPTION
## Summary

- `$familyRelationships->map()` preserves the keys it inherits from the upstream `filter()` chain (relationship IDs), so the prop renders as `{"2":{…},"4":{…}}` and `<ContactGift>`'s `type: Array` check rejects it with a Vue warning on every contact detail page that has family relationships.
- Append `->values()` so the JSON serializes as `[{…},{…}]`. No-op when the collection is empty.
- Upstream code last touched in 2019 — predates the fork.

Closes #679.

## Test plan

- [x] Reproduce pre-fix: log in as `admin@admin.com / admin0`, visit a contact with family relationships, inspect raw page source — `family-contacts="{&quot;2&quot;:{…},&quot;4&quot;:{…}}"`.
- [x] Apply fix, restart `monica-app-1` to clear OpCache, reload the same page — `family-contacts="[{&quot;id&quot;:4,…},{&quot;id&quot;:6,…}]"` (array form).
- [ ] PHPStan + existing test suite stay green (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
