### PR TITLE
fix(pwa): drop empty related_applications block from manifest (closes #626)

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -22,8 +22,5 @@
       "type": "image/svg+xml"
     }
   ],
-  "orientation": "portrait-primary",
-  "related_applications": [{
-    "platform": "web"
-  }]
+  "orientation": "portrait-primary"
 }

--- a/tests/playwright/support/console-gate.ts
+++ b/tests/playwright/support/console-gate.ts
@@ -44,8 +44,6 @@ export const KNOWN_CONSOLE_NOISE: ConsoleNoiseEntry[] = [
   { match: /Invalid handler for event "search:(?:blur|focus)"/, issue: '#624' },
   // #625 — Unknown <error> element in ContactFieldTypes.vue
   { match: /Unknown custom element: <error>/, issue: '#625' },
-  // #626 — PWA manifest missing url/id in related_applications
-  { match: /Manifest: one of 'url' or 'id' is required/, issue: '#626' },
 ];
 
 export class ConsoleGate {


### PR DESCRIPTION
## Summary

- `public/manifest.webmanifest` declared `related_applications: [{ platform: "web" }]` with no `url` or `id` — both are required, so Chromium logs `Manifest: one of 'url' or 'id' is required, related application ignored` on every authenticated page load.
- No companion app to link to, so the block is removed entirely rather than backfilling a placeholder URL.
- Also drop the `#626` matcher from `KNOWN_CONSOLE_NOISE` in `tests/playwright/support/console-gate.ts` — the underlying warning can no longer fire, so the allowlist entry is dead weight, and removing it means any regression that brings the bad entry back will trip the console gate in every spec that loads an authenticated page (the manifest is requested on every page).

Closes #626.

## Test plan

- [x] Inspect served file before fix: `xh GET http://localhost:8082/manifest.webmanifest` returns the original entry.
- [x] Apply fix, `docker cp` into the running container, fetch with `cache: 'reload'` → fixed manifest (no `related_applications`).
- [x] Run two Playwright specs that exercise the consoleGate (`contact-introductions.spec.ts`, `note-modal-crud.spec.ts`) after dropping the `#626` matcher — both pass, confirming the warning is no longer raised in practice.
- [ ] After merge, existing browsers may still warn for ~24h until the manifest cache TTL expires. New sessions and incognito tabs pick up the fix immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
