### PR TITLE
refactor(forms): rename Error.vue → FormErrors.vue with hyphenated tag (closes #625)

### DIFF
--- a/resources/js/components/partials/FormErrors.vue
+++ b/resources/js/components/partials/FormErrors.vue
@@ -28,6 +28,8 @@
 
 <script>
 export default {
+  name: 'FormErrors',
+
   props: {
     errors: {
       type: [Array, Object],

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -97,7 +97,7 @@
                   @open="_focusInput"
     >
       <!-- Form Errors -->
-      <errors :errors="form.errors" />
+      <form-errors :errors="form.errors" />
 
       <!-- Create Client Form -->
       <form ref="form" class="form-horizontal" role="form">
@@ -184,14 +184,14 @@
 </template>
 
 <script>
-import Errors from '../partials/Error.vue';
+import FormErrors from '../partials/FormErrors.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { required, url } from '@vuelidate/validators';
 
 export default {
 
   components: {
-    Errors,
+    FormErrors,
   },
 
   setup: () => ({ v$: useVuelidate() }),

--- a/resources/js/components/passport/PersonalAccessTokens.vue
+++ b/resources/js/components/passport/PersonalAccessTokens.vue
@@ -66,7 +66,7 @@
                   :title="$t('settings.api_token_create')" @open="_focusInput"
     >
       <!-- Form Errors -->
-      <errors :errors="form.errors" />
+      <form-errors :errors="form.errors" />
 
       <!-- Create Token Form -->
       <form ref="form" class="form-horizontal" role="form" @submit.prevent="store">
@@ -140,14 +140,14 @@
 </template>
 
 <script>
-import Errors from '../partials/Error.vue';
+import FormErrors from '../partials/FormErrors.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 
 export default {
 
   components: {
-    Errors,
+    FormErrors,
   },
 
   setup: () => ({ v$: useVuelidate() }),

--- a/resources/js/components/people/activity/CreateActivity.vue
+++ b/resources/js/components/people/activity/CreateActivity.vue
@@ -102,7 +102,7 @@
           />
         </div>
 
-        <error :errors="errors" />
+        <form-errors :errors="errors" />
 
         <!-- ACTIONS -->
         <div class="pt3">
@@ -128,14 +128,14 @@
 import moment from 'moment';
 import ActivityTypeList from './ActivityTypeList.vue';
 import Emotion from '../Emotion.vue';
-import Error from '../../partials/Error.vue';
+import FormErrors from '../../partials/FormErrors.vue';
 import Participant from '../Participant.vue';
 
 export default {
   components: {
     ActivityTypeList,
     Emotion,
-    Error,
+    FormErrors,
     Participant,
   },
 

--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -200,7 +200,7 @@
           </div>
         </div>
 
-        <error :errors="errors" />
+        <form-errors :errors="errors" />
 
         <!-- ACTIONS -->
         <div class="pt3">
@@ -224,14 +224,14 @@
 
 <script>
 
-import Error from '../../partials/Error.vue';
+import FormErrors from '../../partials/FormErrors.vue';
 import PhotoUpload from '../photo/PhotoUpload.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { required, maxLength } from '@vuelidate/validators';
 
 export default {
   components: {
-    Error,
+    FormErrors,
     PhotoUpload
   },
 

--- a/resources/js/components/settings/ContactFieldTypes.vue
+++ b/resources/js/components/settings/ContactFieldTypes.vue
@@ -69,7 +69,7 @@
                   @open="_focusCreateInput"
     >
       <!-- Form Errors -->
-      <errors :errors="createForm.errors" />
+      <form-errors :errors="createForm.errors" />
 
       <form class="form-horizontal" role="form" @submit.prevent="store">
         <div class="form-group">
@@ -135,7 +135,7 @@
                   @open="_focusEditInput"
     >
       <!-- Form Errors -->
-      <error :errors="editForm.errors" />
+      <form-errors :errors="editForm.errors" />
 
       <form class="form-horizontal" role="form" @submit.prevent="update">
         <div class="form-group">
@@ -215,12 +215,12 @@
 </template>
 
 <script>
-import Errors from '../partials/Error.vue';
+import FormErrors from '../partials/FormErrors.vue';
 
 export default {
 
   components: {
-    Errors,
+    FormErrors,
   },
 
   data() {

--- a/tests/playwright/specs/form-errors-rendering.spec.ts
+++ b/tests/playwright/specs/form-errors-rendering.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * FormErrors rendering across every host modal (#625).
+ *
+ * After renaming `partials/Error.vue` to `partials/FormErrors.vue` and
+ * collapsing the `<error>` / `<errors>` aliases to a single `<form-errors>`
+ * tag, this spec locks down that the component resolves and renders in
+ * every modal that mounts it. Without it, a regression to the old tag
+ * names would be silent — Vue 3 treats unknown lowercase tags as
+ * `HTMLUnknownElement` (no warning), so the only symptom is an alert that
+ * never appears.
+ *
+ * Each test intercepts the POST that the modal would otherwise fire and
+ * fulfils a 422 with a server-shaped errors body, so the assertion is
+ * focused on rendering — not on whatever the server-side validator
+ * happens to enforce. The five hosts: ContactFieldTypes (create + edit),
+ * PersonalAccessTokens, Clients, CreateGift, CreateActivity.
+ */
+
+import type { Page, Route } from '@playwright/test';
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+async function fulfil422(page: Page, urlGlob: string, body: Record<string, string[]>): Promise<void> {
+  await page.route(urlGlob, async (route: Route) => {
+    const method = route.request().method();
+    if (method !== 'POST' && method !== 'PUT') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 422,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/**
+ * Every test in this file intentionally triggers a 422; Chromium logs
+ * `[error] Failed to load resource: 422` for those, and the console gate
+ * would otherwise flag them. Allowlist scoped per test so a 422 fired by
+ * an unrelated request still trips the gate.
+ */
+const EXPECTED_422_NOTICE = /Failed to load resource.*422/;
+
+test.describe('Monica v4 — FormErrors rendering (#625)', () => {
+  test('ContactFieldTypes create modal renders alert on 422', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    await fulfil422(page, '**/settings/personalization/contactfieldtypes', {
+      name: ['Field type create: intercepted message'],
+    });
+
+    await page.goto('/settings/personalization');
+    await page.getByRole('link', { name: 'Add new field type' }).click();
+    await page.getByRole('textbox', { name: 'Name' }).fill('Anything');
+    await page.getByRole('link', { name: 'Save', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Field type create: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('contactfieldtypes/create');
+  });
+
+  test('ContactFieldTypes edit modal renders alert on 422 (regression for #625 root cause)', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    // PUT to /settings/personalization/contactfieldtypes/<id>
+    await fulfil422(page, '**/settings/personalization/contactfieldtypes/*', {
+      name: ['Field type edit: intercepted message'],
+    });
+
+    await page.goto('/settings/personalization');
+
+    // Wait for the contact-field-types list to render (account seeding
+    // populates the standard set: LinkedIn, Facebook, Email, Phone…).
+    const linkedInRow = page.locator('.dt-row').filter({ hasText: 'LinkedIn' }).first();
+    await expect(linkedInRow).toBeVisible();
+    await linkedInRow.locator('.fa-pencil-square-o').click();
+
+    // editForm.name pre-fills with the row's name; clear+refill so the
+    // request actually fires.
+    const nameInput = page.getByRole('textbox', { name: 'Name' });
+    await nameInput.fill('LinkedIn edited');
+    await page.getByRole('link', { name: 'Edit', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Field type edit: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('contactfieldtypes/edit');
+  });
+
+  test('PersonalAccessTokens create modal renders alert on 422', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    await fulfil422(page, '**/oauth/personal-access-tokens', {
+      name: ['Token create: intercepted message'],
+    });
+
+    await page.goto('/settings/api');
+    await page.getByRole('link', { name: 'Create New Token' }).click();
+    await page.locator('input[name="create-token-name"]').fill('TestToken');
+    // Submit is rendered as an <a class="btn btn-primary">, not <button>.
+    await page.getByRole('link', { name: 'Create', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Token create: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('oauth/personal-access-tokens/create');
+  });
+
+  test('OAuth Clients create modal renders alert on 422', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    await fulfil422(page, '**/oauth/clients', {
+      name: ['Client create: intercepted message'],
+    });
+
+    await page.goto('/settings/api');
+    await page.getByRole('link', { name: 'Create New Client' }).click();
+    await page.locator('input[name="client-name"]').fill('TestClient');
+    await page.locator('input[name="redirect-url"]').fill('https://example.com/callback');
+    // Submit is rendered as an <a class="btn btn-primary">, not <button>.
+    await page.getByRole('link', { name: 'Create', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Client create: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('oauth/clients/create');
+  });
+
+  test('CreateGift modal renders alert on 422', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    await createContact(page, 'Gift', 'Tester', 'Man');
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    await fulfil422(page, '**/people/h:*/gifts', {
+      name: ['Gift create: intercepted message'],
+    });
+
+    await page.getByRole('link', { name: 'Add a gift' }).click();
+    // CreateGift form opens inline below the gifts section heading. The
+    // visible "Gift name" field is the vuelidate-bound input; fill it so
+    // v$.$invalid is false and the request actually fires.
+    await page.getByLabel('Gift name').fill('A gift');
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Gift create: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('people/h:<contact>/gifts/create');
+  });
+
+  test('CreateActivity modal renders alert on 422', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    await createContact(page, 'Activity', 'Tester', 'Woman');
+    consoleGate.allow(EXPECTED_422_NOTICE, '#625-test-intercept');
+    await fulfil422(page, '**/activities', {
+      summary: ['Activity create: intercepted message'],
+    });
+
+    // Blank-state link reads "Add an activity"; the post-first-activity
+    // section heading reads "Add activity". Either opens the same form.
+    await page.getByRole('link', { name: /Add an? activity/ }).click();
+    // The summary input's label is the parameterised "What did you do
+    // with {name}?" — match the leading literal.
+    await page.getByLabel(/What did you do with/).fill('An activity');
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+
+    await expect(
+      page.locator('.alert.alert-danger').filter({ hasText: 'Activity create: intercepted message' }),
+    ).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('activities/create');
+  });
+});

--- a/tests/playwright/support/console-gate.ts
+++ b/tests/playwright/support/console-gate.ts
@@ -38,13 +38,7 @@ export type ConsoleNoiseEntry = { match: RegExp; issue: string };
 export type UnknownConsole = { type: string; text: string; url: string };
 export type KnownConsole = { issue: string; text: string };
 
-export const KNOWN_CONSOLE_NOISE: ConsoleNoiseEntry[] = [
-  // #624 — ContactSelect references undefined blur/focus handlers
-  { match: /Property or method "(?:blur|focus)" is not defined/, issue: '#624' },
-  { match: /Invalid handler for event "search:(?:blur|focus)"/, issue: '#624' },
-  // #625 — Unknown <error> element in ContactFieldTypes.vue
-  { match: /Unknown custom element: <error>/, issue: '#625' },
-];
+export const KNOWN_CONSOLE_NOISE: ConsoleNoiseEntry[] = [];
 
 export class ConsoleGate {
   readonly unknown: UnknownConsole[] = [];


### PR DESCRIPTION
## Summary

- `<error>` and `<errors>` aren't valid HTML custom-element names (the W3C spec requires a hyphen). Vue's local component registry papered over this for the `<errors>` aliases, but `<error>` in `ContactFieldTypes.vue:138` matched nothing and the edit-modal errors silently never rendered. `CreateGift` / `CreateActivity` further imported the component as `Error`, shadowing the global JS `Error` class.
- Rename `partials/Error.vue` → `partials/FormErrors.vue`, give it an explicit `name: 'FormErrors'`, and update all 5 call sites to `<form-errors>`. The hyphenated tag matches the HTML custom-element spec, the import alias no longer shadows `Error`, and the originally-broken edit-modal path now rendering errors falls out for free.
- Add `tests/playwright/specs/form-errors-rendering.spec.ts` — one test per host modal that intercepts the POST/PUT with a 422 via `page.route()` and asserts the `.alert.alert-danger` text matches. Without this, a regression to the old tag names would be silent again (Vue 3 treats unknown lowercase tags as `HTMLUnknownElement` — no warning, no error, just no alert).
- Drop the now-stale `#624` and `#625` entries from `KNOWN_CONSOLE_NOISE` (the underlying causes are fixed/closed; the matchers are dead weight and would silently swallow regressions).

Closes #625.

## Test plan

- [x] `yarn run lint` → 0 errors.
- [x] `yarn run prod` → clean build.
- [x] `tests/playwright/specs/form-errors-rendering.spec.ts` — 6/6 pass:
    - ContactFieldTypes create
    - ContactFieldTypes edit (the originally broken `<error>` line 138)
    - PersonalAccessTokens create
    - OAuth Clients create
    - CreateGift
    - CreateActivity
- [x] Full Playwright suite — 65/65 pass with the trimmed noise list (proves removing the `#624` matchers doesn't reveal a real warning hiding behind them).
- [ ] CI: PHPStan + PHPUnit unchanged (no PHP touched).

## Files touched

- `resources/js/components/partials/Error.vue` → `partials/FormErrors.vue` (renamed via `git mv`, +2 lines: `name` field)
- `resources/js/components/passport/PersonalAccessTokens.vue` — `<errors>` → `<form-errors>`, import alias updated
- `resources/js/components/passport/Clients.vue` — same shape
- `resources/js/components/settings/ContactFieldTypes.vue` — same shape; fixes the broken `<error>` typo at line 138
- `resources/js/components/people/gifts/CreateGift.vue` — `<error>` → `<form-errors>`, `Error` import alias replaced (was shadowing global `Error`)
- `resources/js/components/people/activity/CreateActivity.vue` — same shape as CreateGift
- `tests/playwright/specs/form-errors-rendering.spec.ts` — new spec (6 tests)
- `tests/playwright/support/console-gate.ts` — drop `#624` + `#625` matchers from `KNOWN_CONSOLE_NOISE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
