### PR TITLE
fix(people): compute hasReachedAccountStorageLimit on avatar edit (closes #645)

### DIFF
--- a/app/Http/Controllers/Contacts/AvatarController.php
+++ b/app/Http/Controllers/Contacts/AvatarController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Contacts;
 
 use Illuminate\Http\Request;
+use App\Helpers\StorageHelper;
 use App\Models\Contact\Contact;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Validator;
@@ -18,8 +19,11 @@ class AvatarController extends Controller
     {
         $contact->throwInactive();
 
+        $hasReachedAccountStorageLimit = StorageHelper::hasReachedAccountStorageLimit($contact->account);
+
         return view('people.avatar.edit')
-            ->withContact($contact);
+            ->withContact($contact)
+            ->withHasReachedAccountStorageLimit($hasReachedAccountStorageLimit);
     }
 
     /**

--- a/resources/views/people/avatar/edit.blade.php
+++ b/resources/views/people/avatar/edit.blade.php
@@ -20,7 +20,7 @@
           :default-url="'{{ $contact->getAvatarDefaultURL() }}'"
           :gravatar-url="'{{ $contact->avatar_gravatar_url }}'"
           :photo-url="'{{ $contact->getAvatarURL() }}'"
-          :has-reached-account-storage-limit="false"
+          :has-reached-account-storage-limit="{{ \Safe\json_encode($hasReachedAccountStorageLimit) }}"
           :max-upload-size="{{ config('monica.max_upload_size') }}"
         >
         </contact-avatar>

--- a/tests/Feature/AvatarTest.php
+++ b/tests/Feature/AvatarTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Tests\FeatureTestCase;
 use App\Models\Account\Photo;
 use App\Models\Contact\Contact;
+use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -114,5 +115,34 @@ class AvatarTest extends FeatureTestCase
             'contact_id' => $contact2->id,
             'photo_id' => $photo->id,
         ]);
+    }
+
+    public function test_edit_screen_passes_storage_limit_false_when_under_quota()
+    {
+        [$user, $contact] = $this->fetchUser();
+        config(['monica.requires_subscription' => true]);
+        config(['monica.max_storage_size' => 100]);
+
+        $response = $this->get('/people/'.$contact->hashID().'/avatar');
+
+        $response->assertStatus(200);
+        $response->assertSee(':has-reached-account-storage-limit="false"', false);
+    }
+
+    public function test_edit_screen_passes_storage_limit_true_when_over_quota()
+    {
+        [$user, $contact] = $this->fetchUser();
+        config(['monica.requires_subscription' => true]);
+        config(['monica.max_storage_size' => 0.1]);
+
+        factory(Document::class)->create([
+            'filesize' => 1000000,
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->get('/people/'.$contact->hashID().'/avatar');
+
+        $response->assertStatus(200);
+        $response->assertSee(':has-reached-account-storage-limit="true"', false);
     }
 }


### PR DESCRIPTION
## Summary

- `AvatarController::edit` now computes `hasReachedAccountStorageLimit` via `StorageHelper::hasReachedAccountStorageLimit` and passes it to the view.
- `resources/views/people/avatar/edit.blade.php` consumes the variable instead of hardcoding `:has-reached-account-storage-limit="false"`.
- Mirrors the pattern already used by `ContactsController` (and the gift / photo / document Blade templates).

Closes #645.

## Scope note

Server-side hardening in `AvatarController::update` is intentionally not included — sibling upload flows (gifts, photos, documents) also rely only on the UI prop to disable upload, so this PR matches their behaviour rather than expanding the surface.

## Test plan

- [x] `vendor/bin/phpunit tests/Feature/AvatarTest.php` — 4 tests pass (2 existing + 2 new).
- [x] `vendor/bin/phpstan analyse app/Http/Controllers/Contacts/AvatarController.php` — no errors.
- [x] New tests cover the under-quota (`false`) and over-quota (`true`) cases by asserting the rendered prop value in the response HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
