### PR TITLE
fix(stripe): read plan off subscription item rather than top-level subscription (closes #681)

### DIFF
--- a/app/Helpers/InstanceHelper.php
+++ b/app/Helpers/InstanceHelper.php
@@ -58,7 +58,8 @@ class InstanceHelper
     {
         try {
             $stripeSubscription = $subscription->asStripeSubscription();
-            $plan = $stripeSubscription->plan;
+            // stripe-php 17 removed the top-level Stripe\Subscription->plan property; per-item plan data now lives on each SubscriptionItem. Reading $stripeSubscription->plan emits a "Stripe Notice: Undefined property" warning on every render of the subscription settings page.
+            $plan = $stripeSubscription->items->data[0]->plan ?? null;
         } catch (\Stripe\Exception\ApiErrorException $e) {
             $stripeSubscription = null;
             $plan = null;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,8 +27,6 @@ parameters:
           path: */Traits/Searchable.php
         - message: '#Access to an undefined property Faker\\Generator::\$state\.#'
           path: */Console/Commands/SetupTest.php
-        - message: '#Access to an undefined property Stripe\\Subscription::\$plan\.#'
-          path: */Helpers/InstanceHelper.php
         - message: '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany(<.+>)?::recurring\(\)\.#'
           path: */Traits/Subscription.php
         - message: '#Argument of an invalid type stdClass supplied for foreach, only iterables are supported\.#'

--- a/tests/Unit/Helpers/InstanceHelperTest.php
+++ b/tests/Unit/Helpers/InstanceHelperTest.php
@@ -99,11 +99,17 @@ class InstanceHelperTest extends TestCase
     public function it_fetches_subscription_information()
     {
         $stripeSubscription = (object) [
-            'plan' => (object) [
-                'currency' => 'USD',
-                'amount' => 500,
-                'interval' => 'month',
-                'id' => 'monthly',
+            'items' => (object) [
+                'data' => [
+                    (object) [
+                        'plan' => (object) [
+                            'currency' => 'USD',
+                            'amount' => 500,
+                            'interval' => 'month',
+                            'id' => 'monthly',
+                        ],
+                    ],
+                ],
             ],
         ];
 


### PR DESCRIPTION
## Summary

- Read `plan` off the first `SubscriptionItem` (`$stripeSubscription->items->data[0]->plan`) instead of the top-level `Stripe\Subscription`.
- Inline comment matches the existing one for `current_period_end` (also moved off `Subscription` in stripe-php 17, fixed in #677).
- Test mock updated to match the new data shape; existing assertions unchanged.

Closes #681.

## Why this is the smallest viable fix

The deprecation notice fires specifically on `Stripe\Subscription->plan` (top-level). The per-item `plan` accessor on `SubscriptionItem` still exists in stripe-php 17 as a backwards-compat alias for `price`, so reading it here keeps the data shape identical and requires no downstream changes to `$plan->currency`, `$plan->amount`, `$plan->interval`, `$plan->id`.

A fuller migration to the Price API (rename `amount` → `unit_amount`, `interval` → `recurring->interval`, etc.) would expand the blast radius beyond a deprecation cleanup, so that's out of scope here.

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/Helpers/InstanceHelperTest.php tests/Unit/Traits/StripeCallTest.php tests/Feature/SubscriptionsControllerTest.php tests/Feature/AccountSubscriptionTest.php` — all 38 tests pass.
- [x] `vendor/bin/phpunit tests/Unit/Traits/StripeCallTest.php tests/Feature/SubscriptionsControllerTest.php tests/Feature/AccountSubscriptionTest.php 2>&1 | grep -i "stripe notice"` — zero matches (was the acceptance criterion in the issue).
- [x] `vendor/bin/phpstan analyse app/Helpers/InstanceHelper.php tests/Unit/Helpers/InstanceHelperTest.php` — no new errors (7 pre-existing errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
