### PR TITLE
refactor(i18n): start per-component useI18n migration (phase 2a of #744)

### DIFF
--- a/resources/js/components/dashboard/DashboardLog.vue
+++ b/resources/js/components/dashboard/DashboardLog.vue
@@ -276,6 +276,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment';
 import Avatar from '../partials/Avatar.vue';
 
@@ -290,6 +291,11 @@ export default {
       type: String,
       default: 'calls',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -426,7 +432,7 @@ export default {
         .then(response => {
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });
@@ -441,7 +447,7 @@ export default {
           this.getTasks();
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/ContactInformation.vue
+++ b/resources/js/components/people/ContactInformation.vue
@@ -108,6 +108,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -123,6 +125,11 @@ export default {
       type: Number,
       default: 26,
     }
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -178,7 +185,7 @@ export default {
       _.each(data, function(value) {
         var shortenName = value.data;
         if (shortenName.length > vm.sizeLimit + 1) {
-          shortenName = vm.$t('format.short_text', { text: shortenName.substr(0, vm.sizeLimit) });
+          shortenName = vm.t('format.short_text', { text: shortenName.substr(0, vm.sizeLimit) });
         }
         value.shortenName = shortenName;
       });
@@ -251,7 +258,7 @@ export default {
           if (typeof error.response.data === 'object') {
             form.errors = _.flatten(_.toArray(error.response.data));
           } else {
-            form.errors = [this.$t('app.error_try_again')];
+            form.errors = [this.t('app.error_try_again')];
           }
         });
     },

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -169,6 +169,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import { useVuelidate } from '@vuelidate/core';
 import { required, numeric } from '@vuelidate/validators';
 import moment from 'moment-timezone';
@@ -203,7 +204,10 @@ export default {
     },
   },
 
-  setup: () => ({ v$: useVuelidate() }),
+  setup() {
+    const { t, locale } = useI18n();
+    return { v$: useVuelidate(), t, locale };
+  },
 
   validations() {
     return {
@@ -248,7 +252,7 @@ export default {
     },
 
     formatDate(dateAsString) {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
       moment.tz.setDefault('UTC');
       var date = moment.tz(moment(dateAsString), this.$root.timezone);
       return date.format('LL');
@@ -268,7 +272,7 @@ export default {
 
       // check if you need a subscription to access this feature
       if (this.limited) {
-        this.errorMessage = this.$t('people.stay_in_touch_premium');
+        this.errorMessage = this.t('people.stay_in_touch_premium');
         return;
       }
 
@@ -286,14 +290,14 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             width: '500px',
             type: 'success'
           });
         })
         .catch(error => {
-          this.errorMessage = this.$t('app.error_save');
+          this.errorMessage = this.t('app.error_save');
         });
     },
 


### PR DESCRIPTION
## Summary

Phase 2a of the vue-i18n composition-mode migration (#744). Validation
batch — 3 components chosen to exercise the three conversion patterns
end-to-end before the per-aggregate fan-out:

- `dashboard/DashboardLog.vue` — **fresh `setup()`**, 2 `this.$t` → `this.t`.
- `people/StayInTouch.vue` — **extend existing setup()** (vuelidate from
  #730), 3 `this.$t` → `this.t` + 1 `this.$i18n.locale` → `this.locale`.
- `people/ContactInformation.vue` — **`vm.$t` edge case** in a `_.each`
  closure that captured `var vm = this`; rewritten to `vm.t(...)`.

Templates retain `{{ $t(...) }}` — composition mode resolves them
through the component's `useI18n()` binding once `setup()` is in place,
so they survive the eventual `globalInjection: false` flip without
further edits.

The `this.$i18n.locale` reads are part of the Phase 2c exit gate, not
just the `this.$t` surface — `$i18n` is also installed by
`globalInjection` and disappears when it flips off. StayInTouch is the
first of 6 components that need this migration alongside `this.$t`.

**Remaining Phase 2 surface:** 33 components / ~82 `this.$t`+`vm.$t` +
5 more `this.$i18n.locale`. Next batches by aggregate: people/ (15),
settings/ (12), partials/ (3), passport/ (2). Phase 2c (flip
`globalInjection: false`) lands once the exit grep gate
(`this\.\$t[c]?\(|vm\.\$t[c]?\(|this\.\$i18n`) returns zero across
`resources/js`.

## Test plan

- [x] `yarn run lint` — 0 errors (pre-existing warnings only, same
      baseline as #746).
- [x] `yarn run prod` — builds clean.
- [x] `tests/playwright dependency-upgrade-smoke.spec.ts` — 42/42,
      including the consoleGate-watched surfaces that exercise all three
      migrated components:
  - `login lands on dashboard with expected nav` (DashboardLog mount).
  - `contact detail sidebar mounts contact-information, contact-address,
    pet` (ContactInformation mount + heading text).
  - `contact detail stay-in-touch panel: full flow guards toggle, $tc
    plural, tooltip (pr-t3 three-in-one)` (StayInTouch full flow,
    including the `$i18n.locale`-fed `formatDate` tooltip path).

Refs #744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
