### PR TITLE
refactor(i18n): walk people/ aggregate to useI18n (phase 2b of #744)

### DIFF
--- a/resources/js/components/people/Addresses.vue
+++ b/resources/js/components/people/Addresses.vue
@@ -245,6 +245,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -252,6 +254,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -416,7 +423,7 @@ export default {
           if (typeof error.response.data === 'object') {
             form.errors = _.flatten(_.toArray(error.response.data));
           } else {
-            form.errors = [this.$t('app.error_try_again')];
+            form.errors = [this.t('app.error_try_again')];
           }
         });
     },

--- a/resources/js/components/people/Archive.vue
+++ b/resources/js/components/people/Archive.vue
@@ -20,6 +20,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -31,6 +33,11 @@ export default {
       type: Boolean,
       default: true,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -55,7 +62,7 @@ export default {
 
           this.$notify({
             group: 'archive',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/ContactList.vue
+++ b/resources/js/components/people/ContactList.vue
@@ -106,6 +106,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import { VueGoodTable } from 'vue-good-table-next';
 import ContactItem from './partials/ContactItem.vue';
 
@@ -127,6 +128,11 @@ export default {
     },
   },
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   data() {
     return {
       contacts: [],
@@ -144,17 +150,17 @@ export default {
 
       columns: [
         {
-          label: this.$t('app.contact_list_avatar'),
+          label: this.t('app.contact_list_avatar'),
           field: 'avatar',
           width: '70px',
           sortable: false,
         },
         {
-          label: this.$t('app.contact_list_name'),
+          label: this.t('app.contact_list_name'),
           field: 'name',
         },
         {
-          label: this.$t('app.contact_list_description'),
+          label: this.t('app.contact_list_description'),
           field: 'description',
         }
       ],

--- a/resources/js/components/people/Notes.vue
+++ b/resources/js/components/people/Notes.vue
@@ -82,6 +82,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -89,6 +91,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -163,7 +170,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.notes_create_success'),
+            title: this.t('people.notes_create_success'),
             text: '',
             type: 'success'
           });
@@ -184,7 +191,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.notes_update_success'),
+            title: this.t('people.notes_update_success'),
             text: '',
             type: 'success'
           });
@@ -209,7 +216,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.notes_delete_success'),
+            title: this.t('people.notes_delete_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/Pets.vue
+++ b/resources/js/components/people/Pets.vue
@@ -111,6 +111,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -118,6 +120,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -184,7 +191,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.pets_create_success'),
+            title: this.t('people.pets_create_success'),
             text: '',
             type: 'success'
           });
@@ -220,7 +227,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.pets_update_success'),
+            title: this.t('people.pets_update_success'),
             text: '',
             type: 'success'
           });
@@ -234,7 +241,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.pets_delete_success'),
+            title: this.t('people.pets_delete_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/SetFavorite.vue
+++ b/resources/js/components/people/SetFavorite.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -32,6 +34,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -56,7 +63,7 @@ export default {
 
           this.$notify({
             group: 'favorite',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/StayInTouchLabel.vue
+++ b/resources/js/components/people/StayInTouchLabel.vue
@@ -1,5 +1,6 @@
 <script>
 import { h } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 export default {
   props: {
@@ -9,8 +10,13 @@ export default {
     },
   },
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   render() {
-    const text = this.$t('people.stay_in_touch_modal_label', {count: '[slot]'}, this.value);
+    const text = this.t('people.stay_in_touch_modal_label', {count: '[slot]'}, this.value);
     const texts = _.split(text, '[slot]');
     return h('div', [
       h('span', texts[0]),

--- a/resources/js/components/people/Tasks.vue
+++ b/resources/js/components/people/Tasks.vue
@@ -145,6 +145,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment-timezone';
 
 export default {
@@ -158,6 +159,11 @@ export default {
       type: Number,
       default: -1,
     },
+  },
+
+  setup() {
+    const { t, locale } = useI18n();
+    return { t, locale };
   },
 
   data() {
@@ -232,7 +238,7 @@ export default {
           this.tasks.push(response.data);
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });
@@ -256,7 +262,7 @@ export default {
           }
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });
@@ -264,7 +270,7 @@ export default {
     },
 
     formatDate(dateAsString) {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
       moment.tz.setDefault('UTC');
 
       var date = moment.tz(moment(dateAsString), this.$root.timezone);

--- a/resources/js/components/people/activity/CreateActivity.vue
+++ b/resources/js/components/people/activity/CreateActivity.vue
@@ -125,6 +125,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment';
 import ActivityTypeList from './ActivityTypeList.vue';
 import Emotion from '../Emotion.vue';
@@ -156,6 +157,11 @@ export default {
       type: Object,
       default: null,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -259,7 +265,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.activities_add_success'),
+            title: this.t('people.activities_add_success'),
             text: '',
             type: 'success'
           });
@@ -283,7 +289,7 @@ export default {
       if (error.response && typeof error.response.data === 'object') {
         this.errors = _.flatten(_.toArray(error.response.data));
       } else {
-        this.errors = [this.$t('app.error_try_again'), error.message];
+        this.errors = [this.t('app.error_try_again'), error.message];
       }
     },
   }

--- a/resources/js/components/people/calls/LastCalled.vue
+++ b/resources/js/components/people/calls/LastCalled.vue
@@ -3,6 +3,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   props: {
     hash: {
@@ -15,6 +17,11 @@ export default {
     }
   },
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   data() {
     return {
       lastCalled: '',
@@ -24,14 +31,14 @@ export default {
   computed: {
     lastCalledMessage() {
       if (!this.initialValue && !this.lastCalled) {
-        return this.$t('people.last_called_empty');
+        return this.t('people.last_called_empty');
       }
 
       if (!this.lastCalled) {
-        return this.$t('people.last_talked_to', {date: this.initialValue});
+        return this.t('people.last_talked_to', {date: this.initialValue});
       }
 
-      return this.$t('people.last_talked_to', {date: this.lastCalled});
+      return this.t('people.last_talked_to', {date: this.lastCalled});
     }
   },
 

--- a/resources/js/components/people/calls/PhoneCallList.vue
+++ b/resources/js/components/people/calls/PhoneCallList.vue
@@ -255,6 +255,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment';
 import Emotion from '../Emotion.vue';
 
@@ -272,6 +273,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -347,7 +353,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.calls_add_success'),
+            title: this.t('people.calls_add_success'),
             text: '',
             type: 'success'
           });
@@ -364,7 +370,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/conversation/ConversationList.vue
+++ b/resources/js/components/people/conversation/ConversationList.vue
@@ -30,6 +30,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import { VueGoodTable } from 'vue-good-table-next';
 
 export default {
@@ -45,28 +46,33 @@ export default {
     },
   },
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   data() {
     return {
       conversations: [],
 
       columns: [
         {
-          label: this.$t('app.date'),
+          label: this.t('app.date'),
           field: 'happened_at',
           tdClass: 'vgt-table-date',
         },
         {
-          label: this.$t('app.type'),
+          label: this.t('app.type'),
           field: 'contact_field_type',
           width: '110px',
         },
         {
-          label: this.$t('people.conversation_list_table_messages'),
+          label: this.t('people.conversation_list_table_messages'),
           field: 'message_count',
           width: '110px',
         },
         {
-          label: this.$t('people.conversation_list_table_content'),
+          label: this.t('people.conversation_list_table_content'),
           field: 'content',
         }
       ],

--- a/resources/js/components/people/document/DocumentList.vue
+++ b/resources/js/components/people/document/DocumentList.vue
@@ -231,6 +231,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment-timezone';
 
 export default {
@@ -244,6 +245,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { locale } = useI18n();
+    return { locale };
   },
 
   data() {
@@ -293,7 +299,7 @@ export default {
     },
 
     formatTime(dateAsString) {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
 
       var date = moment(dateAsString);
       return date.format('ll');

--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -224,6 +224,7 @@
 
 <script>
 
+import { useI18n } from 'vue-i18n';
 import FormErrors from '../../partials/FormErrors.vue';
 import PhotoUpload from '../photo/PhotoUpload.vue';
 import { useVuelidate } from '@vuelidate/core';
@@ -258,7 +259,10 @@ export default {
     },
   },
 
-  setup: () => ({ v$: useVuelidate() }),
+  setup() {
+    const { t } = useI18n();
+    return { v$: useVuelidate(), t };
+  },
 
   data() {
     return {
@@ -392,7 +396,7 @@ export default {
       // shared prototype like vue 2 did), so it dies with the proxy once
       // vm.close() emits 'cancel' and the parent flips its v-if. Resolve
       // the toast string here while the proxy is still alive.
-      const successTitle = this.$t('people.gifts_add_success');
+      const successTitle = this.t('people.gifts_add_success');
 
       const vm = this;
       axios[method](url, this.newGift)
@@ -437,7 +441,7 @@ export default {
       if (error.response && typeof error.response.data === 'object') {
         this.errors = _.flatten(_.toArray(error.response.data));
       } else {
-        this.errors = [this.$t('app.error_try_again'), error.message];
+        this.errors = [this.t('app.error_try_again'), error.message];
       }
     },
 

--- a/resources/js/components/people/gifts/Gift.vue
+++ b/resources/js/components/people/gifts/Gift.vue
@@ -68,6 +68,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment-timezone';
 
 export default {
@@ -80,6 +81,11 @@ export default {
       type: Object,
       default: null,
     },
+  },
+
+  setup() {
+    const { locale } = useI18n();
+    return { locale };
   },
 
   data() {
@@ -105,7 +111,7 @@ export default {
     },
 
     formatDate(dateAsString) {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
       moment.tz.setDefault('UTC');
 
       var date = moment.tz(moment(dateAsString), this.$root.timezone);

--- a/resources/js/components/people/lifeevent/CreateLifeEvent.vue
+++ b/resources/js/components/people/lifeevent/CreateLifeEvent.vue
@@ -153,6 +153,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment';
 
 export default {
@@ -180,6 +181,11 @@ export default {
         return [];
       }
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -283,7 +289,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.life_event_create_success'),
+            title: this.t('people.life_event_create_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/lifeevent/LifeEventList.vue
+++ b/resources/js/components/people/lifeevent/LifeEventList.vue
@@ -550,6 +550,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
@@ -582,6 +584,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -627,7 +634,7 @@ export default {
 
           this.$notify({
             group: 'main',
-            title: this.$t('people.life_event_delete_success'),
+            title: this.t('people.life_event_delete_success'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/people/photo/PhotoList.vue
+++ b/resources/js/components/people/photo/PhotoList.vue
@@ -113,6 +113,7 @@
 
 <script>
 
+import { useI18n } from 'vue-i18n';
 import PhotoUpload from './PhotoUpload.vue';
 
 export default {
@@ -138,6 +139,11 @@ export default {
       type: String,
       default: '',
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -180,7 +186,7 @@ export default {
     handleNewPhoto(photo) {
       this.$notify({
         group: 'main',
-        title: this.$t('app.default_save_success'),
+        title: this.t('app.default_save_success'),
         text: '',
         type: 'success'
       });
@@ -194,7 +200,7 @@ export default {
           this.photos.splice(this.photos.indexOf(photo), 1);
           this.$notify({
             group: 'main',
-            title: this.$t('app.default_save_success'),
+            title: this.t('app.default_save_success'),
             text: '',
             type: 'success'
           });


### PR DESCRIPTION
## Summary

Phase 2b of the vue-i18n composition-mode migration (#744). Walks the
entire `resources/js/components/people/` aggregate that wasn't in
[#755's](https://github.com/brycehans/monica/pull/755) 3-component
validation batch — **18 files, 30 callsites** (27 `this.$t`/`vm.$t`
rewrites + 3 `this.$i18n.locale` rewrites for moment locale binding).

| File | `$t` callsites | `$i18n.locale` |
| --- | ---: | ---: |
| `Archive.vue` | 1 | 0 |
| `Addresses.vue` | 1 | 0 |
| `ContactList.vue` | 3 | 0 |
| `Notes.vue` | 3 | 0 |
| `Pets.vue` | 3 | 0 |
| `SetFavorite.vue` | 1 | 0 |
| `StayInTouchLabel.vue` | 1 (in `render()`) | 0 |
| `Tasks.vue` | 2 | 1 |
| `activity/CreateActivity.vue` | 2 | 0 |
| `calls/LastCalled.vue` | 3 (in `computed`) | 0 |
| `calls/PhoneCallList.vue` | 2 | 0 |
| `conversation/ConversationList.vue` | 4 | 0 |
| `document/DocumentList.vue` | 0 | 1 |
| `gifts/CreateGift.vue` | 2 | 0 |
| `gifts/Gift.vue` | 0 | 1 |
| `lifeevent/CreateLifeEvent.vue` | 1 | 0 |
| `lifeevent/LifeEventList.vue` | 1 | 0 |
| `photo/PhotoList.vue` | 2 | 0 |

Pattern is identical to #755: import `useI18n`, add `setup()` returning
`{ t }` (and `locale` where the file reads `$i18n.locale`), rewrite
`this.$t` → `this.t` and `this.$i18n.locale` → `this.locale`. Templates
retain `{{ $t(...) }}` — composition mode resolves them through the
per-component `useI18n()` binding.

**Render-path nuances:**

- `StayInTouchLabel.vue` calls `t(...)` from a `render()` function with
  the legacy `(key, named, plural)` 3-arg signature. Composition-mode
  `t()` supports that overload; verified by the `$tc plural` arm of the
  pr-t3 three-in-one smoke (`dependency-upgrade-smoke:1200`).
- `calls/LastCalled.vue` calls `this.$t` from inside a `computed`, so
  the rewrite fires on every render. Exercised by
  `dependency-upgrade-smoke:86` ('contact detail renders the full section
  graph') via `_header.blade.php`.
- `gifts/CreateGift.vue` already had `setup: () => ({ v$: useVuelidate() })`
  from #730; expanded to a function body returning `{ v$, t }`.

**`vue/order-in-components` sweep:** initial pass landed `setup()` between
`components:` and `props:` in 8 files; reordered to `props` → `setup` →
`data` to match Vue convention. Lint stays at 142 warnings (same baseline
as #746/#755).

**Remaining Phase 2 surface:** 15 components in settings/ (12),
partials/ (3), passport/ (2), then the 2c flip of `globalInjection: false`
once the exit grep gate returns zero across `resources/js`.

## Test plan

- [x] `yarn run lint` — 0 errors, 142 warnings (same baseline as #755).
- [x] `yarn run prod` — built in 4.00s.
- [x] `tests/playwright`: **65/65** — 42/42 `dependency-upgrade-smoke` +
      23/23 across all 17 feature specs (account-export, account-import-
      vcard, activity-journal-side-effect, activity-types-premium-gate,
      activity-types, audit-log, contact-create-validation, contact-
      favorite-ordering, contact-introductions, conversation-create,
      form-errors-rendering, gift-crud, journal-rate-day, note-modal-crud,
      reminder-persistence, signup-duplicate-email, subscription-flow).
- [x] `vendor/bin/phpstan analyse` — 0 errors / 481 files (no PHP touched).

Every playwright spec uses the `consoleGate` fixture, so any
ReferenceError from a broken setup() destructure, vue-i18n
"Not found" warning from a misnamed key, or pageerror from a stray
legacy `this.$t` would have failed the spec — none did.

Refs #744. Independent of #755 (separate file sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
