### PR TITLE
refactor(i18n): walk settings/partials/passport to useI18n (phase 2c of #744)

### DIFF
--- a/resources/js/components/partials/form/Date.vue
+++ b/resources/js/components/partials/form/Date.vue
@@ -23,6 +23,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import { VueDatePicker as Datepicker } from '@vuepic/vue-datepicker';
 import moment from 'moment';
 // @vuepic/vue-datepicker v13 passes :locale straight to date-fns/format,
@@ -69,6 +70,11 @@ export default {
 
   emits: ['update:modelValue'],
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   data() {
     return {
       exchange: '',
@@ -99,11 +105,11 @@ export default {
     },
 
     requiredMessage() {
-      return this.$t('validation.vue.required', { field: this.label });
+      return this.t('validation.vue.required', { field: this.label });
     },
 
     beforeMessage() {
-      return this.$t('validation.vue.max.numeric', {
+      return this.t('validation.vue.max.numeric', {
         field: this.label,
         max: this.displayValue(this.validator?.before?.$params?.date),
       });

--- a/resources/js/components/partials/form/Input.vue
+++ b/resources/js/components/partials/form/Input.vue
@@ -52,6 +52,7 @@
 
 <script>
 import { getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 export default {
 
@@ -113,7 +114,8 @@ export default {
   emits: ['update:modelValue', 'input', 'submit', 'blur', 'change'],
 
   setup() {
-    return { uid: getCurrentInstance().uid };
+    const { t } = useI18n();
+    return { uid: getCurrentInstance().uid, t };
   },
 
   computed: {
@@ -136,10 +138,10 @@ export default {
       return this.label && this.label.length > 0 ? this.label : this.title;
     },
     requiredMessage() {
-      return this.$t('validation.vue.required', { field: this.field });
+      return this.t('validation.vue.required', { field: this.field });
     },
     urlMessage() {
-      return this.$t('validation.vue.url', { field: this.field });
+      return this.t('validation.vue.url', { field: this.field });
     },
     maxLengthMessage() {
       var type = 'string';
@@ -148,7 +150,7 @@ export default {
         type = 'numeric';
         break;
       }
-      return this.$t(`validation.vue.max.${type}`, {
+      return this.t(`validation.vue.max.${type}`, {
         field: this.field,
         max: this.validator?.maxLength?.$params?.max ?? '',
       });

--- a/resources/js/components/partials/form/Select.vue
+++ b/resources/js/components/partials/form/Select.vue
@@ -62,6 +62,7 @@
 
 <script>
 import { getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 export default {
 
@@ -111,7 +112,8 @@ export default {
   emits: ['update:modelValue', 'input'],
 
   setup() {
-    return { uid: getCurrentInstance().uid };
+    const { t } = useI18n();
+    return { uid: getCurrentInstance().uid, t };
   },
 
   data() {
@@ -136,7 +138,7 @@ export default {
       return this.label && this.label.length > 0 ? this.label : this.title;
     },
     requiredMessage() {
-      return this.$t('validation.vue.required', { field: this.field });
+      return this.t('validation.vue.required', { field: this.field });
     },
   },
 

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -184,6 +184,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import FormErrors from '../partials/FormErrors.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { required, url } from '@vuelidate/validators';
@@ -194,7 +195,10 @@ export default {
     FormErrors,
   },
 
-  setup: () => ({ v$: useVuelidate() }),
+  setup() {
+    const { t } = useI18n();
+    return { v$: useVuelidate(), t };
+  },
 
   data() {
     return {
@@ -321,7 +325,7 @@ export default {
           if (typeof error.response.data === 'object') {
             form.errors = _.flatten(_.toArray(error.response.data));
           } else {
-            form.errors = [this.$t('app.error_try_again')];
+            form.errors = [this.t('app.error_try_again')];
           }
         });
     },
@@ -376,7 +380,7 @@ export default {
     copyIntoClipboard(text) {
       navigator.clipboard.writeText(text)
         .then(() => {
-          this.notify(this.$t('settings.dav_clipboard_copied'), true);
+          this.notify(this.t('settings.dav_clipboard_copied'), true);
         })
         .catch(() => { /* silent on permission denial / non-secure context */ });
     },

--- a/resources/js/components/passport/PersonalAccessTokens.vue
+++ b/resources/js/components/passport/PersonalAccessTokens.vue
@@ -140,6 +140,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import FormErrors from '../partials/FormErrors.vue';
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
@@ -150,7 +151,10 @@ export default {
     FormErrors,
   },
 
-  setup: () => ({ v$: useVuelidate() }),
+  setup() {
+    const { t } = useI18n();
+    return { v$: useVuelidate(), t };
+  },
 
   data() {
     return {
@@ -271,7 +275,7 @@ export default {
           if (typeof error.response.data === 'object') {
             this.form.errors = _.flatten(_.toArray(error.response.data));
           } else {
-            this.form.errors = [this.$t('app.error_try_again')];
+            this.form.errors = [this.t('app.error_try_again')];
           }
         });
     },
@@ -321,7 +325,7 @@ export default {
     copyIntoClipboard(text) {
       navigator.clipboard.writeText(text)
         .then(() => {
-          this.notify(this.$t('settings.dav_clipboard_copied'), true);
+          this.notify(this.t('settings.dav_clipboard_copied'), true);
         })
         .catch(() => { /* silent on permission denial / non-secure context */ });
     },

--- a/resources/js/components/settings/ActivityTypes.vue
+++ b/resources/js/components/settings/ActivityTypes.vue
@@ -246,6 +246,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
@@ -256,6 +258,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -352,7 +359,7 @@ export default {
           this.activityTypeCategories.push(response.data.data);
           this.createCategoryForm.name = '';
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -407,7 +414,7 @@ export default {
           this.updatedCategory.name = this.updateCategoryForm.name;
           this.updateCategoryForm.name = '';
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -424,7 +431,7 @@ export default {
           this.createTypeForm.name = '';
           this.getActivityTypeCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -435,7 +442,7 @@ export default {
           this.destroyCategoryForm.id = '';
           this.getActivityTypeCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         })
         .catch(error => {
           this.errorMessage = error.response.data.message;
@@ -450,7 +457,7 @@ export default {
           this.updateTypeForm.name = '';
           this.getActivityTypeCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -461,7 +468,7 @@ export default {
           this.destroyTypeForm.id = '';
           this.getActivityTypeCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         })
         .catch(error => {
           this.errorMessage = error.response.data.message;

--- a/resources/js/components/settings/ContactFieldTypes.vue
+++ b/resources/js/components/settings/ContactFieldTypes.vue
@@ -215,12 +215,18 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import FormErrors from '../partials/FormErrors.vue';
 
 export default {
 
   components: {
     FormErrors,
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -291,7 +297,7 @@ export default {
 
       this.$notify({
         group: 'main',
-        title: this.$t('settings.personalization_contact_field_type_add_success'),
+        title: this.t('settings.personalization_contact_field_type_add_success'),
         text: '',
         width: '500px',
         type: 'success'
@@ -315,7 +321,7 @@ export default {
 
       this.$notify({
         group: 'main',
-        title: this.$t('settings.personalization_contact_field_type_edit_success'),
+        title: this.t('settings.personalization_contact_field_type_edit_success'),
         text: '',
         width: '500px',
         type: 'success'
@@ -336,7 +342,7 @@ export default {
 
       this.$notify({
         group: 'main',
-        title: this.$t('settings.personalization_contact_field_type_delete_success'),
+        title: this.t('settings.personalization_contact_field_type_delete_success'),
         text: '',
         width: '500px',
         type: 'success'
@@ -364,7 +370,7 @@ export default {
           if (typeof error.response.data === 'object') {
             form.errors = _.flatten(_.toArray(error.response.data));
           } else {
-            form.errors = [this.$t('app.error_try_again')];
+            form.errors = [this.t('app.error_try_again')];
           }
         });
     },

--- a/resources/js/components/settings/DAVResources.vue
+++ b/resources/js/components/settings/DAVResources.vue
@@ -85,6 +85,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -106,12 +108,17 @@ export default {
     },
   },
 
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
+
   methods: {
 
     copyIntoClipboard(text) {
       navigator.clipboard.writeText(text)
         .then(() => {
-          this.notify(this.$t('settings.dav_clipboard_copied'), true);
+          this.notify(this.t('settings.dav_clipboard_copied'), true);
         })
         .catch(() => { /* silent on permission denial / non-secure context */ });
     },

--- a/resources/js/components/settings/Genders.vue
+++ b/resources/js/components/settings/Genders.vue
@@ -244,9 +244,16 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -300,8 +307,8 @@ export default {
 
     toggleOptions() {
       return {
-        checked: this.$t('app.yes'),
-        unchecked: this.$t('app.no')
+        checked: this.t('app.yes'),
+        unchecked: this.t('app.no')
       };
     },
 
@@ -427,7 +434,7 @@ export default {
           if (typeof error.response.data === 'object') {
             this.errorMessage = error.response.data.message;
           } else {
-            this.errorMessage = this.$t('app.error_try_again');
+            this.errorMessage = this.t('app.error_try_again');
           }
         });
     },

--- a/resources/js/components/settings/LifeEventTypes.vue
+++ b/resources/js/components/settings/LifeEventTypes.vue
@@ -158,6 +158,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
@@ -168,6 +170,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -233,7 +240,7 @@ export default {
 
     showEditType(type, categoryId) {
       this.updateTypeForm.id = type.id;
-      this.updateTypeForm.name = type.name ? type.name : this.$t('people.life_event_sentence_' + type.default_life_event_type_key);
+      this.updateTypeForm.name = type.name ? type.name : this.t('people.life_event_sentence_' + type.default_life_event_type_key);
       this.updateTypeForm.life_event_category_id = categoryId;
 
       this.showUpdateTypeModal = true;
@@ -258,7 +265,7 @@ export default {
           this.createTypeForm.name = '';
           this.getLifeEventCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -269,7 +276,7 @@ export default {
           this.updateTypeForm.name = '';
           this.getLifeEventCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         });
     },
 
@@ -280,7 +287,7 @@ export default {
           this.destroyTypeForm.id = '';
           this.getLifeEventCategories();
 
-          this.notify(this.$t('app.default_save_success'), true);
+          this.notify(this.t('app.default_save_success'), true);
         })
         .catch(error => {
           this.errorMessage = error.response.data.message;

--- a/resources/js/components/settings/MfaActivate.vue
+++ b/resources/js/components/settings/MfaActivate.vue
@@ -80,6 +80,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
@@ -90,6 +92,11 @@ export default {
       type: Boolean,
       default: false
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -123,9 +130,9 @@ export default {
           this.closeEnableModal();
           this.selectActivated = response.data.success;
           if (response.data.success) {
-            this.notify(this.$t('settings.2fa_enable_success'), true);
+            this.notify(this.t('settings.2fa_enable_success'), true);
           } else {
-            this.notify(this.$t('settings.2fa_enable_error'), false);
+            this.notify(this.t('settings.2fa_enable_error'), false);
           }
         }).catch(error => {
           this.closeEnableModal();
@@ -139,9 +146,9 @@ export default {
           this.closeDisableModal();
           this.selectActivated = ! response.data.success;
           if (response.data.success) {
-            this.notify(this.$t('settings.2fa_disable_success'), true);
+            this.notify(this.t('settings.2fa_disable_success'), true);
           } else {
-            this.notify(this.$t('settings.2fa_disable_error'), false);
+            this.notify(this.t('settings.2fa_disable_error'), false);
           }
         }).catch(error => {
           this.closeDisableModal();

--- a/resources/js/components/settings/Modules.vue
+++ b/resources/js/components/settings/Modules.vue
@@ -59,6 +59,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -66,6 +68,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -97,7 +104,7 @@ export default {
         .then(response => {
           this.$notify({
             group: 'main',
-            title: this.$t('settings.personalization_module_save'),
+            title: this.t('settings.personalization_module_save'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/settings/RecoveryCodes.vue
+++ b/resources/js/components/settings/RecoveryCodes.vue
@@ -53,9 +53,16 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   components: {
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -70,10 +77,10 @@ export default {
       return this.$root.htmldir === 'ltr';
     },
     usedHelp() {
-      return this.$t('settings.recovery_already_used_help');
+      return this.t('settings.recovery_already_used_help');
     },
     copyHelp() {
-      return this.$t('settings.recovery_copy_help');
+      return this.t('settings.recovery_copy_help');
     },
   },
 
@@ -106,13 +113,13 @@ export default {
     copyIntoClipboard() {
       navigator.clipboard.writeText(this.getDataStream())
         .then(() => {
-          this.notify(this.$t('settings.recovery_clipboard'), true);
+          this.notify(this.t('settings.recovery_clipboard'), true);
         })
         .catch(() => { /* silent on permission denial / non-secure context */ });
     },
 
     getDataStream() {
-      var text = this.$t('settings.recovery_help_intro')+'\n';
+      var text = this.t('settings.recovery_help_intro')+'\n';
       var i = 1;
       this.codes.forEach(code => {
         if (code.used) {

--- a/resources/js/components/settings/ReminderRules.vue
+++ b/resources/js/components/settings/ReminderRules.vue
@@ -45,7 +45,14 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
+  },
 
   data() {
     return {
@@ -80,7 +87,7 @@ export default {
         .then(response => {
           this.$notify({
             group: 'main',
-            title: this.$t('settings.personalization_reminder_rule_save'),
+            title: this.t('settings.personalization_reminder_rule_save'),
             text: '',
             type: 'success'
           });

--- a/resources/js/components/settings/ReminderTime.vue
+++ b/resources/js/components/settings/ReminderTime.vue
@@ -30,6 +30,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment-timezone';
 
 export default {
@@ -57,6 +58,11 @@ export default {
     }
   },
 
+  setup() {
+    const { t, locale } = useI18n();
+    return { t, locale };
+  },
+
   data() {
     return {
       message: '',
@@ -77,7 +83,7 @@ export default {
     },
 
     computeMessage() {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
       moment.tz.setDefault('UTC');
 
       var now = moment();
@@ -89,7 +95,7 @@ export default {
         date = date.add(1, 'days');
       }
 
-      this.message = this.$t('settings.reminder_time_to_send_help', {
+      this.message = this.t('settings.reminder_time_to_send_help', {
         dateTime: date.format('LLL'),
         dateTimeUtc: date.utc().format('YYYY-MM-DD HH:mm z')
       });

--- a/resources/js/components/settings/Subscription.vue
+++ b/resources/js/components/settings/Subscription.vue
@@ -82,6 +82,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
 
   props: {
@@ -125,6 +127,11 @@ export default {
       type: Boolean,
       default: false,
     },
+  },
+
+  setup() {
+    const { t } = useI18n();
+    return { t };
   },
 
   data() {
@@ -205,7 +212,7 @@ export default {
     handleError(error) {
       if (error.code === 'parameter_invalid_empty' &&
             error.param === 'payment_method_data[billing_details][name]') {
-        this.errors = this.$t('settings.subscriptions_payment_error_name');
+        this.errors = this.t('settings.subscriptions_payment_error_name');
       } else {
         this.errors = error.message;
       }

--- a/resources/js/components/settings/WebauthnConnector.vue
+++ b/resources/js/components/settings/WebauthnConnector.vue
@@ -171,6 +171,7 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
 import moment from 'moment-timezone';
 import { startRegistration, startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
 
@@ -204,6 +205,11 @@ export default {
     },
   },
 
+  setup() {
+    const { t, locale } = useI18n();
+    return { t, locale };
+  },
+
   data() {
     return {
       isSupported: true,
@@ -233,9 +239,9 @@ export default {
     _errorMessage(name, message) {
       switch (name) {
       case 'InvalidStateError':
-        return this.$t('settings.webauthn_error_already_used');
+        return this.t('settings.webauthn_error_already_used');
       case 'NotAllowedError':
-        return this.$t('settings.webauthn_error_not_allowed');
+        return this.t('settings.webauthn_error_not_allowed');
       default:
         return message;
       }
@@ -243,9 +249,9 @@ export default {
 
     notSupportedMessage() {
       if (! window.isSecureContext && window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
-        return this.$t('settings.webauthn_not_secured');
+        return this.t('settings.webauthn_not_secured');
       }
-      return this.$t('settings.webauthn_not_supported');
+      return this.t('settings.webauthn_not_supported');
     },
 
     start() {
@@ -311,7 +317,7 @@ export default {
           name: this.keyName,
         });
         this.success = true;
-        this.notify(this.$t('settings.webauthn_success'), true);
+        this.notify(this.t('settings.webauthn_success'), true);
         this.currentkeys.push({
           id: response.data.result.id,
           name: response.data.result.name,
@@ -337,7 +343,7 @@ export default {
       try {
         const response = await axios.post('webauthn/auth', { ...assertionResp });
         this.success = true;
-        this.notify(this.$t('settings.webauthn_success'), true);
+        this.notify(this.t('settings.webauthn_success'), true);
         window.location = response.data.callback;
       } catch (error) {
         this.errorMessage = error.message ? error.message : error.response.data.message;
@@ -367,7 +373,7 @@ export default {
     },
 
     formatTime(value) {
-      moment.locale(this.$i18n.locale);
+      moment.locale(this.locale);
       moment.tz.setDefault('UTC');
 
       var t = moment(value);


### PR DESCRIPTION
## Summary

Finishes the per-component vue-i18n composition-mode migration from
[#755](https://github.com/brycehans/monica/pull/755) (validation) and
[#756](https://github.com/brycehans/monica/pull/756) (people/). This
batch covers the last three aggregates still carrying `this.$t` /
`this.$i18n`: **settings/, partials/, passport/** — **17 files, 48
callsites** (46 `this.$t` + 2 `this.$i18n.locale`).

| File | `$t` | `$i18n.locale` |
| --- | ---: | ---: |
| `settings/ActivityTypes.vue` | 6 | 0 |
| `settings/ContactFieldTypes.vue` | 4 | 0 |
| `settings/DAVResources.vue` | 1 | 0 |
| `settings/Genders.vue` | 3 | 0 |
| `settings/LifeEventTypes.vue` | 4 | 0 |
| `settings/MfaActivate.vue` | 4 | 0 |
| `settings/Modules.vue` | 1 | 0 |
| `settings/RecoveryCodes.vue` | 4 | 0 |
| `settings/ReminderRules.vue` | 1 | 0 |
| `settings/ReminderTime.vue` | 1 | 1 |
| `settings/Subscription.vue` | 1 | 0 |
| `settings/WebauthnConnector.vue` | 6 | 1 |
| `partials/form/Date.vue` | 2 | 0 |
| `partials/form/Input.vue` | 3 | 0 |
| `partials/form/Select.vue` | 1 | 0 |
| `passport/Clients.vue` | 2 | 0 |
| `passport/PersonalAccessTokens.vue` | 2 | 0 |

Pattern is identical to #755/#756. Two `setup()` extension shapes worth
calling out:

- **`partials/form/Input.vue` and `Select.vue`** already had
  `setup() { return { uid: getCurrentInstance().uid }; }` for stable
  per-instance label/input id binding. Expanded to also expose `t` so
  the validation-message computed-getters can resolve translation keys
  without `this.$t`.
- **`passport/Clients.vue` and `PersonalAccessTokens.vue`** had
  `setup: () => ({ v$: useVuelidate() })` arrow-form; rewritten to a
  function body returning `{ v$, t }`, matching the StayInTouch/CreateGift
  pattern from earlier batches.

**Coverage exercised by smoke:**
- `WebauthnConnector.vue` — webauthn registration smoke covers the
  success-toast `.then()` arm.
- `MfaActivate.vue` — `pr-t3 vue-notification error guard` (smoke:1342)
  asserts on the localized text of the wrong-OTP error toast.
- `DAVResources.vue` — `pr-1a guard` (smoke:890) asserts on the
  localized `dav_clipboard_copied` toast text.
- `ReminderRules.vue` — `pr-t3 $tc plural rewrite guard` (smoke:1385).

**Exit gate cleared:** after this PR + #755 + #756, the grep gate

```
grep -rE "this\.\$t[c]?\(|vm\.\$t[c]?\(|this\.\$i18n" resources/js
```

returns zero across `resources/js`. The remaining Phase 2 step is the
config flip in `resources/js/common.js`: drop `globalInjection: true`
once these three PRs land. That's a single-line config change and a
follow-up PR.

## Test plan

- [x] `yarn run lint` — 0 errors, 142 warnings (same baseline as #755/#756).
- [x] `yarn run prod` — built in 3.99s.
- [x] `tests/playwright`: **65/65** — 42/42 dependency-upgrade-smoke +
      23/23 across all 17 feature specs.
- [x] `vendor/bin/phpstan analyse` — 0 errors / 481 files (no PHP touched).

Every playwright spec runs under the `consoleGate` fixture, so any
ReferenceError from a broken setup() destructure, vue-i18n "Not found"
warning, or pageerror would have failed the spec — none did.

Refs #744. Independent of #755 and #756 (separate file sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
