### PR TITLE
test(playwright): backfill #731 tier A mailhog-coupled coverage (A.1, A.2)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -5,7 +5,7 @@ APP_KEY=ChangeMeBy32KeyLengthOrGenerated
 HASH_SALT=ChangeMeBy20+KeyLength
 HASH_LENGTH=18
 
-APP_URL=http://localhost
+APP_URL=http://localhost:8082
 
 DB_CONNECTION=mysql
 DB_HOST=mysql

--- a/docs/superpowers/specs/2026-06-04-731-tier-a-mailhog-design.md
+++ b/docs/superpowers/specs/2026-06-04-731-tier-a-mailhog-design.md
@@ -1,0 +1,133 @@
+# Playwright e2e coverage backfill: Tier A Mailhog-coupled subset
+
+- Issue: [#731](https://github.com/brycehans/monica/issues/731) (umbrella)
+- Predecessor PR: [#739](https://github.com/brycehans/monica/pull/739) — Tier A in-app subset (A.3–A.6)
+- Date: 2026-06-04
+- Status: design accepted
+
+## Problem
+
+#731's Tier A has six items. PR #739 shipped the four in-app ones (A.3 audit log, A.4 export, A.5 import, A.6 reminder persistence) and explicitly deferred the two Mailhog-coupled flows:
+
+- **A.1 — Password reset.** Visit `/password/reset`, submit an email, retrieve the reset token from the email, set a new password, log in with it.
+- **A.2 — Email verification.** Trigger a verification email, click the signed URL, assert the user lands on `/dashboard` as a verified account.
+
+Both flows depend on reading email content from the dev compose's Mailhog service (`localhost:8025`). The predecessor PR deferred them so the Mailhog support module could be designed against settled spec idioms.
+
+## Goal
+
+Add the missing two specs and the shared `tests/playwright/support/mailhog.ts` helper, lifting #731's Tier A acceptance from 4/6 to 6/6.
+
+## Non-goals
+
+- **Bulk-clearing Mailhog's inbox before each test.** Filtering by recipient (each fresh user has a faker-generated unique email) disambiguates without coupling specs to a shared global state.
+- **Tier B / C / D from #731.** Out of scope; this PR closes Tier A only.
+- **Mailtrap or other external mail providers.** Helper targets Mailhog HTTP API exclusively; production mail backends use SMTP/SES/Mailgun and are out of scope for e2e.
+- **CSRF / signed-URL expiry edge cases.** The acceptance contract is "click the link Monica sent → it works." Expiry handling is a separate spec if anyone wants it.
+
+## Approach
+
+### Mailhog helper shape
+
+New module: `tests/playwright/support/mailhog.ts`. One exported function plus URL extraction helper.
+
+```typescript
+export async function waitForEmailTo(
+  recipient: string,
+  opts?: { timeoutMs?: number; since?: Date }
+): Promise<MailhogMessage>;
+
+export function extractUrl(message: MailhogMessage, pattern: RegExp): string;
+```
+
+`waitForEmailTo` polls `http://localhost:8025/api/v2/messages?limit=100` every 250ms up to `timeoutMs` (default 5000), filtering by `To[].Mailbox + '@' + To[].Domain === recipient`. Returns the most recent match. Throws on timeout with a message listing the recipients seen, to make flake diagnosis easy.
+
+`extractUrl` decodes the message body (multipart quoted-printable, `=\r\n` soft-wrap unwrap, `=XX` hex decode), then runs `pattern.exec()` and returns the first capture group. Pattern is supplied by the caller so the helper stays generic across reset/verify/etc.
+
+Host is configurable via `PW_MAILHOG_URL` (default `http://localhost:8025`).
+
+No clear-inbox method exposed; recipient filtering is sufficient and avoids cross-spec coupling.
+
+### A.1 password reset spec
+
+`tests/playwright/specs/password-reset.spec.ts`:
+
+1. Mint a fresh user via `loginAsFreshUser(page)` — but we want a *logged-out* user, so use the existing artisan call directly. Add `createFreshUser()` to `auth.ts` that returns `{ userId, accountId, email }` without driving `/_dusk/login`. (Reuses 90% of `loginAsFreshUser`'s body; emails come back via the same lastLine tinker idiom.)
+2. `page.goto('/password/reset')`.
+3. Fill the email field with the user's email. Click "Send Password Reset Link" (or whatever the button name resolves to — verify during writing).
+4. Assert visible success flash on the page.
+5. `await waitForEmailTo(email)`. Extract the URL matching `/password/reset/[^\s)"]+/`.
+6. `page.goto(resetUrl)`. Fill new password, confirmation, submit.
+7. Assert redirect to `/dashboard` (Laravel's `ResetsPasswords` auto-logs-in on success).
+8. `consoleGate.assertNoUnknownErrors('/password/reset')`.
+
+### A.2 email verification spec
+
+The dev rig's `monica.signup_double_optin` defaults to `false`, which makes `User::sendEmailVerificationNotification()` a no-op and `RegisterController::registered()` auto-verify. The `/email/resend` route still goes through that gated notification method, so flipping `signup_double_optin=true` would be needed to drive the full register-then-resend flow.
+
+Globally flipping `signup_double_optin` in `.env.dev` would break `signup-duplicate-email.spec.ts` (which asserts post-registration redirect to `/dashboard` — the `verified` middleware would bounce that to `/email/verify` once the auto-verify is gated). The cleanest path that keeps every existing spec passing is to **simulate the unverified state in-test**:
+
+`tests/playwright/specs/email-verification.spec.ts`:
+
+1. Mint a fresh user via `loginAsFreshUser(page)` — gives `{ userId, accountId, email }` and an active session.
+2. Run a tinker one-liner that:
+   - Sets `email_verified_at = null` on the user.
+   - Calls `$user->notify(new \Illuminate\Auth\Notifications\VerifyEmail())` (mirrors what `App\Jobs\SendVerifyEmail` does, bypassing the `signup_double_optin` gate).
+3. `await waitForEmailTo(email)`. Extract the signed verification URL matching `/email/verify/\d+/[a-f0-9]+\?expires=\d+&signature=[a-f0-9]+/`.
+4. `page.goto(verifyUrl)`. The `verified` middleware on `/dashboard` requires a logged-in session, which we already have from step 1.
+5. Assert redirect to `/dashboard` and that the user's `email_verified_at` is now populated (via a follow-up tinker query, or — simpler — via the absence of the verification gate page).
+6. `consoleGate.assertNoUnknownErrors('/email/verify/...')`.
+
+The trade-off: we test the verification *handler* end-to-end (signed URL, hash match, redirect, DB flag flip), but not the registration→notification dispatch chain. The dispatch chain is gated by a single config flag and is exercised by Laravel's own framework tests; the high-blast-radius failure mode (broken verify URL handler — bricks new signups when `signup_double_optin=true`) is covered.
+
+### Auth helper extension
+
+`tests/playwright/support/auth.ts` gains one new exported function:
+
+```typescript
+export async function createFreshUser(): Promise<FreshUser & { email: string }>;
+```
+
+Same body as `loginAsFreshUser` minus the `/_dusk/login` call, plus an extra tinker shellout to fetch the user's email. Used by A.1.
+
+`loginAsFreshUser` itself extends its return type to include `email`; existing callers ignore it (TS structural typing).
+
+### Spec-layer pattern (same as #739)
+
+Both new specs:
+
+- Import `test` / `expect` from `../support/console-gate`.
+- Use `loginAsFreshUser` (A.2) or the new `createFreshUser` (A.1).
+- Select by ARIA role / visible text / form label. No `.monica-modal__panel`, `.dp__*`, `.multiselect-*`, `.vgt-*`.
+- Call `consoleGate.assertNoUnknownErrors(label)` at the end.
+
+### Execution order on the branch
+
+1. **`mailhog.ts` helper.** Standalone module, no spec deps. Validates the polling + decode + extraction shape.
+2. **`auth.ts` extension** (`createFreshUser`, email in `FreshUser`).
+3. **A.1 password reset.** Exercises the helper against Laravel's stock password-reset email.
+4. **A.2 email verification.** Exercises the helper against Monica's verification notification + the in-test unverify trick.
+5. **README + comment on #731.**
+
+### Acceptance
+
+- Two new specs added; both green locally via the dev compose rig (`docker compose -f docker-compose.dev.yml up`, `yarn run prod`, `cd tests/playwright && npx playwright test specs/password-reset.spec.ts specs/email-verification.spec.ts`).
+- `tests/playwright/support/mailhog.ts` added and unit-clean (no spec imports it transitively unless it's listed in this PR).
+- All existing specs still pass on a fresh `tests/playwright` run.
+- `tests/playwright/README.md`'s feature-spec list extended with one bullet per new spec.
+- Umbrella issue #731's Tier A acceptance ticks A.1 and A.2 in a PR comment.
+
+## Risks
+
+- **Mailhog API rate / pagination.** With `limit=100` and recipient filtering, the dev rig's accumulated message count (~9 today, much more after a long session) sits well inside one page. If a long-running session pushes past 100, switch to `start=N` paging — but this is a future concern, not a launch blocker.
+- **Quoted-printable decoding edge cases.** Laravel's reset email is a multipart message; the plain-text leg is the one we want to parse. If the URL straddles a `=\r\n` soft-wrap boundary, the decode has to be done before regex matching, not after. Spec test: write a fixture-based decode unit smoke (or skip this and rely on the integration spec; the dev rig's actual email is the only fixture we care about).
+- **Signed-URL session coupling for A.2.** The `verified` middleware redirects to `/dashboard` only when the user is logged in. We log in via `loginAsFreshUser` *before* clearing `email_verified_at`. The session cookie persists; the verified middleware on `/dashboard` is the only gate. Verify by writing the spec and observing — if the verify-URL handler logs the user out, we'll need an extra login step after step 4.
+- **Stale Mailhog messages from prior runs.** Recipient is unique per `setup:frontendtestuser` run (faker email). Even with multi-day stale messages in the inbox, the filter resolves to the new user's email. The `since` option in `waitForEmailTo` is a defensive belt-and-braces if a deterministic-email regression ever happens.
+- **Tinker-dispatched notification timing.** `QUEUE_CONNECTION=sync` in `.env.dev` (already confirmed in #739's spec) means `$user->notify(...)` blocks until the SMTP send completes. No worker fixture needed.
+
+## Out-of-scope follow-ups
+
+- **Restore the register→verify chain in a future spec.** Requires either a dev-compose env-flip mode or a per-spec config override mechanism. File only if appetite emerges.
+- **Mailhog inbox cleanup hook.** Not needed today; useful if specs ever start cross-matching on subject or sender domain.
+- **CSV import path** (carryover from #739).
+- **Tier B/C/D** of #731.

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -20,6 +20,8 @@ Standalone Playwright suite for verifying the user-facing app. Two distinct sets
    - `audit-log.spec.ts` — contact-create surfaces in `/settings/auditlogs` (#731 A.3)
    - `account-export.spec.ts` — JSON + SQL export submit, complete, and download with the right filename (#731 A.4)
    - `account-import-vcard.spec.ts` — vCard upload lands an imported contact on `/people` (#731 A.5)
+   - `password-reset.spec.ts` — Mailhog-delivered reset token round-trips through `/password/reset` (#731 A.1)
+   - `email-verification.spec.ts` — Mailhog-delivered signed verify URL marks the account verified (#731 A.2)
 
 ## Why it's a separate suite
 

--- a/tests/playwright/specs/email-verification.spec.ts
+++ b/tests/playwright/specs/email-verification.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Email verification flow (#731 Tier A.2).
+ *
+ * Exercises the signed-URL verify handler on /email/verify/{id}/{hash}.
+ * Drives a fresh user into the "unverified" state in-test, dispatches the
+ * VerifyEmail notification, fetches the signed URL from Mailhog, navigates
+ * to it, and asserts the user lands on /dashboard with email_verified_at
+ * populated.
+ *
+ * The dev rig's monica.signup_double_optin defaults to false, so the real
+ * register → notification chain is short-circuited (RegisterController
+ * auto-marks the user verified). Flipping that config globally would break
+ * signup-duplicate-email.spec.ts and any other spec asserting post-register
+ * redirect to /dashboard. We therefore simulate the unverified state on a
+ * fresh user and dispatch the notification directly via tinker — the
+ * verify-URL handler is what's under test, and the dispatch chain is
+ * gated by a single config flag covered by Laravel's framework tests.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { artisan } from '../support/artisan';
+import { waitForEmailTo, extractUrl, urlPathOnly } from '../support/mailhog';
+
+test.describe('Monica v4 — email verification', () => {
+  test('signed verification URL marks the account verified and lands on dashboard', async ({ page, consoleGate }) => {
+    const beforeRequest = new Date();
+    const user = await loginAsFreshUser(page);
+
+    // Drop the verified flag, then send the VerifyEmail notification
+    // directly so the dispatch is independent of monica.signup_double_optin.
+    artisan(
+      'tinker',
+      '--execute',
+      `$u = App\\Models\\User\\User::find(${user.userId}); ` +
+        `$u->forceFill(['email_verified_at' => null])->save(); ` +
+        `$u->notify(new Illuminate\\Auth\\Notifications\\VerifyEmail());`,
+    );
+
+    const message = await waitForEmailTo(user.email, { since: beforeRequest, timeoutMs: 10000 });
+    const verifyUrl = urlPathOnly(extractUrl(
+      message,
+      /(https?:\/\/[^\s)"'<>]+\/email\/verify\/\d+\/[^\s)"'<>]+)/,
+    ));
+
+    await page.goto(verifyUrl);
+
+    // The signed URL handler redirects to VerificationController::$redirectTo
+    // ('/dashboard'). The session from loginAsFreshUser is still active, so
+    // the verified middleware now lets us through.
+    await page.waitForURL('**/dashboard');
+
+    // Confirm the DB flag flipped — guards against a regression that
+    // 302s to /dashboard but doesn't actually persist the verification.
+    const verifiedAt = artisan(
+      'tinker',
+      '--execute',
+      `echo App\\Models\\User\\User::find(${user.userId})->email_verified_at;`,
+    )
+      .trim()
+      .split(/\r?\n/)
+      .pop()!
+      .trim();
+    expect(verifiedAt).not.toBe('');
+
+    consoleGate.assertNoUnknownErrors('/email/verify/{id}/{hash}');
+  });
+});

--- a/tests/playwright/specs/password-reset.spec.ts
+++ b/tests/playwright/specs/password-reset.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Password reset flow (#731 Tier A.1).
+ *
+ * Visit /password/reset as a logged-out user, submit the registered email,
+ * follow the Mailhog-delivered reset token URL, set a new password, and
+ * confirm the new credentials log in successfully.
+ *
+ * The flow exercises Laravel's stock SendsPasswordResetEmails +
+ * ResetsPasswords traits behind Monica's ForgotPasswordController and
+ * ResetPasswordController — a regression here silently breaks every
+ * self-hoster's "I lost my password" recovery path.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { createFreshUser } from '../support/auth';
+import { waitForEmailTo, extractUrl, urlPathOnly } from '../support/mailhog';
+
+test.describe('Monica v4 — password reset', () => {
+  test('forgot-password email delivers a working reset URL', async ({ page, consoleGate }) => {
+    const beforeRequest = new Date();
+    const user = await createFreshUser();
+    const newPassword = 'NewPassword!2026';
+
+    await page.goto('/password/reset');
+    await page.getByLabel('E-Mail Address').fill(user.email);
+    await page.getByRole('button', { name: 'Send Password Reset Link' }).click();
+
+    // Laravel surfaces the post-submit confirmation via session('status'),
+    // rendered into an .alert-success block on the same view.
+    await expect(page.locator('body')).toContainText(
+      /password reset link|we have emailed/i,
+    );
+
+    const message = await waitForEmailTo(user.email, { since: beforeRequest, timeoutMs: 10000 });
+    const resetUrl = urlPathOnly(extractUrl(
+      message,
+      /(https?:\/\/[^\s)"'<>]+\/password\/reset\/[^\s)"'<>]+)/,
+    ));
+
+    await page.goto(resetUrl);
+    // The view pre-fills the email from the URL's `email` query param; assert
+    // it before typing the password so a routing regression surfaces here
+    // rather than later as "credentials rejected".
+    await expect(page.getByLabel('E-Mail Address')).toHaveValue(user.email);
+    await page.getByLabel('Password', { exact: true }).fill(newPassword);
+    await page.getByLabel('Confirm Password').fill(newPassword);
+    await page.getByRole('button', { name: 'Reset Password' }).click();
+
+    // ResetsPasswords::sendResetResponse auto-logs the user in and redirects
+    // to the configured home — Monica's RouteServiceProvider::HOME is
+    // /dashboard.
+    await page.waitForURL('**/dashboard');
+
+    // Belt-and-braces: log out, log back in with the new password, prove the
+    // credential was persisted (not just the active session).
+    await page.goto('/logout');
+    await page.goto('/login');
+    await page.getByRole('textbox', { name: 'Email' }).fill(user.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(newPassword);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL('**/dashboard');
+
+    consoleGate.assertNoUnknownErrors('/password/reset → reset → login');
+  });
+});

--- a/tests/playwright/support/auth.ts
+++ b/tests/playwright/support/auth.ts
@@ -39,26 +39,40 @@ export async function loginAsAdmin(page: Page): Promise<void> {
   await page.waitForURL('**/dashboard');
 }
 
-export type FreshUser = { userId: string; accountId: string };
+export type FreshUser = { userId: string; accountId: string; email: string };
 
 export async function loginAsFreshUser(page: Page): Promise<FreshUser> {
+  const user = await createFreshUser();
+  // /_dusk/login returns 200 with an empty body. Use page.request rather
+  // than page.goto so the empty / non-HTML response doesn't trip navigation;
+  // cookies still persist into the page context.
+  const response = await page.request.get(`/_dusk/login/${user.userId}`);
+  if (!response.ok()) {
+    throw new Error(`/_dusk/login/${user.userId} returned ${response.status()}`);
+  }
+  return user;
+}
+
+/**
+ * Mint a fresh user without driving the Dusk login bridge. Used by specs
+ * that need to act as a logged-out visitor (e.g. password reset).
+ */
+export async function createFreshUser(): Promise<FreshUser> {
   // PHP versions with display_errors=on interleave deprecation warnings with
   // the command's stdout; the user id is always the last non-empty line. See
   // #592 for the cypress equivalent that taught us this.
   const userId = lastLine(artisan('setup:frontendtestuser'));
-  // /_dusk/login returns 200 with an empty body. Use page.request rather
-  // than page.goto so the empty / non-HTML response doesn't trip navigation;
-  // cookies still persist into the page context.
-  const response = await page.request.get(`/_dusk/login/${userId}`);
-  if (!response.ok()) {
-    throw new Error(`/_dusk/login/${userId} returned ${response.status()}`);
-  }
-  // Look up the user's account_id so callers that need to setPremium on the
-  // isolated account can target it without falling back to admin.
-  const accountId = lastLine(
-    artisan('tinker', '--execute', `echo App\\Models\\User\\User::find(${userId})->account_id;`),
+  // Look up account_id + email so callers can target the isolated account
+  // and address it in flows that route through email (reset, verify, etc.).
+  const out = lastLine(
+    artisan(
+      'tinker',
+      '--execute',
+      `$u = App\\Models\\User\\User::find(${userId}); echo $u->account_id . '|' . $u->email;`,
+    ),
   );
-  return { userId, accountId };
+  const [accountId, email] = out.split('|');
+  return { userId, accountId, email };
 }
 
 function lastLine(stdout: string): string {

--- a/tests/playwright/support/mailhog.ts
+++ b/tests/playwright/support/mailhog.ts
@@ -1,0 +1,143 @@
+/**
+ * Mailhog HTTP API helper.
+ *
+ * The dev compose stack ships a Mailhog container at host:port 8025 (mapped
+ * from container :8025). All outgoing mail from the dev app lands in its
+ * inbox and is queryable via /api/v2/messages.
+ *
+ * Pattern:
+ *
+ *   import { waitForEmailTo, extractUrl } from '../support/mailhog';
+ *
+ *   const message = await waitForEmailTo('alice@example.org');
+ *   const resetUrl = extractUrl(message, /(https?:\/\/[^\s)"']+\/password\/reset\/[^\s)"']+)/);
+ *   await page.goto(resetUrl);
+ *
+ * Filters by recipient. Mailhog accumulates messages across dev sessions;
+ * recipient-based matching is sufficient because `setup:frontendtestuser`
+ * mints faker-generated emails per call (unique across runs).
+ *
+ * The body decoder handles RFC 2045 quoted-printable: strips soft line
+ * breaks (`=\r\n` and `=\n`) and decodes `=XX` hex escapes. Laravel's mail
+ * pipeline emits multipart/alternative with a text/plain leg first; the
+ * decoded body therefore contains the raw URL we want.
+ *
+ * Override `PW_MAILHOG_URL` to point at a non-default host (defaults to
+ * http://localhost:8025).
+ */
+const MAILHOG_URL = process.env.PW_MAILHOG_URL ?? 'http://localhost:8025';
+const DEFAULT_TIMEOUT_MS = 5000;
+const POLL_INTERVAL_MS = 250;
+
+export type MailhogAddress = {
+  Mailbox: string;
+  Domain: string;
+};
+
+export type MailhogMessage = {
+  ID: string;
+  From: MailhogAddress;
+  To: MailhogAddress[];
+  Content: {
+    Headers: Record<string, string[]>;
+    Body: string;
+  };
+  Created?: string;
+};
+
+type MailhogListResponse = {
+  total: number;
+  count: number;
+  start: number;
+  items: MailhogMessage[];
+};
+
+/**
+ * Polls Mailhog until a message addressed to `recipient` is found. Returns
+ * the most-recent match. Throws with the list of recipients seen on the last
+ * poll cycle if the timeout fires — makes flake diagnosis fast.
+ *
+ * `since` (optional) discards any message whose Created timestamp predates
+ * it; useful when a recipient email could be reused across tests.
+ */
+export async function waitForEmailTo(
+  recipient: string,
+  opts?: { timeoutMs?: number; since?: Date },
+): Promise<MailhogMessage> {
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const since = opts?.since;
+  const deadline = Date.now() + timeoutMs;
+  const target = recipient.toLowerCase();
+
+  let lastRecipients: string[] = [];
+
+  while (Date.now() < deadline) {
+    const response = await fetch(`${MAILHOG_URL}/api/v2/messages?limit=100`);
+    if (!response.ok) {
+      throw new Error(`Mailhog returned ${response.status} querying /api/v2/messages`);
+    }
+    const data = (await response.json()) as MailhogListResponse;
+    const matches = data.items.filter((msg) => {
+      if (since && msg.Created && new Date(msg.Created) < since) return false;
+      return msg.To.some(
+        (addr) => `${addr.Mailbox}@${addr.Domain}`.toLowerCase() === target,
+      );
+    });
+    if (matches.length > 0) {
+      return matches[0]; // /api/v2/messages returns newest-first
+    }
+    lastRecipients = data.items.flatMap((msg) =>
+      msg.To.map((addr) => `${addr.Mailbox}@${addr.Domain}`),
+    );
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for an email to ${recipient}. ` +
+      `Last poll saw recipients: ${lastRecipients.slice(0, 10).join(', ') || '(inbox empty)'}` +
+      (lastRecipients.length > 10 ? ` (+${lastRecipients.length - 10} more)` : ''),
+  );
+}
+
+/**
+ * Decodes the message body and returns the first regex match's capture
+ * group. Caller-supplied pattern keeps this helper agnostic across reset /
+ * verify / etc. URL shapes.
+ */
+export function extractUrl(message: MailhogMessage, pattern: RegExp): string {
+  const decoded = decodeQuotedPrintable(message.Content.Body);
+  const match = pattern.exec(decoded);
+  if (!match) {
+    throw new Error(
+      `extractUrl: pattern ${pattern} did not match decoded body. ` +
+        `Body preview: ${decoded.slice(0, 200)}`,
+    );
+  }
+  return match[1] ?? match[0];
+}
+
+/**
+ * Returns the path + query portion of an absolute URL, discarding scheme
+ * and host. Use this when handing a Mailhog-extracted URL to playwright's
+ * page.goto so its configured `baseURL` applies — Monica renders mail URLs
+ * via Laravel's URL helper, which uses APP_URL (`http://localhost`) and
+ * doesn't know about the host:port the playwright run is targeting.
+ */
+export function urlPathOnly(absoluteUrl: string): string {
+  const parsed = new URL(absoluteUrl);
+  return parsed.pathname + parsed.search;
+}
+
+function decodeQuotedPrintable(input: string): string {
+  // Strip soft line breaks (RFC 2045 §6.7): `=` immediately followed by CRLF
+  // (or LF) means "this line continues on the next line, ignore the break".
+  const unwrapped = input.replace(/=\r?\n/g, '');
+  // Decode `=XX` hex escapes → byte value.
+  return unwrapped.replace(/=([0-9A-Fa-f]{2})/g, (_, hex) =>
+    String.fromCharCode(parseInt(hex, 16)),
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

Closes out the two flows deferred from #739 (Tier A in-app subset), lifting #731's Tier A acceptance from 4/6 to **6/6**.

- **A.1 password reset** — `password-reset.spec.ts`. Submit `/password/reset`, retrieve the token from Mailhog, set a new password, then log out + back in with the new credentials to prove persistence (not just in-session redirect).
- **A.2 email verification** — `email-verification.spec.ts`. Drive a fresh user into the unverified state, dispatch the `VerifyEmail` notification directly via tinker (so the test doesn't depend on flipping `signup_double_optin` globally and breaking `signup-duplicate-email.spec.ts`), retrieve the signed URL from Mailhog, navigate to it, and assert `/dashboard` + populated `email_verified_at`.

Design spec at [`docs/superpowers/specs/2026-06-04-731-tier-a-mailhog-design.md`](docs/superpowers/specs/2026-06-04-731-tier-a-mailhog-design.md).

## Shared support

- **`tests/playwright/support/mailhog.ts`** — new module. `waitForEmailTo(recipient, { timeoutMs, since })` polls `http://localhost:8025/api/v2/messages` filtering by recipient (each fresh user has a unique faker email, so stale messages in the dev rig's Mailhog inbox don't collide). `extractUrl(message, pattern)` decodes the multipart quoted-printable body (`=\r\n` soft-wraps + `=XX` hex). `urlPathOnly(absoluteUrl)` returns path + query so playwright's `baseURL` applies.
- **`tests/playwright/support/auth.ts`** — `createFreshUser()` minted as a sibling to `loginAsFreshUser()` for specs that need a user without driving the Dusk login bridge (A.1). `FreshUser` gains an `email` field; existing call sites ignore it (TS structural typing).

## Side finding: `.env.dev` `APP_URL` patch

`APP_URL=http://localhost` (port-less) made Laravel's signed-URL middleware HMAC the no-port URL at send time; the incoming request comes in on `:8082`, so signatures mismatched and A.2 hit a 403 "Invalid signature". Patched `.env.dev` to `APP_URL=http://localhost:8082`. Same pattern as #739's `MAIL_FROM_ADDRESS` patch: dev-rig defect uncovered by the new spec, fixed in the same PR.

**Reviewers / fresh self-hosters:** the patched value won't take effect until the existing dev container is recreated, because `env_file` in docker compose is read at container *create* time, not start time. Run `docker compose -f docker-compose.dev.yml up -d --force-recreate app` after pulling this branch — otherwise A.1 will fail with a 500 (no MAIL_FROM_ADDRESS) and A.2 with a 403 (invalid signature).

## Tier A acceptance after this PR

| | item | shipped |
|---|---|---|
| ✅ | A.1 password reset | `password-reset.spec.ts` (this PR) |
| ✅ | A.2 email verification | `email-verification.spec.ts` (this PR) |
| ✅ | A.3 audit log | `audit-log.spec.ts` (#739) |
| ✅ | A.4 export (JSON + SQL) | `account-export.spec.ts` (#739) |
| ✅ | A.5 import vCard | `account-import-vcard.spec.ts` (#739) |
| ✅ | A.6 reminder persistence | `reminder-persistence.spec.ts` (#739) |

## Shape (same as #739)

- Both new specs import `test` / `expect` from `../support/console-gate` and call `consoleGate.assertNoUnknownErrors(label)` at the end.
- Selectors are ARIA role / visible text / form label / button name. No `.monica-modal__panel` / `.dp__*` / `.multiselect-*` / `.vgt-*`.
- A.1 uses `createFreshUser()` (logged-out flow); A.2 uses `loginAsFreshUser()` (verified middleware needs a session).

## Trade-off documented in the design spec

A.2 simulates the unverified state in-test rather than flipping `monica.signup_double_optin=true` globally and exercising the full register→notification chain. A global flip would break `signup-duplicate-email.spec.ts` (which asserts post-register redirect to `/dashboard`). The verify-URL handler — the high-blast-radius bit — is fully covered; the dispatch chain is a single config-gated call that Laravel's own framework tests exercise.

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml up -d --force-recreate app` (one-time, to pick up the new APP_URL).
- [ ] `cd tests/playwright && npx playwright test specs/password-reset.spec.ts specs/email-verification.spec.ts` — 2 tests, both green.
- [ ] `cd tests/playwright && npx playwright test` — full 67-test suite still green against the patched APP_URL (verified locally; 1.8m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
