### PR TITLE
test(playwright): backfill #731 tier B auth coverage (B.1, B.2, B.3)

### DIFF
--- a/docs/superpowers/specs/2026-06-04-731-tier-b-design.md
+++ b/docs/superpowers/specs/2026-06-04-731-tier-b-design.md
@@ -1,0 +1,198 @@
+# Playwright e2e coverage backfill: Tier B (auth surface)
+
+- Issue: [#731](https://github.com/brycehans/monica/issues/731) (umbrella)
+- Predecessor PRs: [#739](https://github.com/brycehans/monica/pull/739) (Tier A in-app), [#762](https://github.com/brycehans/monica/pull/762) (Tier A Mailhog)
+- Date: 2026-06-04
+- Status: design accepted
+
+## Problem
+
+#731's Tier B has three items, all auth-surface flows that no end-to-end test covers today:
+
+- **B.1 — Recovery codes login challenge.** The "use a recovery code instead" branch of the 2FA login gate.
+- **B.2 — Multi-FA disable / regenerate.** Disabling 2FA from `/settings/security` and rotating recovery codes.
+- **B.3 — Logout deep assertions.** Extending the shallow `/logout` smoke test at `dependency-upgrade-smoke.spec.ts:577` with the actual logged-out contract (protected routes redirect, header identity is gone).
+
+Dusk's `tests/Browser/Settings/MultiFAControllerTest.php` superficially looks like coverage but every test in it is `markTestIncomplete('Ignore 2fa tests for now.')`. Tier B is therefore *the* end-to-end 2FA coverage — there is no shadow safety net.
+
+## Goal
+
+Add three new spec files plus one shared helper, lifting #731's Tier B acceptance from 0/3 to 3/3. As a side effect, the UI-driven 2FA enrollment used in B.1 and B.2 also closes the (silent) gap left by Dusk's skipped enrollment tests.
+
+## Non-goals
+
+- **Cron-driven 2FA recovery flows** (e.g. lockout after N failed OTPs). Out of scope; the umbrella's non-goals (3) already defer cron-driven work.
+- **WebAuthn / security key flows.** The smoke spec at L657–L800ish covers enrollment; full E2E webauthn would need virtual-authenticator plumbing and is a separate effort.
+- **OAuth-mediated 2FA challenge.** `Auth\RecoveryLoginController` has a branch for OAuth-session re-login. Out of scope; the issue text describes the standard `/login` → `/validate2fa` path only.
+- **Replacing smoke L577.** Per design decision below, the smoke logout test stays as a canary; the new B.3 spec carries the deep contract.
+
+## Approach
+
+### File layout
+
+```
+tests/playwright/
+├── specs/
+│   ├── auth-recovery-codes.spec.ts  # B.1
+│   ├── auth-2fa-disable.spec.ts     # B.2
+│   └── auth-logout.spec.ts          # B.3
+└── support/
+    ├── auth.ts                      # extended with createFreshUserWithPassword
+    └── twofa.ts                     # NEW
+```
+
+Three separate spec files match the per-concept precedent set by `email-verification.spec.ts` and `password-reset.spec.ts` in Tier A. B.3's existence as a dedicated file deliberately diverges from the issue's "extend smoke L577" wording — see decision below.
+
+### `support/twofa.ts` helper
+
+```typescript
+// Drives /settings/security UI to enable 2FA. Opens the enable modal,
+// reads the server-issued secret from #secretkey, computes the current
+// OTP via artisan tinker, submits, waits for modal close, returns the
+// secret so callers can compute further OTPs (e.g. for the disable form).
+export async function enable2faViaUi(page: Page): Promise<{ secret: string }>;
+
+// Bridge to PragmaRX\Google2FA (already a composer dep). No JS TOTP
+// dependency added.
+export function currentOtp(secret: string): string;
+
+// Reads the user's recovery_codes via artisan tinker. Decrypts the
+// Crypt-encrypted column server-side and returns the plain-code list.
+// We don't drive the "Get recovery codes" UI to retrieve them — that's
+// a separate surface; B.1 just needs known codes.
+export function fetchRecoveryCodes(userId: string): string[];
+
+// Reads google2fa_secret directly via artisan tinker. Used to assert
+// the column is cleared post-disable.
+export function fetch2faSecret(userId: string): string;
+```
+
+The helper computes OTP at the moment of fill, never earlier, so the 30s TOTP window doesn't roll over between read and submit.
+
+### `support/auth.ts` extension
+
+```typescript
+// Mint a fresh user and set a known bcrypt password on them.
+// Returns the FreshUser shape plus the plaintext password. Used by
+// flows that need to drive the /login form (e.g. to engage the 2FA
+// challenge — the Dusk session bridge bypasses it).
+export async function createFreshUserWithPassword(plainPassword: string)
+  : Promise<FreshUser & { password: string }>;
+```
+
+Implementation: call existing `createFreshUser()`, then one tinker shellout to `$u->password = bcrypt($plain); $u->save();`. Composed, not inlined into specs, so future form-login specs don't redo the dance.
+
+### Header testid addition
+
+`resources/views/partials/header.blade.php` renders two parallel `<a href="logout">` links — one icon-only for desktop, one text for mobile. Neither is selectable robustly today: the icon has no accessible name, and the mobile text variant is `display:none` on desktop viewport (Playwright default). Both get `data-testid="header-logout"`. The B.3 spec uses:
+
+- `expect(page.getByTestId('header-logout').first()).toBeVisible()` pre-logout (matches the visible variant for the current viewport)
+- `expect(page.getByTestId('header-logout')).toHaveCount(0)` post-logout (header partial isn't rendered when logged out — both go away together)
+
+The existing `data-cy="header-link-logout"` on the desktop variant is cypress-era and unused. Left in place; cleanup is a separate concern.
+
+### B.1 — `auth-recovery-codes.spec.ts`
+
+```
+1. createFreshUserWithPassword('test-recovery-pw') → { user, password }
+2. loginAsFreshUser(page) — uses Dusk bridge to land authenticated for setup leg
+3. page.goto('/settings/security')
+4. enable2faViaUi(page) → { secret }
+5. recoveryCodes = fetchRecoveryCodes(user.userId)
+6. page.goto('/logout')
+7. page.goto('/login') — drive the form
+8. fill email + password, click Login
+9. page.waitForURL('**/validate2fa') — 2FA gate engages
+10. click link "recovery code" (from auth.use_recovery)
+11. page.waitForURL('**/auth/login-recovery')
+12. fill Recovery code input, click Login
+13. page.waitForURL('**/dashboard')
+14. consoleGate.assertNoUnknownErrors('/auth/login-recovery')
+```
+
+The dual-login (Dusk bridge for setup, form for the gate) is deliberate: setup is faster via the bridge, but the actual test surface — the recovery-code branch — only fires on form login.
+
+### B.2 — `auth-2fa-disable.spec.ts`
+
+```
+1. user = loginAsFreshUser(page)
+2. page.goto('/settings/security')
+3. { secret } = enable2faViaUi(page)
+
+# Disable leg
+4. click "Disable Two Factor Authentication"
+5. fill the disable-modal OTP field with currentOtp(secret)
+6. click Verify
+7. assert "Enable Two Factor Authentication" link visible (UI invariant)
+8. expect(fetch2faSecret(user.userId)).toBe('') (DB invariant)
+
+# Re-enable + regenerate leg
+9. { secret: secret2 } = enable2faViaUi(page)
+10. codesBefore = fetchRecoveryCodes(user.userId)
+11. click "Get recovery codes"
+12. click "Generate new codes…"
+13. codesAfter = fetchRecoveryCodes(user.userId)
+14. expect(codesAfter).not.toEqual(codesBefore)
+15. expect(codesAfter.length).toBe(codesBefore.length) — sanity
+16. consoleGate.assertNoUnknownErrors('/settings/security 2FA disable + regenerate')
+```
+
+Both UI invariant (link flip) and DB invariant (column cleared) are asserted on disable — UI alone would miss a controller that returns success without persisting; DB alone would miss a component that silently fails to update its state.
+
+### B.3 — `auth-logout.spec.ts`
+
+```
+1. loginAsFreshUser(page)
+2. page.goto('/dashboard')
+3. expect(page.getByTestId('header-logout').first()).toBeVisible()
+4. page.goto('/logout')
+5. page.goto('/dashboard')
+6. page.waitForURL('**/login') — protected-route contract
+7. expect(page.getByTestId('header-logout')).toHaveCount(0) — header gone
+8. expect(page.getByRole('button', { name: 'Login' })).toBeVisible() — re-entry surface present
+9. consoleGate.assertNoUnknownErrors('/logout deep')
+```
+
+## Decisions
+
+### 1. Three spec files, not one extension to smoke L577
+
+The issue text says "extend smoke L657" (actual line 577). Diverging because:
+
+- Tier A's precedent (`email-verification.spec.ts`, `password-reset.spec.ts`) is one spec per concept; logout is a concept.
+- The smoke spec is a 1500-line dependency-upgrade regression file; adding deep auth assertions there makes the smoke pass slower and harder to read.
+- Leaving smoke L577 intact gives us a 5-second canary that still fires in the upgrade pass, plus a deep contract in the dedicated spec. Each test has a distinct purpose.
+
+### 2. UI-driven 2FA enrollment, not artisan injection
+
+Both B.1 and B.2 enroll via the `/settings/security` modal rather than seeding `google2fa_secret` and `recovery_codes` directly. Rationale:
+
+- Dusk's enrollment-via-UI test is `markTestIncomplete`, so the modal flow has zero E2E coverage today.
+- Driving enrollment adds ~20 lines per spec (extracted into `enable2faViaUi`) for meaningful surface coverage.
+- The artisan-tinker pattern is still used for OTP computation and DB-state reads — the helper composes UI-drive and tinker-bridge cleanly.
+
+### 3. `createFreshUserWithPassword` helper, not inline tinker in B.1
+
+B.1 is the only Tier B slice that needs a known password (form login engages the gate). Three options were on the table: inline tinker, helper, modify the `setup:frontendtestuser` artisan command. Chose the helper because: future form-login specs (e.g. potential Tier D password-change flows) will want this too, and it's a clean 10-line addition.
+
+### 4. `data-testid` over reusing `data-cy`
+
+`data-cy` is a cypress-era artifact in this codebase (16 files via `v-cy-name`, 1 static — the existing logout link). Cypress is being retired (#725). Greenfield tests use Playwright's `data-testid` convention. Not migrating existing `data-cy` attributes — out of scope.
+
+## Acceptance criteria
+
+- [ ] `tests/playwright/specs/auth-recovery-codes.spec.ts` passes locally against the dev rig
+- [ ] `tests/playwright/specs/auth-2fa-disable.spec.ts` passes locally against the dev rig
+- [ ] `tests/playwright/specs/auth-logout.spec.ts` passes locally against the dev rig
+- [ ] `tests/playwright/support/twofa.ts` and the `auth.ts` extension exported and used by the new specs
+- [ ] `resources/views/partials/header.blade.php` carries `data-testid="header-logout"` on both `<a>` variants
+- [ ] Smoke L577 still passes unmodified
+- [ ] All three specs opt into the shared console-error fixture
+- [ ] No new tests use `.monica-modal__panel` / `.dp__*` / `.multiselect-*` / `.vgt-*` selectors
+- [ ] #731 umbrella comment updated to tick B.1 / B.2 / B.3
+
+## Open questions resolved during design
+
+1. **Where do recovery codes get fetched from in B.1?** From the DB via artisan, not from the "Get recovery codes" UI modal. The UI modal is a Tier-D-shaped surface (D.4 / personalization); B.1 just needs known codes.
+2. **What about the OAuth 2FA-challenge branch in `RecoveryLoginController`?** Out of scope; the issue text describes the standard `/login` → `/validate2fa` path only.
+3. **Does B.3 need to test session-cookie behavior directly?** No — protected-route redirect is the user-observable contract; cookie internals are framework-level and covered by Laravel's own suite.

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -25,7 +25,7 @@
           <a href="{{ route('changelog.index') }}" class="header-nav-item-link dib-l dn">
             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" width="14" height="16" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 14 16"><path fill-rule="evenodd" d="M14 12v1H0v-1l.73-.58c.77-.77.81-2.55 1.19-4.42C2.69 3.23 6 2 6 2c0-.55.45-1 1-1s1 .45 1 1c0 0 3.39 1.23 4.16 5 .38 1.88.42 3.66 1.19 4.42l.66.58H14zm-7 4c1.11 0 2-.89 2-2H5c0 1.11.89 2 2 2z" fill="#fff"/></svg>
           </a>
-          <a href="logout" class="header-nav-item-link dib-l dn" data-cy="header-link-logout">
+          <a href="logout" class="header-nav-item-link dib-l dn" data-cy="header-link-logout" data-testid="header-logout">
             <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" width="16" height="16" style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M12 9V7H8V5h4V3l4 3-4 3zm-2 3H6V3L2 1h8v3h1V1c0-.55-.45-1-1-1H1C.45 0 0 .45 0 1v11.38c0 .39.22.73.55.91L6 16.01V13h4c.55 0 1-.45 1-1V8h-1v4z" fill="#fff"/></svg>
           </a>
 
@@ -36,7 +36,7 @@
           <a href="{{ route('changelog.index') }}" class="header-nav-item-link dib dn-l">
             {{ trans('app.header_changelog_link') }}
           </a>
-          <a href="logout" class="header-nav-item-link dib dn-l">
+          <a href="logout" class="header-nav-item-link dib dn-l" data-testid="header-logout">
             {{ trans('app.header_logout_link') }}
           </a>
         </div>

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -4,7 +4,7 @@ Standalone Playwright suite for verifying the user-facing app. Two distinct sets
 
 1. **`dependency-upgrade-smoke.spec.ts`** — the phase-close gate per `CLAUDE.md`: login → dashboard → contact list → contact detail → vCard export → journal → reminders → settings → search → logout. Run before merging composer/npm bump PRs.
 2. **`subscription-flow.spec.ts`** — drives the Stripe-gated `/settings/subscriptions/*` routes through stripe-mock.
-3. **`<feature>.spec.ts`** — UI-binding / cross-component invariant coverage (#725) + Tier A coverage-gap backfill (#731). Each spec covers behaviour that phpunit alone can't reach:
+3. **`<feature>.spec.ts`** — UI-binding / cross-component invariant coverage (#725) + Tier A & B coverage-gap backfill (#731). Each spec covers behaviour that phpunit alone can't reach:
    - `contact-introductions.spec.ts` — ContactSelect multiselect ARIA contract + filter behaviour
    - `activity-types.spec.ts` — settings → activity-add cross-flow (premium-gated)
    - `activity-journal-side-effect.spec.ts` — activity-create inserts a non-deletable journal row
@@ -22,6 +22,9 @@ Standalone Playwright suite for verifying the user-facing app. Two distinct sets
    - `account-import-vcard.spec.ts` — vCard upload lands an imported contact on `/people` (#731 A.5)
    - `password-reset.spec.ts` — Mailhog-delivered reset token round-trips through `/password/reset` (#731 A.1)
    - `email-verification.spec.ts` — Mailhog-delivered signed verify URL marks the account verified (#731 A.2)
+   - `auth-recovery-codes.spec.ts` — 2FA recovery-code login challenge (#731 B.1)
+   - `auth-2fa-disable.spec.ts` — 2FA disable + regenerate-recovery-codes round trip (#731 B.2)
+   - `auth-logout.spec.ts` — logout deep contract: protected routes redirect, header identity cleared (#731 B.3)
 
 ## Why it's a separate suite
 

--- a/tests/playwright/specs/auth-2fa-disable.spec.ts
+++ b/tests/playwright/specs/auth-2fa-disable.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * 2FA disable + regenerate-recovery-codes round trip (#731 Tier B.2).
+ *
+ * Dusk's MultiFAControllerTest has a disable test but it's
+ * markTestIncomplete; nothing else covers the disable path or the
+ * "Generate new codes" rotation. This spec exercises both halves:
+ *
+ *   - Disable: enable 2FA via UI → open the disable modal → submit a
+ *     fresh OTP → assert the Enable link is back and google2fa_secret
+ *     is cleared on the user row.
+ *   - Regenerate: re-enable → open the recovery-codes modal (lazily
+ *     generates the first set) → click "Generate new codes…" → assert
+ *     the recovery_codes table now holds a different set of codes of
+ *     the same cardinality.
+ *
+ * Design rationale lives in docs/superpowers/specs/2026-06-04-731-tier-b-design.md.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import {
+  enable2faViaUi,
+  showRecoveryCodesViaUi,
+  regenerateRecoveryCodesViaUi,
+  fetchRecoveryCodes,
+  fetch2faSecret,
+  currentOtp,
+} from '../support/twofa';
+
+test.describe('Monica v4 — 2FA disable + regenerate', () => {
+  test('2FA can be disabled and recovery codes can be rotated', async ({ page, consoleGate }) => {
+    const user = await loginAsFreshUser(page);
+    await page.goto('/settings/security');
+
+    // ---- Enable -------------------------------------------------------
+    const { secret } = await enable2faViaUi(page);
+
+    // ---- Disable ------------------------------------------------------
+    await page.getByRole('link', { name: 'Disable Two Factor Authentication' }).click();
+    // Disable modal accepts either an OTP or a recovery code; we use a
+    // freshly computed OTP. Same labelled-input pattern as enable.
+    await page
+      .getByLabel('Enter a two factor authentication code or a recovery code')
+      .fill(currentOtp(secret));
+    await page.locator('#verify2').click();
+
+    // UI invariant: Enable link is back.
+    await expect(page.getByRole('link', { name: 'Enable Two Factor Authentication' }))
+      .toBeVisible();
+    // DB invariant: google2fa_secret column is cleared. A controller
+    // that returned success without persisting would slip past the UI
+    // check alone.
+    expect(fetch2faSecret(user.userId)).toBe('');
+
+    // ---- Re-enable + regenerate recovery codes ------------------------
+    await enable2faViaUi(page);
+    await showRecoveryCodesViaUi(page);
+
+    // Lazy generation fired on the click above; the codes now exist.
+    const codesBefore = fetchRecoveryCodes(user.userId);
+    expect(codesBefore.length).toBeGreaterThan(0);
+
+    await regenerateRecoveryCodesViaUi(page);
+
+    const codesAfter = fetchRecoveryCodes(user.userId);
+    // Rotation invariant: same cardinality, fully disjoint set.
+    expect(codesAfter.length).toBe(codesBefore.length);
+    expect(codesAfter).not.toEqual(codesBefore);
+    expect(codesAfter.some((c) => codesBefore.includes(c))).toBe(false);
+
+    consoleGate.assertNoUnknownErrors('/settings/security 2FA disable + regenerate');
+  });
+});

--- a/tests/playwright/specs/auth-logout.spec.ts
+++ b/tests/playwright/specs/auth-logout.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Logout deep contract (#731 Tier B.3).
+ *
+ * Extends the smoke spec's shallow logout assertion at L577 (which only
+ * checks "URL is /(login)? and body mentions Login"). This spec carries
+ * the deep behavioural contract:
+ *
+ *   - the logout link is visible while authenticated,
+ *   - hitting /logout terminates the session,
+ *   - protected routes redirect to the login surface afterwards
+ *     (route('loginRedirect') = '/' — the login form is rendered at the
+ *     root path, not at /login; see App\Http\Middleware\Authenticate),
+ *   - the header partial that hosts the logout link is gone.
+ *
+ * Smoke L577 deliberately stays in place as a fast canary in the
+ * dependency-upgrade pass — see docs/superpowers/specs/2026-06-04-731-tier-b-design.md
+ * decision (1) for why.
+ *
+ * The header logout link is selected via data-testid="header-logout"
+ * (added to both viewport variants in resources/views/partials/header.blade.php)
+ * because (a) the desktop icon variant has no accessible name and
+ * (b) the mobile text variant is display:none on default Playwright
+ * viewport, so getByRole('link', { name: 'Logout' }) matches nothing.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+
+test.describe('Monica v4 — logout deep contract', () => {
+  test('hitting /logout terminates the session and clears header identity', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+    await page.goto('/dashboard');
+
+    // Pre-condition: the header partial is rendered while authenticated,
+    // so at least one header-logout link exists in the DOM. .first()
+    // picks the viewport-visible variant.
+    await expect(page.getByTestId('header-logout').first()).toBeVisible();
+
+    await page.goto('/logout');
+
+    // Contract 1: subsequent visit to a protected route redirects to the
+    // login surface. App\Http\Middleware\Authenticate sends guests to
+    // route('loginRedirect'), which is '/' — the login form is rendered
+    // there directly without a further redirect to '/login'.
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/(login)?$/);
+
+    // Contract 2: the entire header partial is no longer rendered, so
+    // both header-logout variants are gone. Using toHaveCount(0) instead
+    // of toBeHidden() because the elements are absent from the DOM, not
+    // hidden by CSS.
+    await expect(page.getByTestId('header-logout')).toHaveCount(0);
+
+    // Contract 3: the re-entry surface (login form) is rendered.
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('/logout deep');
+  });
+});

--- a/tests/playwright/specs/auth-recovery-codes.spec.ts
+++ b/tests/playwright/specs/auth-recovery-codes.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * 2FA recovery-code login challenge (#731 Tier B.1).
+ *
+ * Exercises the "use a recovery code instead" branch of the 2FA login
+ * gate. Dusk's MultiFAControllerTest covers the OTP branch but every
+ * test in it is markTestIncomplete('Ignore 2fa tests for now.'), so
+ * the recovery-code branch has zero end-to-end coverage today.
+ *
+ * The flow:
+ *
+ *   1. Mint a fresh user with a known bcrypt password (the Dusk session
+ *      bridge bypasses the /login form and therefore bypasses the 2FA
+ *      gate — we need a real form login here).
+ *   2. Establish a session via the Dusk bridge (cheap) so we can drive
+ *      /settings/security to enable 2FA via the UI.
+ *   3. Click "Get recovery codes" — the controller lazily generates
+ *      codes on first read, mirroring the real user flow.
+ *   4. Read the now-populated codes from the DB.
+ *   5. Logout, navigate to /login, submit credentials. Land on
+ *      /validate2fa.
+ *   6. Click the "recovery code" link (renders into the validate2fa
+ *      view from auth.use_recovery).
+ *   7. Submit a known code. Assert /dashboard renders, which is what
+ *      RecoveryLoginController::$redirectTo resolves to.
+ *
+ * Design rationale lives in docs/superpowers/specs/2026-06-04-731-tier-b-design.md.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { createFreshUserWithPassword } from '../support/auth';
+import {
+  enable2faViaUi,
+  showRecoveryCodesViaUi,
+  fetchRecoveryCodes,
+} from '../support/twofa';
+
+test.describe('Monica v4 — 2FA recovery-code login', () => {
+  test('user with 2FA enrolled can log in via a recovery code', async ({ page, consoleGate }) => {
+    // ---- Setup: fresh user with known password + 2FA enrolled --------
+    const user = await createFreshUserWithPassword('test-recovery-pw');
+
+    // Establish a session via the Dusk bridge so the next request is
+    // authenticated. Skipping the form login here is fine — the form
+    // engages later, after we logout, and that's what's under test.
+    const bridge = await page.request.get(`/_dusk/login/${user.userId}`);
+    if (!bridge.ok()) {
+      throw new Error(`/_dusk/login/${user.userId} returned ${bridge.status()}`);
+    }
+
+    await page.goto('/settings/security');
+    await enable2faViaUi(page);
+    await showRecoveryCodesViaUi(page);
+
+    const recoveryCodes = fetchRecoveryCodes(user.userId);
+    expect(recoveryCodes.length).toBeGreaterThan(0);
+
+    // ---- Logout + form login engages the 2FA gate --------------------
+    await page.goto('/logout');
+
+    await page.goto('/login');
+    await page.getByRole('textbox', { name: 'Email' }).fill(user.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(user.password);
+    await page.getByRole('button', { name: 'Login' }).click();
+
+    // The 2FA middleware (PragmaRX\Google2FALaravel) does NOT redirect to
+    // a dedicated URL — it renders the validate2fa view at whatever URL
+    // the user was heading to (here /dashboard, the login redirect
+    // target). We assert engagement by the page heading.
+    await expect(page.getByRole('heading', { name: 'Two Factor Authentication' }))
+      .toBeVisible();
+
+    // ---- Recovery-code branch ----------------------------------------
+    // auth.use_recovery renders as: "Or you can use a <a>recovery code</a>"
+    await page.getByRole('link', { name: 'recovery code' }).click();
+    await page.waitForURL('**/auth/login-recovery');
+
+    await page.getByLabel('Recovery code').fill(recoveryCodes[0]);
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL('**/dashboard');
+
+    consoleGate.assertNoUnknownErrors('/auth/login-recovery');
+  });
+});

--- a/tests/playwright/support/auth.ts
+++ b/tests/playwright/support/auth.ts
@@ -54,6 +54,37 @@ export async function loginAsFreshUser(page: Page): Promise<FreshUser> {
 }
 
 /**
+ * Mint a fresh user, force a known bcrypt password on them, and return
+ * the plaintext alongside the FreshUser shape. Used by specs that need
+ * to drive the /login form (e.g. to engage the 2FA challenge gate —
+ * the /_dusk/login bridge bypasses it).
+ *
+ * The factory in `setup:frontendtestuser` writes a random password we
+ * never see; one extra tinker shellout reshapes the user into a known
+ * state without touching the artisan command itself.
+ */
+export async function createFreshUserWithPassword(
+  plainPassword: string,
+): Promise<FreshUser & { password: string }> {
+  const user = await createFreshUser();
+  // bcrypt() lives on the global helper namespace; tinker eval picks it
+  // up without an explicit import. Using single-quote PHP string so
+  // plainPassword can contain $ or " without escaping (we still reject
+  // single quotes below to keep the call site honest).
+  if (plainPassword.includes("'")) {
+    throw new Error('createFreshUserWithPassword: plainPassword cannot contain single quotes');
+  }
+  artisan(
+    'tinker',
+    '--execute',
+    `$u = App\\Models\\User\\User::find(${user.userId}); ` +
+      `$u->password = bcrypt('${plainPassword}'); ` +
+      `$u->save();`,
+  );
+  return { ...user, password: plainPassword };
+}
+
+/**
  * Mint a fresh user without driving the Dusk login bridge. Used by specs
  * that need to act as a logged-out visitor (e.g. password reset).
  */

--- a/tests/playwright/support/twofa.ts
+++ b/tests/playwright/support/twofa.ts
@@ -1,0 +1,172 @@
+/**
+ * Two-factor authentication helper.
+ *
+ * Wraps the /settings/security 2FA enrollment + recovery-code UI and
+ * exposes a small set of tinker-backed reads/computes so specs can
+ * assert against the underlying state without re-implementing the
+ * Google2FA OTP math in JS.
+ *
+ * Pattern:
+ *
+ *   import { enable2faViaUi, showRecoveryCodesViaUi,
+ *            regenerateRecoveryCodesViaUi, fetchRecoveryCodes,
+ *            fetch2faSecret, currentOtp } from '../support/twofa';
+ *
+ *   const { secret } = await enable2faViaUi(page);
+ *   await showRecoveryCodesViaUi(page);          // triggers lazy gen
+ *   const codes = fetchRecoveryCodes(user.userId);
+ *
+ * Why UI-drive enrollment and tinker-bridge OTP:
+ *
+ *   - Dusk's MultiFAControllerTest has the enrollment test, but every
+ *     method is markTestIncomplete('Ignore 2fa tests for now.'), so
+ *     today there is no end-to-end coverage of the enrollment modal.
+ *     Driving it from this helper backfills that surface.
+ *   - PragmaRX\Google2FA is already a composer dep, so computing OTPs
+ *     server-side via tinker avoids adding a JS TOTP library (otplib
+ *     etc.) and the clock-skew failure mode that comes with it. The
+ *     OTP is read at the moment of fill, never earlier, so the 30s
+ *     window doesn't roll over between read and submit.
+ *   - Recovery codes are surfaced lazily by the controller (POST
+ *     /settings/security/recovery-codes generates rows only when the
+ *     user has none). showRecoveryCodesViaUi mirrors the real user
+ *     flow (click "Get recovery codes"); fetchRecoveryCodes then reads
+ *     the now-populated rows from the DB.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { artisan } from './artisan';
+
+/**
+ * Drive /settings/security to enable 2FA. Opens the enable modal, reads
+ * the server-issued secret from #secretkey, computes the current OTP
+ * server-side, submits, and waits for the disable link to appear (which
+ * is the page's signal that 2FA is now active).
+ *
+ * Returns the secret so callers can compute further OTPs (e.g. for the
+ * disable form in B.2).
+ */
+export async function enable2faViaUi(page: Page): Promise<{ secret: string }> {
+  await page.getByRole('link', { name: 'Enable Two Factor Authentication' }).click();
+
+  // The modal renders the server-generated secret inside <code id="secretkey">.
+  // MfaActivate.vue fetches the secret via axios.get then sets enableModalOpen,
+  // so visibility implies the secret is bound. textContent includes the
+  // surrounding whitespace from the template, so trim before handing off.
+  const secretLocator = page.locator('#secretkey');
+  await expect(secretLocator).toBeVisible();
+  const secret = (await secretLocator.textContent())?.trim();
+  if (!secret) {
+    throw new Error('enable2faViaUi: failed to read secret from #secretkey');
+  }
+
+  // Compute OTP at the moment of fill so the 30s TOTP window doesn't
+  // roll over between read and submit.
+  //
+  // form-input renders its <input> with id = `<id-prop><vue-uid>`, so
+  // selecting the field by literal `#one_time_password1` misses. The
+  // <label for> binding is on the same suffixed id, so getByLabel works
+  // and the smoke spec calls this out at L666 of dependency-upgrade-smoke.
+  const otp = currentOtp(secret);
+  await page.getByLabel('Two factor authentication code').fill(otp);
+  await page.locator('#verify1').click();
+
+  // Confirm enrollment succeeded: the link flips from Enable to Disable.
+  await expect(
+    page.getByRole('link', { name: 'Disable Two Factor Authentication' }),
+  ).toBeVisible();
+
+  return { secret };
+}
+
+/**
+ * Click "Get recovery codes" to open the modal. Triggers lazy code
+ * generation server-side if the user has none yet (the controller's
+ * index() generates when count === 0). Leaves the modal open so the
+ * caller can drive regenerate from it; pair with a closeRecoveryCodesModal
+ * (out of scope here — specs that need to close it just navigate away).
+ */
+export async function showRecoveryCodesViaUi(page: Page): Promise<void> {
+  await page.getByRole('link', { name: 'Get recovery codes' }).click();
+  // The modal contains the recovery_help_intro string. Wait for it so
+  // the regenerate button is interactable.
+  await expect(page.getByText('These are your recovery codes:')).toBeVisible();
+}
+
+/**
+ * Click "Generate new codes…" inside the open recovery-codes modal.
+ * Caller is responsible for having opened the modal via
+ * showRecoveryCodesViaUi first. Waits for the regenerate axios POST
+ * to complete by waiting for the response.
+ */
+export async function regenerateRecoveryCodesViaUi(page: Page): Promise<void> {
+  const regeneratePost = page.waitForResponse(
+    (r) =>
+      r.url().endsWith('/settings/security/generate-recovery-codes')
+      && r.request().method() === 'POST'
+      && r.status() === 200,
+  );
+  await page.getByRole('link', { name: /Generate new codes/ }).click();
+  await regeneratePost;
+}
+
+/**
+ * Read the user's recovery codes (the plain `recovery` column on the
+ * recovery_codes table) via artisan tinker. Returns an array of
+ * recovery strings in DB insertion order.
+ *
+ * Note: the schema stores codes in plaintext (no Crypt), so a direct
+ * column read is sufficient — no decryption needed.
+ */
+export function fetchRecoveryCodes(userId: string): string[] {
+  const out = artisan(
+    'tinker',
+    '--execute',
+    `echo App\\Models\\User\\User::find(${userId})->recoveryCodes()->pluck('recovery')->implode("\\n");`,
+  );
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && /^[A-Z0-9-]+$/.test(line));
+}
+
+/**
+ * Read the user's google2fa_secret via artisan tinker. The User model
+ * encrypts on write and decrypts on read via its accessor, so we hit
+ * the model accessor (echo $user->google2fa_secret) rather than the
+ * raw column. Returns the empty string when 2FA is disabled (the
+ * disable controller sets the column to null).
+ */
+export function fetch2faSecret(userId: string): string {
+  const out = artisan(
+    'tinker',
+    '--execute',
+    `echo App\\Models\\User\\User::find(${userId})->google2fa_secret ?? '';`,
+  );
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .pop() ?? '';
+}
+
+/**
+ * Compute the current Google2FA OTP for a given base32 secret. Bridges
+ * to the PragmaRX\Google2FA library that the app itself uses, so the
+ * OTP we submit is computed by the same library that will validate it.
+ */
+export function currentOtp(secret: string): string {
+  const out = artisan(
+    'tinker',
+    '--execute',
+    `echo (new PragmaRX\\Google2FA\\Google2FA())->getCurrentOtp('${secret}');`,
+  );
+  // tinker may interleave deprecation warnings; OTP is the last non-empty
+  // line of stdout.
+  return out
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^\d{6}$/.test(line))
+    .pop() ?? '';
+}


### PR DESCRIPTION
## Summary

Closes Tier B of #731 with three new playwright specs covering the auth surface gaps Dusk's `MultiFAControllerTest` *appears* to cover but actually doesn't (every method is `markTestIncomplete('Ignore 2fa tests for now.')`):

- **B.1 — `auth-recovery-codes.spec.ts`** — drives a fresh user through 2FA enrollment, surfaces recovery codes via the lazy-gen UI flow, logs out, re-enters via the login form to engage the `validate2fa` middleware, and consumes a recovery code through `/auth/login-recovery`.
- **B.2 — `auth-2fa-disable.spec.ts`** — enables 2FA, disables via the disable modal (asserting both UI link flip and the `google2fa_secret` column cleared), re-enables, and rotates recovery codes through "Generate new codes…" with a disjoint-set rotation invariant.
- **B.3 — `auth-logout.spec.ts`** — `/logout` terminates the session; subsequent `/dashboard` redirects to `route('loginRedirect')` (which is `/`, not `/login`); the header partial that hosts the logout link is gone.

## Supporting changes

- **`tests/playwright/support/twofa.ts`** — new helper exposing `enable2faViaUi` / `showRecoveryCodesViaUi` / `regenerateRecoveryCodesViaUi` (UI-drive), plus `fetchRecoveryCodes` / `fetch2faSecret` / `currentOtp` (artisan-tinker bridges to PragmaRX\Google2FA — no JS TOTP dep added). OTP is computed at fill time so the 30s window doesn't roll over between read and submit.
- **`tests/playwright/support/auth.ts`** — new `createFreshUserWithPassword` for specs that need a real form login (the Dusk session bridge bypasses 2FA, so B.1 needed a known password).
- **`resources/views/partials/header.blade.php`** — `data-testid="header-logout"` on both desktop-icon and mobile-text logout links. The icon variant has no accessible name, and the mobile text variant is `display:none` on default Playwright viewport, so `getByRole('link', { name: 'Logout' })` matches nothing without this. Existing `data-cy="header-link-logout"` left in place.
- **`docs/superpowers/specs/2026-06-04-731-tier-b-design.md`** — design spec mirroring the Tier A predecessors.

Smoke L577's shallow `logout clears session` test stays unmodified — it's a 1-second canary in the dependency-upgrade pass; `auth-logout.spec.ts` carries the deep contract.

## Test plan

- [x] `yarn run smoke auth-logout.spec.ts` passes locally
- [x] `yarn run smoke auth-recovery-codes.spec.ts` passes locally
- [x] `yarn run smoke auth-2fa-disable.spec.ts` passes locally
- [x] All three specs run together in one invocation (`yarn run smoke auth-logout.spec.ts auth-recovery-codes.spec.ts auth-2fa-disable.spec.ts`) — 3 passed in 10.3s
- [x] Smoke L577 logout test still passes unmodified (`yarn run smoke dependency-upgrade-smoke.spec.ts -g 'logout clears session'`)

## After merge

Update the #731 umbrella comment ticking B.1 / B.2 / B.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
