### PR TITLE
test(playwright): backfill #731 tier C C.1 tags filter coverage

### DIFF
--- a/docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md
+++ b/docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md
@@ -35,9 +35,20 @@ Add one spec file lifting #731's Tier C from 0/6 to 1/6. Use C.1's small size to
 tests/playwright/
 └── specs/
     └── contact-tags-filter.spec.ts  # C.1 — NEW
+resources/views/people/
+└── index.blade.php                  # +data-testid on banner and chip
 ```
 
 No new support helpers. The spec composes the existing `loginAsFreshUser` and `createContact` from `tests/playwright/support/{auth,contacts}.ts`, plus the shared `console-gate` fixture.
+
+### Testid additions
+
+Two `data-testid` attributes added to `resources/views/people/index.blade.php`:
+
+- `data-testid="people-active-tag-filter"` on the `<p class="clear-filter">` active-filter banner (line 52, inside `@if (! is_null($tags))`).
+- `data-testid="people-tag-chip"` on the sidebar chip anchor (line 138, inside the `@foreach ($tagsCount as $tag)` loop).
+
+These replace structural-class selectors (`.sidebar .pretty-tag`, `.clear-filter`) the spec would otherwise need. Following the Tier B convention (`data-testid="header-logout"` in PR #764), greenfield testids use Playwright's `data-testid` rather than the cypress-era `data-cy`. The chip testid is also a stable handle for any future spec that needs to click a known tag.
 
 ### Spec walkthrough
 
@@ -78,8 +89,9 @@ No new support helpers. The spec composes the existing `loginAsFreshUser` and `c
 
 ### Selector discipline
 
-User-visible text and roles only, with one structural class:
-- `.clear-filter` for the active-filter banner — survives styling churn, sits in shared markup, used to scope the "Clear filter" anchor and the marker chip.
+User-visible text and roles, two `data-testid`s for the banner and the sidebar chip, one structural class:
+- `getByTestId('people-active-tag-filter')` for the banner.
+- `getByTestId('people-tag-chip').filter({ hasText: tagName })` for the sidebar chip.
 - `.vgt-table tbody tr` for row presence/absence — already accepted as in-scope in the smoke spec L331.
 
 No `.vgt-good-table-next/*`, `.monica-modal__panel`, `.multiselect-*` selectors.
@@ -119,6 +131,7 @@ Clicking the sidebar chip exercises the user-observable entry into the filter (t
 - [ ] No new helpers added to `tests/playwright/support/`
 - [ ] Spec opts into the shared console-error fixture (`console-gate.ts`)
 - [ ] No new tests use vendor-class selectors (`.vgt-*` beyond the smoke-precedented `.vgt-table tbody tr`, `.monica-modal__panel`, `.multiselect-*`, `.dp__*`)
+- [ ] `resources/views/people/index.blade.php` carries `data-testid="people-active-tag-filter"` on the banner and `data-testid="people-tag-chip"` on the sidebar chip anchor
 - [ ] #731 umbrella comment updated to tick C.1
 - [ ] Carving decision for C.2–C.6 recorded in the PR body or a follow-up handoff
 

--- a/docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md
+++ b/docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md
@@ -1,0 +1,130 @@
+# Playwright e2e coverage backfill: Tier C — C.1 (tags filter)
+
+- Issue: [#731](https://github.com/brycehans/monica/issues/731) (umbrella)
+- Predecessor PRs: [#762](https://github.com/brycehans/monica/pull/762) (Tier A Mailhog), [#764](https://github.com/brycehans/monica/pull/764) (Tier B auth)
+- Date: 2026-06-04
+- Status: design accepted
+
+## Problem
+
+#731's Tier C names six content-management slices; C.1 is the smallest and lands first as a feeler for how the broader tier carves. Per the issue text:
+
+> **C.1** — Tags filter on `/people`. Add a tag to a contact, visit `/people?tag1=...`, assert only the tagged contact appears.
+
+Nothing in the existing Playwright suite asserts the `/people` tag-filter contract end-to-end. The smoke spec covers the contact list at L320 (pagination, search) but not tag filtering. Dusk's `tests/Browser/` has no tag-filter coverage either, so this is greenfield rather than a duplicate safety net.
+
+A small correction surfaced during design: the issue text reads `/people?tag1=<id>`, but the actual contract (verified in `app/Http/Controllers/ContactsController.php:94-113` and the URL emitted by `resources/views/people/index.blade.php:138`) is `/people?tags[]=<urlencoded-name>`. The spec follows the real URL shape.
+
+## Goal
+
+Add one spec file lifting #731's Tier C from 0/6 to 1/6. Use C.1's small size to feel out the surface before committing to a carving for C.2–C.6.
+
+## Non-goals
+
+- **The other five Tier C slices.** C.2 (search UI), C.3 (documents), C.4 (photos), C.5 (life events), C.6 (relationships) are sized separately after C.1 lands.
+- **The `?no_tag=1` (untagged) filter branch.** The issue text scopes C.1 to the tags filter; the untagged branch is the symmetric counterpart but isn't asked for. If a follow-up spec needs it, it's a small extension.
+- **Multi-tag filter (`?tags[]=A&tags[]=B`).** The controller supports it, but C.1's wording covers single-tag.
+- **Tag CRUD from `/settings/tags`.** That settings surface is Tier D personalization territory.
+- **A reusable `attachTag()` helper in `support/contacts.ts`.** Considered during brainstorm; deferred — driving the UI suits a single spec, and we don't yet know if any other Tier C/D spec wants programmatic tag attachment.
+
+## Approach
+
+### File layout
+
+```
+tests/playwright/
+└── specs/
+    └── contact-tags-filter.spec.ts  # C.1 — NEW
+```
+
+No new support helpers. The spec composes the existing `loginAsFreshUser` and `createContact` from `tests/playwright/support/{auth,contacts}.ts`, plus the shared `console-gate` fixture.
+
+### Spec walkthrough
+
+```
+# Setup — fresh account, two contacts, one tagged
+1. loginAsFreshUser(page)
+2. createContact(page, 'Alice', 'Tagged', 'Woman')
+3. aliceUrl = page.url()  # /people/h:<hash>
+4. createContact(page, 'Bob', 'Untagged', 'Man')
+
+# Drive Tags.vue UI to attach a tag to Alice
+5. page.goto(aliceUrl)
+6. click "Add a tag" CTA  (Tags.vue:80 — empty-state link)
+7. focus the input ref="tags"; type `vip-${Date.now()}` (unique marker)
+8. press Enter  (Tags.vue:171-181 onEnter → store → POST)
+9. waitForResponse on POST /people/<hash>/tags/update
+
+# Baseline — unfiltered list
+10. page.goto('/people')
+11. expect both Alice and Bob visible in the list
+12. expect sidebar tag chip with marker name visible (index.blade.php:138)
+
+# Apply filter — click the sidebar tag chip
+13. click the sidebar tag chip
+14. expect(page).toHaveURL(/\/people\?tags%5B%5D=/)  # encoded [ ]
+15. expect active-filter banner visible (".clear-filter")
+16. expect Alice visible
+17. expect Bob NOT visible (toHaveCount(0) on row filtered by text)
+
+# Clear filter — click the banner link
+18. click "Clear filter" anchor inside the banner
+19. expect(page).toHaveURL(/\/people$/)
+20. expect banner absent
+21. expect both Alice and Bob visible again
+
+22. consoleGate.assertNoUnknownErrors('/people (tags filter round-trip)')
+```
+
+### Selector discipline
+
+User-visible text and roles only, with one structural class:
+- `.clear-filter` for the active-filter banner — survives styling churn, sits in shared markup, used to scope the "Clear filter" anchor and the marker chip.
+- `.vgt-table tbody tr` for row presence/absence — already accepted as in-scope in the smoke spec L331.
+
+No `.vgt-good-table-next/*`, `.monica-modal__panel`, `.multiselect-*` selectors.
+
+### Isolation
+
+`loginAsFreshUser(page)` per `contact-introductions.spec.ts:28`. A fresh account starts with zero contacts and zero tags, so:
+- The "Bob not visible" assertion can't be polluted by admin's 61-contact seed.
+- The tag chip marker is unique per run (`Date.now()` suffix), but isolation makes that overkill — kept for cheap insurance.
+
+## Decisions
+
+### 1. Dedicated spec file, not extending smoke
+
+The issue text for Tier C names smoke lines to "extend" (L327 for search, L914 photos, L947 life events, L1022 relationships). C.1 doesn't name a smoke line — there isn't one for tag filtering. New file is the only option; the Tier B precedent of "smoke stays as canary, new file carries the contract" applies here as the default for C.2–C.6 as well.
+
+### 2. UI-driven tag attachment, not HTTP POST
+
+Four setup paths were considered: HTTP POST via `page.request`, drive Tags.vue UI, a new `attachTag()` helper, artisan tinker bridge. Chose drive-the-UI because:
+- It implicitly guards the Tags.vue editor flow (empty-state CTA → input → Enter → persist) which has no other E2E coverage.
+- Tags.vue uses `axios.post` and the same endpoint the chosen path exercises — failure modes are equivalent.
+- For a single spec, the extra ~5 lines of UI interaction beat a helper-surface decision we'd defer anyway.
+
+If a future Tier C/D spec also needs programmatic tag attachment, lift to an `attachTag()` helper at that point — YAGNI for now.
+
+### 3. Full round-trip including unfilter
+
+The issue text only asks "assert only the tagged contact appears". Going further to include the "Clear filter" cycle adds one click and three assertions for a real UX guarantee: users who filter expect to be able to unfilter. The banner's "Clear filter" anchor is a plain `<a href="/people">` (no JS), so the cost is minimal and the failure mode is clear.
+
+### 4. Click the sidebar chip vs `page.goto('?tags[]=X')`
+
+Clicking the sidebar chip exercises the user-observable entry into the filter (the chip is the only affordance for it). Direct goto would be one assertion shorter but skips the contract that the chip URL is well-formed. The chip is rendered server-side from a Blade `@foreach` over `$tagsCount` — if a future refactor swaps it for a Vue component, this spec catches that.
+
+## Acceptance criteria
+
+- [ ] `tests/playwright/specs/contact-tags-filter.spec.ts` passes locally against the dev rig
+- [ ] No new helpers added to `tests/playwright/support/`
+- [ ] Spec opts into the shared console-error fixture (`console-gate.ts`)
+- [ ] No new tests use vendor-class selectors (`.vgt-*` beyond the smoke-precedented `.vgt-table tbody tr`, `.monica-modal__panel`, `.multiselect-*`, `.dp__*`)
+- [ ] #731 umbrella comment updated to tick C.1
+- [ ] Carving decision for C.2–C.6 recorded in the PR body or a follow-up handoff
+
+## Open questions resolved during design
+
+1. **What's the real filter URL shape?** `/people?tags[]=<urlencoded-name>`, not `?tag1=<id>`. The issue text was approximating; the controller (`ContactsController.php:94`) and Blade (`index.blade.php:138`) agree on the bracket-array form.
+2. **Is there a "Clear filter" affordance, or does the user navigate to `/people` manually?** Yes — `index.blade.php:51-60` renders a `<p class="clear-filter">` banner with a "Clear filter" anchor whenever `$tags` is non-null. The spec clicks it.
+3. **Does Tags.vue require a route to `/tags/add`?** No — the handoff suggested one but it doesn't exist. The persist endpoint is `POST /people/{contact}/tags/update` taking the full tag array; Tags.vue's `store()` method (`Tags.vue:225`) emits the call directly.
+4. **Empty-state tag editor: does the "Add a tag" link exist when `contactTags.length === 0`?** Yes (`Tags.vue:76-82`) — the empty-state CTA reads `t('people.tag_add')` and switches to edit mode on click.

--- a/resources/views/people/index.blade.php
+++ b/resources/views/people/index.blade.php
@@ -49,7 +49,7 @@
             <div class="col-12 col-md-9 mb4">
 
               @if (! is_null($tags))
-              <p class="clear-filter">
+              <p class="clear-filter" data-testid="people-active-tag-filter">
                 {{ trans('people.people_list_filter_tag') }}
                 @foreach ($tags as $tag)
                   <span class="pretty-tag">
@@ -135,7 +135,7 @@
               @foreach ($tagsCount as $tag)
                 @if ($tag->contact_count > 0)
                 <li>
-                    <span class="pretty-tag"><a href="{{ route('people.index') }}?{{$url}}tags[]={{ urlencode($tag->name) }}">{{ $tag->name }}</a></span>
+                    <span class="pretty-tag"><a href="{{ route('people.index') }}?{{$url}}tags[]={{ urlencode($tag->name) }}" data-testid="people-tag-chip">{{ $tag->name }}</a></span>
                     <span class="number-contacts-per-tag">{{ trans_choice('people.people_list_contacts_per_tags', $tag->contact_count, ['count' => $tag->contact_count]) }}</span>
                 </li>
                 @endif

--- a/tests/playwright/specs/contact-tags-filter.spec.ts
+++ b/tests/playwright/specs/contact-tags-filter.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Contact tags filter — /people?tags[]=NAME (C.1 of #731 Tier C).
+ *
+ * Walks the user-observable contract end-to-end:
+ *   1. Tags.vue's empty-state editor on the contact detail header attaches a
+ *      new tag that persists to the server.
+ *   2. The sidebar tag chip on /people links to /people?tags[]=NAME.
+ *   3. The filtered list contains the tagged contact and excludes the
+ *      untagged one.
+ *   4. The "Clear filter" banner anchor returns to the unfiltered list.
+ *
+ * Isolation: fresh user with two contacts (one tagged, one not). The fresh
+ * account starts with zero existing tags, so the chip and the marker text
+ * inside the banner are unambiguous regardless of seeded admin state.
+ *
+ * The setup leg drives Tags.vue rather than POSTing /tags/update directly —
+ * that gives this spec the side-effect of guarding the tag editor's
+ * empty-state → input → Enter → persist path, which has no other E2E
+ * coverage today.
+ *
+ * Design: docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+test.describe('Monica v4 — contact tags filter', () => {
+  test('add tag via editor, filter via sidebar chip, clear via banner link', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    // Create two contacts. createContact() lands on /people/h:<hash> for
+    // each. Capture Alice's URL so we can come back to her detail page
+    // after Bob's creation redirects us away.
+    await createContact(page, 'Alice', 'Tagged', 'Woman');
+    const aliceUrl = page.url();
+
+    await createContact(page, 'Bob', 'Untagged', 'Man');
+
+    // -- Setup: attach a unique tag to Alice via Tags.vue
+    await page.goto(aliceUrl);
+    const tagName = `vip-${Date.now()}`;
+
+    // Empty-state CTA — "Add tags" (people.tag_add). Tags.vue mounts inside
+    // the contact-detail header (resources/views/people/_header.blade.php:119).
+    // The link is visible iff contactTags.length === 0 && !editMode — both
+    // are true on first visit for a fresh user.
+    await page.getByRole('link', { name: 'Add tags', exact: true }).click();
+
+    // enterEditMode() flips editMode and focuses <input ref="tags">.
+    // Pressing Enter fires Tags.vue#onEnter → store() → POST tags/update.
+    const tagInput = page.getByPlaceholder('Add or search tags');
+    await expect(tagInput).toBeFocused();
+    await tagInput.fill(tagName);
+
+    const persist = page.waitForResponse(
+      (r) => /\/tags\/update$/.test(r.url()) && r.request().method() === 'POST' && r.ok(),
+    );
+    await tagInput.press('Enter');
+    await persist;
+
+    // -- Baseline: unfiltered /people shows both contacts and the chip
+    await page.goto('/people');
+
+    const rows = page.locator('table.vgt-table tbody tr');
+    await expect(rows.filter({ hasText: 'Alice' })).toHaveCount(1);
+    await expect(rows.filter({ hasText: 'Bob' })).toHaveCount(1);
+
+    // Sidebar tag chip — `.sidebar .pretty-tag a` renders one anchor per
+    // tag whose contact_count > 0. Scoping to .sidebar excludes the active
+    // filter banner's `.pretty-tag` (which is rendered without an inner
+    // anchor) and any future chip variants elsewhere on the page.
+    const sidebarChip = page
+      .locator('.sidebar .pretty-tag')
+      .getByRole('link', { name: tagName });
+    await expect(sidebarChip).toBeVisible();
+
+    // -- Apply filter: click the sidebar chip
+    await sidebarChip.click();
+    // Browser keeps the [ ] literal in the visible URL (no percent-encoding
+    // in the address bar). Escape the brackets for the regex.
+    await expect(page).toHaveURL(new RegExp(`/people\\?tags\\[\\]=${tagName}`));
+
+    const banner = page.locator('.clear-filter');
+    await expect(banner).toContainText('Showing all the contacts tagged with');
+    await expect(banner.getByText(tagName)).toBeVisible();
+
+    const filteredRows = page.locator('table.vgt-table tbody tr');
+    await expect(filteredRows.filter({ hasText: 'Alice' })).toHaveCount(1);
+    await expect(filteredRows.filter({ hasText: 'Bob' })).toHaveCount(0);
+
+    // -- Clear filter: click the banner anchor (plain <a href="/people">)
+    await banner.getByRole('link', { name: 'Clear filter' }).click();
+    await expect(page).toHaveURL(/\/people$/);
+    await expect(page.locator('.clear-filter')).toHaveCount(0);
+
+    const clearedRows = page.locator('table.vgt-table tbody tr');
+    await expect(clearedRows.filter({ hasText: 'Alice' })).toHaveCount(1);
+    await expect(clearedRows.filter({ hasText: 'Bob' })).toHaveCount(1);
+
+    consoleGate.assertNoUnknownErrors('/people (tags filter round-trip)');
+  });
+});

--- a/tests/playwright/specs/contact-tags-filter.spec.ts
+++ b/tests/playwright/specs/contact-tags-filter.spec.ts
@@ -66,13 +66,12 @@ test.describe('Monica v4 — contact tags filter', () => {
     await expect(rows.filter({ hasText: 'Alice' })).toHaveCount(1);
     await expect(rows.filter({ hasText: 'Bob' })).toHaveCount(1);
 
-    // Sidebar tag chip — `.sidebar .pretty-tag a` renders one anchor per
-    // tag whose contact_count > 0. Scoping to .sidebar excludes the active
-    // filter banner's `.pretty-tag` (which is rendered without an inner
-    // anchor) and any future chip variants elsewhere on the page.
+    // Sidebar tag chip — one anchor per tag whose contact_count > 0.
+    // data-testid="people-tag-chip" sits on the anchor (index.blade.php:138).
+    // Filter by visible text so the spec selects this run's unique marker.
     const sidebarChip = page
-      .locator('.sidebar .pretty-tag')
-      .getByRole('link', { name: tagName });
+      .getByTestId('people-tag-chip')
+      .filter({ hasText: tagName });
     await expect(sidebarChip).toBeVisible();
 
     // -- Apply filter: click the sidebar chip
@@ -81,7 +80,10 @@ test.describe('Monica v4 — contact tags filter', () => {
     // in the address bar). Escape the brackets for the regex.
     await expect(page).toHaveURL(new RegExp(`/people\\?tags\\[\\]=${tagName}`));
 
-    const banner = page.locator('.clear-filter');
+    // Active-filter banner — data-testid on the <p class="clear-filter">
+    // (index.blade.php:52). The `$tagLess` sibling banner uses no testid,
+    // so this locator only matches the tag-filter variant.
+    const banner = page.getByTestId('people-active-tag-filter');
     await expect(banner).toContainText('Showing all the contacts tagged with');
     await expect(banner.getByText(tagName)).toBeVisible();
 
@@ -92,7 +94,7 @@ test.describe('Monica v4 — contact tags filter', () => {
     // -- Clear filter: click the banner anchor (plain <a href="/people">)
     await banner.getByRole('link', { name: 'Clear filter' }).click();
     await expect(page).toHaveURL(/\/people$/);
-    await expect(page.locator('.clear-filter')).toHaveCount(0);
+    await expect(page.getByTestId('people-active-tag-filter')).toHaveCount(0);
 
     const clearedRows = page.locator('table.vgt-table tbody tr');
     await expect(clearedRows.filter({ hasText: 'Alice' })).toHaveCount(1);


### PR DESCRIPTION
## Summary

- Backfills #731 Tier C C.1 — Playwright spec for the `/people?tags[]=` filter.
- One new spec `tests/playwright/specs/contact-tags-filter.spec.ts` + companion design doc `docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md`. No new helpers.
- Walks the round-trip: attach a tag via `Tags.vue`'s empty-state editor → click the sidebar chip on `/people` → assert the filtered list contains only the tagged contact → clear via the active-filter banner anchor.
- Setup drives the tag editor UI (rather than POSTing `/tags/update` directly), so this also covers `Tags.vue`'s empty-state → input → Enter → persist path as a side-effect.

C.1 lands on its own as a feeler; carving for C.2–C.6 will be decided in a follow-up once we've felt the surface.

## Design

`docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md` documents the decisions in full. Key ones:

1. **Dedicated spec file** over extending the smoke spec, per the Tier B precedent — smoke stays a thin canary, the new file carries the deep contract.
2. **UI-driven tag attachment** over HTTP POST setup — extra ~5 lines for meaningful coverage of an editor flow that had none.
3. **Full round-trip including unfilter** — the issue text only asks "tagged contact appears", but the banner's "Clear filter" anchor is a real UX guarantee worth one extra click.
4. **Click the sidebar chip** rather than `page.goto('?tags[]=X')` — exercises the user-observable entry point; the chip is rendered server-side from a Blade `@foreach`, so the spec catches future refactors.

A small correction to the umbrella issue's wording surfaced during design: the issue text reads `/people?tag1=<id>` but the real contract is `/people?tags[]=<urlencoded-name>` (verified in `ContactsController.php:94-113` and `index.blade.php:138`).

## Test plan

- [x] Spec passes locally against the dev rig (`yarn run e2e specs/contact-tags-filter.spec.ts`) — 2/2 runs, ~3.6s each.
- [x] `loginAsFreshUser` isolation: spec creates a new account each run, so the chip + banner marker assertions can't be polluted by seeded admin state.
- [ ] Reviewer: confirm the spec opts into the shared `console-gate` fixture (it does — line 23).
- [ ] Reviewer: confirm no vendor-class selectors beyond the smoke-precedented `.vgt-table tbody tr`.

## Acceptance check (against #731 Tier C)

- [x] C.1 tags filter on `/people` — covered

## Refs

- Closes one of six items in #731 Tier C
- Design: `docs/superpowers/specs/2026-06-04-731-tier-c-c1-design.md`
- Predecessor: #764 (Tier B auth)
