### PR TITLE
test(playwright): backfill #731 tier c c.2 search ui coverage

### DIFF
--- a/tests/playwright/specs/contact-header-search.spec.ts
+++ b/tests/playwright/specs/contact-header-search.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Header contact autosuggest — type → dropdown → click → contact detail
+ * (C.2a of #731 Tier C).
+ *
+ * Covers the global <contact-search> in resources/views/partials/header.blade.php,
+ * which mounts ContactSearch.vue → ContactAutosuggest.vue. Typing into the
+ * header input POSTs to /people/search after a 200ms debounce; the dropdown
+ * renders <li class="contact-autosuggest__result"> items. Clicking a match
+ * fires onSelect → window.location = item.route, navigating to the contact
+ * detail page.
+ *
+ * Isolation: fresh user with one named contact ("Alice Findable"). A fresh
+ * account starts with zero contacts so the dropdown match is unambiguous.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+test.describe('Monica v4 — header contact search', () => {
+  test('type → dropdown match → click → contact detail', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    await createContact(page, 'Alice', 'Findable', 'Woman');
+    const aliceUrl = page.url();
+
+    // Land on a page where the header autosuggest is the only visible
+    // autosuggest. The dashboard is the natural starting surface for a
+    // fresh login.
+    await page.goto('/dashboard');
+
+    // The input carries `header-search-input` via ContactSearch.vue's
+    // :input-class. That class is unique to this instance (verified by
+    // grep of resources/) so it disambiguates from other ContactAutosuggest
+    // mounts (e.g. ContactSelect.vue's form-create autocomplete).
+    const searchInput = page.locator('.header-search-input');
+    await expect(searchInput).toBeVisible();
+
+    await searchInput.fill('Alice');
+
+    // The dropdown is gated on items.length > 0 — render happens after the
+    // 200ms debounce + the POST /people/search round-trip. Filter by the
+    // full complete_name so we land on the real match, not the always-
+    // present "add new contact" sentinel (id: -1) at the end of the list.
+    const result = page
+      .locator('.contact-autosuggest__result')
+      .filter({ hasText: 'Alice Findable' });
+    await expect(result).toBeVisible();
+
+    // onSelect uses @mousedown.prevent (ContactAutosuggest.vue:69) to beat
+    // the input's blur — Playwright's .click() dispatches mousedown first
+    // so this path works. The click triggers window.location, which is a
+    // full document navigation.
+    await result.click();
+    await expect(page).toHaveURL(aliceUrl);
+
+    consoleGate.assertNoUnknownErrors('/dashboard (header autosuggest → detail)');
+  });
+});

--- a/tests/playwright/specs/contact-list-inline-search.spec.ts
+++ b/tests/playwright/specs/contact-list-inline-search.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * /people inline vgt-table search — filter → match → click row → contact
+ * detail (C.2b of #731 Tier C).
+ *
+ * Covers ContactList.vue's match-then-click-through flow. The smoke spec
+ * at dependency-upgrade-smoke.spec.ts:320-349 already asserts the no-match
+ * "No results found" toast under the vue-good-table cutover guard; this
+ * spec carries the positive contract — typing a match filters the rows,
+ * and clicking the surviving row navigates to the contact detail page via
+ * onRowClick → window.location.href (ContactList.vue:187-194).
+ *
+ * Isolation: fresh user with two contacts (one match, one not). Search by
+ * first name so the table filter has something to exclude.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+test.describe('Monica v4 — /people inline search', () => {
+  test('filter rows → click match → contact detail', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    await createContact(page, 'Alice', 'Findable', 'Woman');
+    const aliceUrl = page.url();
+    await createContact(page, 'Bob', 'Excluded', 'Man');
+
+    await page.goto('/people');
+
+    const rows = page.locator('table.vgt-table tbody tr');
+    await expect(rows.filter({ hasText: 'Alice' })).toHaveCount(1);
+    await expect(rows.filter({ hasText: 'Bob' })).toHaveCount(1);
+
+    // Same selector as the smoke spec (L340). vgt-table's global search
+    // input lives inside .vgt-global-search__input.
+    const searchInput = page.locator('.vgt-global-search__input input.vgt-input');
+    await searchInput.fill('Alice');
+
+    // The table debounces then server-fetches; auto-waiting assertions
+    // ride the round-trip.
+    await expect(rows.filter({ hasText: 'Alice' })).toHaveCount(1);
+    await expect(rows.filter({ hasText: 'Bob' })).toHaveCount(0);
+
+    // Click anywhere on Alice's row. ContactList.vue's @row-click handler
+    // (line 187) calls preventDefault on the event and sets
+    // window.location.href = row.route — a full-document navigation.
+    await rows.filter({ hasText: 'Alice' }).first().click();
+    await expect(page).toHaveURL(aliceUrl);
+
+    consoleGate.assertNoUnknownErrors('/people (inline search → detail)');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes C.2 of the [#731](https://github.com/brycehans/monica/issues/731) umbrella with two Playwright specs covering the user-facing contact-search surfaces, both green-field for E2E.
- `tests/playwright/specs/contact-header-search.spec.ts` — global `<contact-search>` autosuggest in the header: type → wait for dropdown match → click → assert contact detail URL.
- `tests/playwright/specs/contact-list-inline-search.spec.ts` — `/people` vgt-table inline filter: extends the smoke spec's no-match canary (`dependency-upgrade-smoke.spec.ts:320-349`) with the positive contract (type → filter rows → click match → detail).

Both specs use `loginAsFreshUser` + `createContact` for isolation. No new helpers, no source edits, no `data-testid` additions — the existing `.header-search-input` and `.vgt-global-search__input` selectors are uniquely scoped and stable.

Carving note: C.2 ships alone for the same reason C.1 did — search is discoverability, not the file-upload (C.3 + C.4) or create-flow (C.5, C.6) sibling territory. The umbrella tracker moves from 1/6 → 2/6.

## Test plan

- [x] `npx playwright test contact-header-search.spec.ts contact-list-inline-search.spec.ts` — both pass locally against the dev rig on `:8082` (~7s combined, single worker).
- [x] No console errors reported by the `console-gate` fixture in either spec.
- [x] `git diff` confirms only the two new spec files are touched — no Blade/PHP edits, so no `docker restart monica-app-1` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
