### PR TITLE
test(playwright): backfill #731 tier c c.3 + c.4 upload coverage

### DIFF
--- a/tests/playwright/specs/contact-documents-upload.spec.ts
+++ b/tests/playwright/specs/contact-documents-upload.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Contact documents upload (C.3 of #731 Tier C).
+ *
+ * Covers DocumentList.vue, mounted inline on the contact detail page under
+ * the `documents` module (profile.blade.php:162-166). Drives the full
+ * empty-state-to-populated flow:
+ *
+ *   1. Detail page mounts <document-list>; the empty-state CTA reads
+ *      "Upload document" (people.document_list_cta).
+ *   2. Clicking the CTA reveals the upload zone with a hidden
+ *      <input id="file"> (opacity:0 absolute-overlay, accepts files via
+ *      setInputFiles).
+ *   3. POST /people/<hash>/documents stores the file via UploadDocument.
+ *      On success, the response gets pushed into the documents array and
+ *      rendered as a table row with original_filename.
+ *
+ * Isolation: fresh user with one contact, no existing documents. The
+ * upload binary is a tiny inline buffer — no fixtures, no disk I/O.
+ *
+ * The fresh account is granted has_access_to_paid_version_for_free so the
+ * documents/index.blade.php gate
+ *   @if (config('monica.requires_subscription') && $accountHasLimitations)
+ * falls through to the <document-list> branch. The dev rig hard-codes
+ * REQUIRES_SUBSCRIPTION=true in docker-compose.dev.yml, so without the
+ * paid-access toggle every fresh user sees the upgrade prompt instead of
+ * the upload UI. auth.ts's docstring explicitly anticipates this toggle.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+import { artisan } from '../support/artisan';
+
+test.describe('Monica v4 — contact documents upload', () => {
+  test('CTA → file input → POST → document appears in list', async ({ page, consoleGate }) => {
+    const user = await loginAsFreshUser(page);
+    artisan(
+      'tinker',
+      '--execute',
+      `$a = App\\Models\\Account\\Account::find(${user.accountId}); ` +
+        `$a->has_access_to_paid_version_for_free = true; $a->save();`,
+    );
+
+    await createContact(page, 'Alice', 'Documented', 'Woman');
+    // createContact lands on /people/h:<hash> (the default notes view),
+    // and the documents section is rendered inline within that view —
+    // no tab click needed.
+
+    // The DocumentList CTA is an <a class="btn edit-information"> with no
+    // href, so getByRole('link') doesn't match (HTML/ARIA: bare <a> isn't
+    // a link). Scope to the anchor class and filter by visible text. The
+    // CTA is gated on no-upload-zone-active state — true on first visit
+    // for a fresh contact.
+    const filename = `tier-c3-${Date.now()}.txt`;
+    const fileBuffer = Buffer.from('tier C.3 spec fixture content', 'utf-8');
+
+    await page.locator('a.edit-information').filter({ hasText: 'Upload document' }).click();
+
+    // Wait for the POST /people/<hash>/documents round-trip. The Vue
+    // component pushes the response into `this.documents`, which the
+    // template renders as a <div class="table-row"> containing
+    // `{{ document.original_filename }}`.
+    const persist = page.waitForResponse(
+      (r) => /\/people\/h:[A-Za-z0-9]+\/documents$/.test(r.url())
+        && r.request().method() === 'POST'
+        && r.ok(),
+    );
+
+    await page.locator('input#file').setInputFiles({
+      name: filename,
+      mimeType: 'text/plain',
+      buffer: fileBuffer,
+    });
+    await persist;
+
+    // The new row carries the original_filename as a table-cell. Scope
+    // the locator to the documents section by filtering on the unique
+    // filename marker so we don't pick up matches elsewhere on the page.
+    await expect(page.locator('.table-row').filter({ hasText: filename })).toHaveCount(1);
+
+    consoleGate.assertNoUnknownErrors('/people/h:<contact> (documents upload)');
+  });
+});

--- a/tests/playwright/specs/contact-photos-upload.spec.ts
+++ b/tests/playwright/specs/contact-photos-upload.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Contact photos upload (C.4 of #731 Tier C).
+ *
+ * Extends dependency-upgrade-smoke.spec.ts:849-878 (photos tab mount-only)
+ * with the positive upload contract. PhotoList.vue / PhotoUpload.vue render
+ * inside the Photos tab on /people/h:<hash>, conditioned on
+ * global_profile_default_view === 'photos'. Clicking the "Photos" tab span
+ * fires updateDefaultProfileView('photos'); the section then renders the
+ * "Upload photo" CTA which reveals the upload zone.
+ *
+ * Flow:
+ *   1. Click Photos tab → PhotoList mounts, list is empty.
+ *   2. Click "Upload photo" CTA → PhotoUpload's displayUploadZone = true,
+ *      hidden <input id="file"> becomes target-able.
+ *   3. setInputFiles with a tiny PNG → POST /people/<hash>/photos → on
+ *      success, PhotoList's handleNewPhoto pushes the new photo into the
+ *      grid. The card carries a background-image: url(<photo.link>) which
+ *      we assert via inline style attribute matching the storage path.
+ *
+ * Isolation: fresh user, fresh contact, empty photo list. No try/finally
+ * tab restoration needed (the persisted default-view preference is on the
+ * fresh user, who is discarded at session end).
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+// 67-byte 1x1 transparent PNG. Same buffer the smoke avatar tests use
+// (dependency-upgrade-smoke.spec.ts:1482-1485). UploadPhoto's `image`
+// validator accepts this.
+const tinyPng = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkAAIAAAoAAv/lxKUAAAAASUVORK5CYII=',
+  'base64',
+);
+
+test.describe('Monica v4 — contact photos upload', () => {
+  test('Photos tab → CTA → file input → POST → photo appears in grid', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    await createContact(page, 'Alice', 'Photographed', 'Woman');
+    // createContact lands on /people/h:<hash> (the default notes view).
+    // Click the Photos tab to flip global_profile_default_view = 'photos'.
+    await page.locator('span').filter({ hasText: /^Photos$/ }).click();
+
+    // PhotoList renders its title only inside the 'photos' view. Use it
+    // as the gate that the tab swap completed before clicking the CTA.
+    await expect(page.getByRole('heading', { name: 'Related photos' })).toBeVisible();
+
+    // PhotoList CTA: people.photo_list_cta = "Upload photo". Anchor; same
+    // role/text pattern as the documents CTA.
+    await page.getByRole('link', { name: 'Upload photo', exact: true }).click();
+
+    // POST /people/<hash>/photos round-trip. handleNewPhoto pushes the
+    // PhotoResource into PhotoList.photos which renders as a w-third-ns
+    // card with style="background-image: url(...);".
+    const persist = page.waitForResponse(
+      (r) => /\/people\/h:[A-Za-z0-9]+\/photos$/.test(r.url())
+        && r.request().method() === 'POST'
+        && r.ok(),
+    );
+
+    await page.locator('input#file').setInputFiles({
+      name: 'tier-c4.png',
+      mimeType: 'image/png',
+      buffer: tinyPng,
+    });
+    await persist;
+
+    // PhotoList renders one .photo card per uploaded image, with the
+    // image-link injected as an inline background-image style. Asserting
+    // count rather than parsing the URL keeps the spec resilient to the
+    // storage backend (filesystem vs s3) and signed-URL query params.
+    await expect(page.locator('.photo')).toHaveCount(1);
+
+    consoleGate.assertNoUnknownErrors('/people/h:<contact> (photos upload)');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes C.3 (documents) + C.4 (photos) of the [#731](https://github.com/brycehans/monica/issues/731) umbrella with two Playwright specs covering the contact-detail upload surfaces. Bundled because both share the file-upload pattern (fresh-user setup + `setInputFiles` with an inline buffer + auto-wait on the POST round-trip).
- `contact-documents-upload.spec.ts` — drives `DocumentList.vue` (mounted inline on the contact detail page under `profile.blade.php:162-166`). CTA → file input → POST `/people/<hash>/documents` → assert new row with `original_filename`.
- `contact-photos-upload.spec.ts` — extends smoke L849-878 (photos tab mount-only). Clicks the Photos tab span → "Upload photo" CTA → 67-byte tiny PNG (same buffer the smoke avatar tests use at `dependency-upgrade-smoke.spec.ts:1482-1485`) → POST `/people/<hash>/photos` → assert one `.photo` grid card.

### Subscription-gate gotcha worth flagging

`documents/index.blade.php` gates the `<document-list>` mount on `config('monica.requires_subscription') && $accountHasLimitations`. The dev rig (`docker-compose.dev.yml`) hard-codes `REQUIRES_SUBSCRIPTION=true`, so a vanilla `loginAsFreshUser` lands on the upgrade prompt instead of the upload form. The spec calls into `artisan tinker` to flip `has_access_to_paid_version_for_free = true` on the fresh account before driving the UI — `auth.ts`'s docstring already anticipated this pattern. The photos blade has no equivalent gate (only PhotoList's storage-byte check, which fresh accounts pass trivially) so its path needs no toggle.

### Selector note

The documents CTA is `<a class="btn edit-information">` with **no** `href` attribute, so it's not a link by HTML/ARIA. `getByRole('link', { name: 'Upload document' })` fails. Spec uses `page.locator('a.edit-information').filter({ hasText: 'Upload document' })` instead. The photos CTA uses `href=""` (still empty, but the attribute exists) which qualifies as a link role — `getByRole` works there.

## Test plan

- [x] `npx playwright test contact-documents-upload.spec.ts contact-photos-upload.spec.ts` — both pass locally against the dev rig (`5.1s` combined, single worker).
- [x] No new helpers added to `tests/playwright/support/`. The `artisan()` shim already supports `tinker --execute`; spec inlines the one-liner.
- [x] No source edits (no Blade, no PHP, no Vue) — no `docker restart monica-app-1` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
