### PR TITLE
test(playwright): backfill #731 tier c c.5 life event create coverage

### DIFF
--- a/tests/playwright/specs/contact-life-event-create.spec.ts
+++ b/tests/playwright/specs/contact-life-event-create.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Contact life-event create flow (C.5 of #731 Tier C).
+ *
+ * Extends dependency-upgrade-smoke.spec.ts:881-907 (life-events tab mount-only)
+ * with the positive create contract. The tab is switched by clicking the
+ * "Life events" span which fires updateDefaultProfileView('life-events').
+ * The LifeEventList blank state then renders an "Add a life event" CTA;
+ * clicking it mounts CreateLifeEvent inline with a three-step wizard:
+ *
+ *   categories  → click a category row → GET /lifeevents/categories/<id>/types
+ *   types       → click a type row     → switches view to 'add'
+ *   add         → date defaults to today; click "Add" → POST
+ *                 /people/<hash>/lifeevents → response pushed into
+ *                 lifeEvents → renders an .life-event-list-icon row.
+ *
+ * The spec picks the FIRST category and the FIRST type in each list. The
+ * categories and types are seeded by the account-create lifecycle; their
+ * order is deterministic per user (id ASC) but their localised names
+ * aren't — picking by position keeps the selector resilient to i18n
+ * changes that have bitten the cypress equivalents historically.
+ *
+ * No subscription gate on life-events at the blade level (verified in
+ * resources/views/people/life-events/index.blade.php — the <life-event-list>
+ * mount is unconditional). The fresh-user account works without paid-access
+ * toggling, unlike documents.
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+test.describe('Monica v4 — contact life event create', () => {
+  test('tab → CTA → category → type → submit → row in timeline', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    await createContact(page, 'Alice', 'Anniversary', 'Woman');
+
+    // Switch to the Life events tab. Same span pattern as smoke L894.
+    // The rendered text is "new Life events (0)" for users whose
+    // profile_new_life_event_badge_seen flag is still false (which fresh
+    // accounts always are), so anchor on the stable middle substring.
+    await page.locator('span').filter({ hasText: /Life events/ }).first().click();
+
+    // LifeEventList blank-state CTA. people.life_event_list_cta =
+    // "Add life event". <a> with href="" qualifies as a link role.
+    await page.getByRole('link', { name: 'Add life event', exact: true }).click();
+
+    // CreateLifeEvent mounts with view='categories'. Categories are
+    // fetched async via GET /lifeevents/categories — wait for the first
+    // row to appear before clicking.
+    const firstCategory = page.locator('.life-event-add-row').first();
+    await expect(firstCategory).toBeVisible();
+    await firstCategory.click();
+
+    // After click, view='types' and getType POSTs to fetch the type list.
+    // Wait for the new rows then click the first.
+    const firstType = page.locator('.life-event-add-row').first();
+    await expect(firstType).toBeVisible();
+    await firstType.click();
+
+    // The 'add' view renders the date form (defaulted to today) and the
+    // primary "Add" button at the bottom. We submit without changing any
+    // fields — date defaults to today, type-specific content is optional.
+    const persist = page.waitForResponse(
+      (r) => /\/people\/h:[A-Za-z0-9]+\/lifeevents$/.test(r.url())
+        && r.request().method() === 'POST'
+        && r.ok(),
+    );
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+    await persist;
+
+    // After store(), parent updates lifeEvents — the populated list
+    // renders one .life-event-list-icon per row.
+    await expect(page.locator('.life-event-list-icon')).toHaveCount(1);
+
+    consoleGate.assertNoUnknownErrors('/people/h:<contact> (life event create)');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes C.5 of the [#731](https://github.com/brycehans/monica/issues/731) umbrella. Extends `dependency-upgrade-smoke.spec.ts:881-907` (life-events tab mount-only) into the positive create contract: tab click → "Add life event" CTA → categories wizard → first category → first type → submit → assert one `.life-event-list-icon` row in the populated timeline.
- Single spec, single test, ~80 lines. Mirrors the cadence of C.1 / C.2 (one slice per PR for discoverability-style slices).

### Notable choices

- **Select category + type by position** (`.life-event-add-row.first()`), not by visible name. The category/type rows come from seeded reference data with deterministic id-ASC order per fresh account, but their labels are i18n'd. Position-based selection is what the cypress equivalents settled on after the locale-coupled selectors flaked historically.
- **No subscription gate** on life-events at the blade level (`resources/views/people/life-events/index.blade.php` mounts `<life-event-list>` unconditionally), so the fresh-user account works without the `has_access_to_paid_version_for_free` toggle that documents (C.3) needed.
- **Tab span carries a "new" badge** for users whose `profile_new_life_event_badge_seen` flag is false (always true for fresh accounts). The regex selector drops the `^` anchor so it matches both `"new Life events"` and `"Life events"`; matches the smoke spec's L894 pattern.

## Test plan

- [x] `npx playwright test contact-life-event-create.spec.ts` — passes locally against the dev rig (2.7s, single worker).
- [x] No new helpers added to `tests/playwright/support/`. No source edits.
- [x] `consoleGate.assertNoUnknownErrors` clean over the create flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
