### PR TITLE
test(playwright): backfill #731 tier c c.6 relationship create coverage

### DIFF
--- a/tests/playwright/specs/contact-relationship-create.spec.ts
+++ b/tests/playwright/specs/contact-relationship-create.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * Contact relationship create (C.6 of #731 Tier C).
+ *
+ * Extends dependency-upgrade-smoke.spec.ts:954-1025 (relationship/create
+ * mount-only) with the positive create-and-associate contract. The smoke
+ * tests assert form-checkbox toggling + SpecialDate slot rendering on the
+ * form, but stop short of submitting. This spec drives the full flow:
+ *
+ *   /relationships/create → select "existing contact" radio → open the
+ *   contact picker (@vueform/multiselect via <contact-select>) → click
+ *   the other contact → pick a relationship type from the <form-select>
+ *   → submit → server redirects to /people/h:<contact> with the success
+ *   flash → relationships section now renders a <a> link to the
+ *   associated contact.
+ *
+ * Two contacts in setup so the picker has something to find. The picker
+ * pattern follows contact-introductions.spec.ts (ARIA combobox/listbox/
+ * option roles, scoped by the localised title).
+ */
+
+import { test, expect } from '../support/console-gate';
+import { loginAsFreshUser } from '../support/auth';
+import { createContact } from '../support/contacts';
+
+test.describe('Monica v4 — contact relationship create', () => {
+  test('open create form → pick existing contact → submit → relationship renders on detail', async ({ page, consoleGate }) => {
+    await loginAsFreshUser(page);
+
+    // Two contacts. Alice is the active subject; Bob is the partner we'll
+    // associate her with. createContact lands on each new contact's detail
+    // page, so the second call leaves us on Bob — we navigate back to
+    // Alice via her captured URL.
+    await createContact(page, 'Alice', 'Subject', 'Woman');
+    const aliceUrl = page.url();
+    await createContact(page, 'Bob', 'Partner', 'Man');
+
+    await page.goto(`${aliceUrl}/relationships/create`);
+
+    // Flip to the "existing contact" radio. The "Add a new person" radio
+    // is checked by default; clicking "An existing contact" flips
+    // global_relationship_form_new_contact = false, which v-if-toggles
+    // the ContactSelect into view.
+    await page.locator('label', { hasText: 'An existing contact' }).click();
+
+    // ContactSelect mounts a @vueform/multiselect rendered as ARIA
+    // combobox + listbox + option tree. Anchor on its localised title
+    // (relationship_form_associate_dropdown) so we don't grab the
+    // adjacent form-select for relationship type.
+    const picker = page.getByRole('combobox', {
+      name: /Search and select an existing contact from the dropdown below/i,
+    });
+    await expect(picker).toBeVisible();
+    await picker.click();
+
+    const listbox = page.getByRole('listbox');
+    await expect(listbox).toBeVisible();
+    await listbox.getByRole('option', { name: 'Bob Partner' }).click();
+
+    // Pick a relationship type. form-select renders a native <select>
+    // labelled by people.relationship_form_is_with = "This person is…".
+    // The relationship type options are seeded per account at creation
+    // time (love / family / professional / etc.); first non-empty option
+    // is good enough for the existence assertion.
+    const typeSelect = page.getByLabel(/This person is/i);
+    await typeSelect.selectOption({ index: 1 });
+
+    // Submit. The store action POSTs to /people/h:<alice>/relationships,
+    // creates the relationship, and redirects back to Alice's detail.
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
+    await expect(page).toHaveURL(aliceUrl);
+
+    // The detail's relationships sidebar renders an <a href="/people/h:bob">
+    // for each related contact. Asserting the link by Bob's full name
+    // is enough — fresh account, no other contacts that could collide.
+    await expect(page.getByRole('link', { name: 'Bob Partner' })).toBeVisible();
+
+    consoleGate.assertNoUnknownErrors('/people/h:<alice> (relationship create)');
+  });
+});


### PR DESCRIPTION
## Summary

- Closes C.6 of the [#731](https://github.com/brycehans/monica/issues/731) umbrella — **the final Tier C slice**. Extends `dependency-upgrade-smoke.spec.ts:954-1025` (relationship/create mount-only) into the positive associate-existing-contact contract.
- Two-contact fresh-user setup → `/relationships/create` on Alice → flip "An existing contact" radio → open `<contact-select>`'s `@vueform/multiselect` combobox → click Bob in the listbox → pick a relationship type from the `<form-select>` → submit → server redirects to Alice's detail → assert Bob renders as a link in Alice's relationships sidebar.

### Notable choices

- **Picker interaction reuses the ARIA combobox/listbox/option pattern** established by `contact-introductions.spec.ts`. Two callers of this pattern now — worth keeping in mind if a third comes along (lift to a helper at that point).
- **Relationship type by `selectOption({ index: 1 })`** — the seeded type list has deterministic id-ASC ordering per account but the names are i18n'd. Picking the first non-empty option is locale-agnostic and adequate for the existence assertion (the spec doesn't care *which* type, only that the relationship is created).
- **No subscription gate** on `/relationships/create` — explicitly noted by the smoke spec docstring at L956-963 as one of the few flows that works on free accounts. No `has_access_to_paid_version_for_free` toggle needed.

## Tier C status

With this merge, the umbrella's Tier C is **6/6** (C.1 → #766, C.2 → #767, C.3+C.4 → #768, C.5 → #769, C.6 → #770).

## Test plan

- [x] `npx playwright test contact-relationship-create.spec.ts` — passes locally against the dev rig (3.9s, single worker, first try).
- [x] No new helpers added to `tests/playwright/support/`. No source edits.
- [x] `consoleGate.assertNoUnknownErrors` clean over the full create flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
