### PR TITLE
fix(passport): allow access-token modal close after create (#771)

### DIFF
--- a/resources/js/components/passport/PersonalAccessTokens.vue
+++ b/resources/js/components/passport/PersonalAccessTokens.vue
@@ -224,7 +224,14 @@ export default {
      * Close all modals.
      */
     closeModal() {
-      this.$refs.form.reset();
+      // $refs.form is the <form ref="form"> inside the create-modal slot.
+      // After a successful create, showAccessToken() flips
+      // showModalCreateToken = false, which unmounts that slot under
+      // vue-final-modal — so when the access-token modal's footer Close
+      // calls closeModal(), $refs.form is undefined. Without the optional
+      // chain, .reset() threw and the booleans below never ran, leaving
+      // the modal visible. See #771 for the trace.
+      this.$refs.form?.reset();
       this.v$.$reset();
       this.showModalCreateToken = false;
       this.showModalAccessToken = false;

--- a/tests/playwright/specs/personal-access-token-crud.spec.ts
+++ b/tests/playwright/specs/personal-access-token-crud.spec.ts
@@ -64,15 +64,15 @@ test.describe('Monica v4 — personal access tokens CRUD', () => {
     // shape so a config change in the keypair doesn't false-positive.
     expect(accessToken.length).toBeGreaterThan(40);
 
-    // Reload to dismiss the modal and pick up the persisted token from
-    // the server. The footer "Close" button is wired to closeModal() which
-    // calls $refs.form.reset() — but $refs.form was unmounted when the
-    // create modal closed, so closeModal throws before the boolean reset
-    // ever runs (vue 2 → 3 unmount-ordering footgun; see #771). Reload
-    // sidesteps the broken control AND gives a stronger assertion: the
-    // row is present because the token round-tripped to the database,
-    // not because of local-array push() from the create response.
-    await page.reload();
+    // Dismiss the access-token modal via its footer Close button. The
+    // handler is shared closeModal() — see PersonalAccessTokens.vue:226 —
+    // which calls $refs.form?.reset() (the optional chain matters: by
+    // this point the create modal's slot is unmounted, so $refs.form is
+    // undefined; without `?.` closeModal threw and the modal stayed
+    // visible — see #771). Target by `.btn` to disambiguate from the
+    // modal-chrome `×` (also has accessible name "Close" via aria-label).
+    await tokenModal.locator('a.btn', { hasText: 'Close' }).click();
+    await expect(tokenModal).toBeHidden();
 
     // -- List: the new token row renders with its name + a Delete action.
     const row = page.locator('.dt-row', { hasText: tokenName });


### PR DESCRIPTION
## Summary

- `closeModal()` in `PersonalAccessTokens.vue` is wired to both the create modal and the post-create access-token modal. After successful create, the create-modal slot unmounts, so `$refs.form` is undefined by the time the user clicks the access-token modal's Close button — `.reset()` throws and the boolean writes that hide the modal never run.
- Fix: `$refs.form?.reset()`. Minimal patch; `.reset()` still runs when the create modal is open, no-ops when the form ref is gone.
- Updates the D.1 spec (`personal-access-token-crud.spec.ts`) to drive the footer Close button directly instead of `page.reload()` — without the fix, the new assertion times out.

Closes #771.

## Test plan

- [x] `yarn run smoke specs/personal-access-token-crud.spec.ts` — 1/1 ✓ (was 0/1 without the source fix; the spec change alone reproduces the original defect)
- [x] `yarn run smoke specs/dependency-upgrade-smoke.spec.ts` — 42/42 ✓ (no regression on the vuelidate empty-name branch which also touches `PersonalAccessTokens.vue`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
