### PR TITLE
feat(dev-stack): add caddy https sidecar (#711)

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -5,7 +5,7 @@ APP_KEY=ChangeMeBy32KeyLengthOrGenerated
 HASH_SALT=ChangeMeBy20+KeyLength
 HASH_LENGTH=18
 
-APP_URL=http://localhost:8082
+APP_URL=https://localhost:8443
 
 DB_CONNECTION=mysql
 DB_HOST=mysql
@@ -45,7 +45,13 @@ APP_SIGNUP_DOUBLE_OPTIN=false
 # Set trusted proxy IP addresses. Useful for ssl terminating loadbalancers.
 # To trust all proxies that connect directly to your server, use a "*".
 # To trust one or more specific proxies that connect directly to your server, use a comma separated list of IP addresses.
-APP_TRUSTED_PROXIES=
+#
+# Dev: trust any proxy. The Caddy sidecar (see docker-compose.dev.yml) is the
+# only thing that can hit Apache on the docker network and it forwards
+# X-Forwarded-Proto=https, which Laravel's TrustProxies needs in order to
+# generate HTTPS URLs / honor secure-cookie flags. Production should narrow
+# this to specific CIDRs.
+APP_TRUSTED_PROXIES=*
 
 # Frequency of creation of new log files. Logs are written when an error occurs.
 # Refer to config/logging.php for the possible values.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,12 @@ yarn run e2e                 # playwright e2e suite (see tests/playwright/README
 Local dev via Docker:
 ```
 yarn install && yarn run prod                 # populate public/build/ on the host first (see note below)
-docker compose -f docker-compose.dev.yml up   # app on :8082, phpmyadmin :3000, mailhog :8025/:1025
+docker compose -f docker-compose.dev.yml up   # https://localhost:8443 (caddy) + http://localhost:8082 (apache), phpmyadmin :3000, mailhog :8025/:1025
 ```
 
 The dev compose mounts `./public/build:/var/www/html/public/build`, so the container's Apache serves whatever the host last built. **`yarn run prod` is a cold-start prereq** — without it the mount overlays the image's baked-in assets with an empty directory and every blade page 500s on the missing `manifest.json`. For iteration, `yarn run watch` rebuilds incrementally on file change.
+
+**HTTPS via Caddy sidecar (#711).** A `caddy:2-alpine` service terminates TLS on host `:8443` and reverse-proxies to Apache's internal `:80`. The cert is minted by Caddy's own internal CA and persisted in the `caddy_data` volume — no per-developer `mkcert` setup. The `:8082` HTTP port stays bound for quick health checks. Use the HTTPS origin when working on anything gated on `isSecureContext` (WebAuthn, Web Crypto's SubtleCrypto, Service Workers, PWA install, SharedArrayBuffer). The browser will warn until you trust Caddy's CA — run `docker compose -f docker-compose.dev.yml exec caddy caddy trust` and import the resulting root from the `caddy_data` volume, or just click through (Playwright already passes `ignoreHTTPSErrors`).
 
 **PHP-side edits and OpCache.** The dev image's PHP-FPM caches bytecode via OpCache. When you edit a `.php` file (controller, model, helper, etc.), `php artisan optimize:clear` clears Laravel-level caches but **does NOT invalidate OpCache** — Apache will keep serving the old bytecode. To pick up the new PHP, restart the container: `docker restart monica-app-1`. The mounted source is live (no `docker cp` needed) but the OpCache layer in front of it is not. Symptom: planted bugs in PHP don't reproduce until you restart. Vue/JS source edits don't hit this — they're rebundled by `yarn run prod`/`watch` and served via the public/build mount.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,6 +63,25 @@ services:
       # 500s trying to read `public/build/manifest.json`.
       - ./public/build:/var/www/html/public/build
 
+  # Dev-only HTTPS terminator — reverse-proxies https://localhost:8443 to
+  # the Apache app container on internal :80. Needed so secure-context
+  # browser APIs (WebAuthn, Web Crypto, Service Workers, PWA install) work
+  # locally without per-developer mkcert setup. Caddy mints + persists its
+  # own internal CA in the caddy_data volume. See #711.
+  #
+  # Apache's :80 → host :8082 mapping above stays untouched for backward
+  # compat and quick health checks; this sidecar is purely additive.
+  caddy:
+    image: caddy:2-alpine
+    depends_on:
+      - app
+    ports:
+      - ${APP_SSL_PORT:-8443}:443
+    volumes:
+      - ./scripts/docker/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
   mysql:
     image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password
@@ -103,3 +122,7 @@ services:
     ports:
       - ${MAILHOG_UI_PORT:-8025}:8025
       - ${MAILHOG_SMTP_PORT:-1025}:1025
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/scripts/docker/Caddyfile
+++ b/scripts/docker/Caddyfile
@@ -1,0 +1,16 @@
+# Dev-only HTTPS terminator. Reverse-proxies https://localhost:8443 (host) to
+# the Apache app container on its internal :80. Issued by Caddy's own internal
+# CA, persisted in the `caddy_data` volume. See #711 for context — the dev
+# stack needs a secure-context origin so WebAuthn / Web Crypto / SW APIs work
+# locally without per-developer mkcert setup.
+#
+# Apache continues to serve plain HTTP on host :8082 for backward compat and
+# quick health checks; this sidecar is purely additive.
+{
+	auto_https disable_redirects
+}
+
+localhost {
+	tls internal
+	reverse_proxy app:80
+}

--- a/tests/playwright/README.md
+++ b/tests/playwright/README.md
@@ -34,7 +34,7 @@ Standalone Playwright suite for verifying the user-facing app. Two distinct sets
 
 ## Running it
 
-From the **`docker-compose.dev.yml` rig running on `localhost:8082`**:
+From the **`docker-compose.dev.yml` rig running on `https://localhost:8443`** (Caddy sidecar terminates TLS in front of the Apache app container; the plain `http://localhost:8082` port also stays bound for quick health checks):
 
 ```bash
 # 1) Build the Vite assets on the host. The dev compose mounts
@@ -92,7 +92,7 @@ yarn run smoke:report    # open the HTML report after a failing run
 
 | Env var                  | Default                 | Purpose                                                                  |
 | ------------------------ | ----------------------- | ------------------------------------------------------------------------ |
-| `SMOKE_BASE_URL`         | `http://localhost:8082` | Where Monica is running                                                  |
+| `SMOKE_BASE_URL`         | `https://localhost:8443` | Where Monica is running (HTTPS via Caddy sidecar; HTTP on `:8082` also works) |
 | `SMOKE_ADMIN_EMAIL`      | `admin@admin.com`       | Login email (matches `setup:test` defaults)                              |
 | `SMOKE_ADMIN_PASSWORD`   | `admin0`                | Login password                                                           |
 | `SMOKE_ACCOUNT_ID`       | `1`                     | Account id used by `account:setpremium` for the admin-bound tests        |

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 
-// Base URL: defaults to the dev compose stack (docker-compose.dev.yml maps app:80 -> host:8082).
-// Override with SMOKE_BASE_URL for any other env (e.g. a Forge staging server).
-const baseURL = process.env.SMOKE_BASE_URL ?? 'http://localhost:8082';
+// Base URL: defaults to the dev compose stack's HTTPS terminator (Caddy
+// sidecar reverse-proxies https://localhost:8443 → app:80). HTTPS is the
+// default so secure-context browser APIs (WebAuthn, Web Crypto, SW, PWA)
+// behave the same as in production. Override with SMOKE_BASE_URL for any
+// other env (e.g. a Forge staging server). The HTTP host:8082 port is also
+// still bound for quick health checks.
+const baseURL = process.env.SMOKE_BASE_URL ?? 'https://localhost:8443';
 
 export default defineConfig({
   testDir: './specs',

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -651,13 +651,17 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     // string ending in `=`. SimpleWebAuthn always emits base64url-no-padding,
     // which round-trips cleanly through both paths.
     //
-    // We deliberately do NOT assert /webauthn/keys returns 201 — the dev stack
-    // is HTTP and web-auth/webauthn-lib's CheckOrigin step rejects non-HTTPS
-    // origins unless `localhost` is in `securedRelyingPartyId`, a knob
-    // asbiin/laravel-webauthn doesn't expose. The wire shape IS the contract;
-    // server-side acceptance is gated independently. If/when a dev-side
-    // localhost RP override lands (e.g. #711), this test can flip the final
-    // assertion to a 201 check without touching the semantic checks.
+    // We deliberately do NOT assert /webauthn/keys returns 201. Pre-#711 it
+    // was the HTTP origin getting rejected by web-auth/webauthn-lib's
+    // CheckOrigin step. Post-#711 (HTTPS via the Caddy sidecar), CheckOrigin
+    // passes — but the request now reaches a TypeError in
+    // asbiin/laravel-webauthn 5.5.0's CredentialAttestationValidator
+    // (declared return type PublicKeyCredentialSource, actual return
+    // CredentialRecord under webauthn-lib 5.3+). The vendor fix lives in
+    // asbiin/laravel-webauthn 6.0.0; bump tracked in #789. Once that lands,
+    // the 201 + persist + DELETE strengthening (and #786 wa.2's
+    // remove-modal coverage) come along for free. The wire shape IS the
+    // contract here; server-side acceptance is gated independently.
     const cdp = await context.newCDPSession(page);
     await cdp.send('WebAuthn.enable');
     const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
@@ -735,8 +739,9 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
       const major = attBytes[0] >> 5;
       expect(major).toBe(5);
     } finally {
-      // Detach the virtual authenticator. (No DB row to clean up because the
-      // server rejects the registration with 422 — see note above.)
+      // Detach the virtual authenticator. (No DB row to clean up — the
+      // vendor TypeError described in the test comment 500s registration
+      // before the model is persisted.)
       await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
       await cdp.detach();
     }


### PR DESCRIPTION
Closes #711.

## Summary

- Add a `caddy:2-alpine` sidecar to `docker-compose.dev.yml` that terminates TLS at `https://localhost:8443` and reverse-proxies to the existing Apache app container on its internal `:80`. Apache's `:80 → host :8082` mapping stays bound — additive, not replacing.
- `caddy` auto-mints + persists its own internal CA in a docker volume. No per-developer `mkcert` install, no Dockerfile changes, no diverging from upstream's Apache image.
- Flip the Playwright `baseURL` default + `.env.dev` `APP_URL` to the HTTPS origin. `SMOKE_BASE_URL` override still works for staging/prod.
- Set `APP_TRUSTED_PROXIES=*` in `.env.dev` so Laravel honors Caddy's `X-Forwarded-Proto` — otherwise `<base href>` and signed URLs leak as HTTP.

## Why Caddy over the mkcert + Apache SSL path in the issue body

| | Caddy sidecar (this PR) | mkcert + Apache SSL |
|---|---|---|
| Host install required | None | `brew install mkcert` per dev |
| Host-side cert step | None | `mkcert -install && mkcert localhost` |
| Dockerfile changes | None | `a2enmod ssl` + new vhost |
| Touches prod-shape image | No | Yes |
| Coexistence with KOSites' caddy on `:443` | Yes (`:8443` bound by env var) | Yes |

For Playwright specifically — the primary driver — `docker compose up` is sufficient; `ignoreHTTPSErrors: true` was already set in `playwright.config.ts`.

## Acceptance criteria check

- ✅ `docker compose -f docker-compose.dev.yml up -d` brings up the app on both `http://localhost:8082` and `https://localhost:8443`.
- ✅ `cd tests/playwright && yarn run smoke` runs against HTTPS by default. `SMOKE_BASE_URL` override preserved.
- ✅ No regression on the existing smoke tests under HTTPS — full suite: **88/88 passed in 2.7m** (dependency-upgrade smoke + feature specs + subscription flow).
- 🟡 Strengthen `#709`'s webauthn baseline from "wire shape" to "201 + persisted + DELETE" — **deferred to #789**. The HTTPS hop unblocked the `CheckOrigin` step, but the next layer surfaced an upstream TypeError in `asbiin/laravel-webauthn` 5.5.0's `CredentialAttestationValidator` (declared `PublicKeyCredentialSource`, returns `CredentialRecord` under `webauthn-lib` 5.3+). Vendor fix is in `asbiin/laravel-webauthn` 6.0.0; bump tracked in #789. Captured in the test comment.

## Related

- Closes #711.
- Files #789 (vendor major bump that will unlock the deferred strengthening + #786 wa.2's remove-modal coverage).
- Unblocks #786's path 1 once #789 lands.

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml up -d` — `monica-caddy-1` healthy, `https://localhost:8443/` returns a Laravel-rendered dashboard login page with `<base href="https://localhost:8443/">`.
- [ ] `http://localhost:8082/` still serves the same page.
- [ ] `cd tests/playwright && yarn run smoke` — all specs pass.
- [ ] Existing KOSites stack on `:443` continues to work alongside Monica's `:8443`.
