### PR TITLE
chore(deps): bump asbiin/laravel-webauthn 5.5.0 → 6.0.0 (#789, closes #786)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-gmp": "*",
         "ext-intl": "*",
         "ext-redis": "*",
-        "asbiin/laravel-webauthn": "^5.0",
+        "asbiin/laravel-webauthn": "^6.0",
         "bacon/bacon-qr-code": "^3.0",
         "creativeorange/gravatar": "^1.0",
         "erusev/parsedown": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1ca10e81877a7da7a61a05dbca30f45",
+    "content-hash": "a09417cc943b8d473c9f70f6123942ba",
     "packages": [
         {
             "name": "asbiin/laravel-webauthn",
-            "version": "5.5.0",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asbiin/laravel-webauthn.git",
-                "reference": "acbbc70cae2846aa926f84b77b236550c8bf7f66"
+                "reference": "7c65b5fbde8f081fff11ca0127328bc2dd79bd0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asbiin/laravel-webauthn/zipball/acbbc70cae2846aa926f84b77b236550c8bf7f66",
-                "reference": "acbbc70cae2846aa926f84b77b236550c8bf7f66",
+                "url": "https://api.github.com/repos/asbiin/laravel-webauthn/zipball/7c65b5fbde8f081fff11ca0127328bc2dd79bd0e",
+                "reference": "7c65b5fbde8f081fff11ca0127328bc2dd79bd0e",
                 "shasum": ""
             },
             "require": {
@@ -28,11 +28,8 @@
                 "symfony/property-info": "^6.4 || ^7.0",
                 "symfony/serializer": "^6.4 || ^7.0",
                 "web-auth/cose-lib": "^4.0",
-                "web-auth/webauthn-lib": "^4.8 || ^5.2",
+                "web-auth/webauthn-lib": "^5.3",
                 "web-token/jwt-library": "^3.0 || ^4.0"
-            },
-            "conflict": {
-                "web-auth/webauthn-lib": "4.7.0"
             },
             "require-dev": {
                 "brainmaestro/composer-git-hooks": "^3.0",
@@ -105,7 +102,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-30T17:20:50+00:00"
+            "time": "2026-06-02T17:36:35+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -7971,20 +7968,20 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -8024,7 +8021,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.8"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -8044,20 +8041,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.11",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075"
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ed0107e43ab452aa77ae99e005b95e56b556e075",
-                "reference": "ed0107e43ab452aa77ae99e005b95e56b556e075",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
                 "shasum": ""
             },
             "require": {
@@ -8122,7 +8119,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.11"
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8142,7 +8139,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:04:42+00:00"
+            "time": "2026-05-24T08:56:14+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -10888,20 +10885,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.11",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
-                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -10954,7 +10951,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.11"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -10974,7 +10971,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:07:53+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
@@ -11160,20 +11157,20 @@
         },
         {
             "name": "symfony/type-info",
-            "version": "v8.0.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/type-info.git",
-                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866"
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/type-info/zipball/08723aceb8c3271e8cb3db8b2565728b0c88e866",
-                "reference": "08723aceb8c3271e8cb3db8b2565728b0c88e866",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/container": "^1.1|^2.0"
             },
             "conflict": {
@@ -11218,7 +11215,7 @@
                 "type"
             ],
             "support": {
-                "source": "https://github.com/symfony/type-info/tree/v8.0.9"
+                "source": "https://github.com/symfony/type-info/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -11238,7 +11235,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/uid",
@@ -12081,16 +12078,16 @@
         },
         {
             "name": "web-auth/webauthn-lib",
-            "version": "5.3.4",
+            "version": "5.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-auth/webauthn-lib.git",
-                "reference": "dbb2d7a03db5893da2ef1f2898063ab8f7792838"
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/dbb2d7a03db5893da2ef1f2898063ab8f7792838",
-                "reference": "dbb2d7a03db5893da2ef1f2898063ab8f7792838",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/9e0986d999f4102e24ac8a598d3a80d98b56c19f",
+                "reference": "9e0986d999f4102e24ac8a598d3a80d98b56c19f",
                 "shasum": ""
             },
             "require": {
@@ -12151,7 +12148,7 @@
                 "webauthn"
             ],
             "support": {
-                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.4"
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.5"
             },
             "funding": [
                 {
@@ -12163,20 +12160,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-05-18T11:59:46+00:00"
+            "time": "2026-05-31T15:00:08+00:00"
         },
         {
             "name": "web-token/jwt-library",
-            "version": "4.1.6",
+            "version": "4.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-library.git",
-                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1"
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/e8ab00927a3856f3f0c8218226382cd6a58928a1",
-                "reference": "e8ab00927a3856f3f0c8218226382cd6a58928a1",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
+                "reference": "fbcbf2c276d04d8b056f5c2957815abd5dfb704d",
                 "shasum": ""
             },
             "require": {
@@ -12240,7 +12237,7 @@
             ],
             "support": {
                 "issues": "https://github.com/web-token/jwt-library/issues",
-                "source": "https://github.com/web-token/jwt-library/tree/4.1.6"
+                "source": "https://github.com/web-token/jwt-library/tree/4.1.7"
             },
             "funding": [
                 {
@@ -12252,7 +12249,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-04-14T07:44:20+00:00"
+            "time": "2026-06-06T18:12:39+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
+++ b/tests/playwright/specs/dependency-upgrade-smoke.spec.ts
@@ -632,14 +632,16 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     consoleGate.assertNoUnknownErrors('/settings/security');
   });
 
-  test('webauthn registration: virtual authenticator drives the register wire shape (swap contract for #710)', async ({ page, context }) => {
+  test('webauthn registration end-to-end: register persists row, remove-modal deletes it (swap contract for #710; covers #786 wa.2)', async ({ page, context }) => {
     // SWAP CONTRACT — locks in @simplewebauthn/browser's POST /webauthn/keys
     // wire shape against what web-auth/webauthn-lib's PHP server expects.
     //
     // What this exercises:
     //   1. POST /webauthn/keys/options  (server generates challenge + opts) → 200
     //   2. navigator.credentials.create() via a CDP-supplied virtual authenticator
-    //   3. POST /webauthn/keys           (registration request body)
+    //   3. POST /webauthn/keys           (registration → 201 + persisted row)
+    //   4. row appears in /settings/security
+    //   5. DELETE /webauthn/keys/{id}   (remove-modal flow → 204 + row gone)
     //
     // Semantic asserts below mirror the server's decoder chain:
     //   - id            → Base64UrlSafe::decodeNoPadding   (strict)
@@ -651,17 +653,13 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
     // string ending in `=`. SimpleWebAuthn always emits base64url-no-padding,
     // which round-trips cleanly through both paths.
     //
-    // We deliberately do NOT assert /webauthn/keys returns 201. Pre-#711 it
-    // was the HTTP origin getting rejected by web-auth/webauthn-lib's
-    // CheckOrigin step. Post-#711 (HTTPS via the Caddy sidecar), CheckOrigin
-    // passes — but the request now reaches a TypeError in
-    // asbiin/laravel-webauthn 5.5.0's CredentialAttestationValidator
-    // (declared return type PublicKeyCredentialSource, actual return
-    // CredentialRecord under webauthn-lib 5.3+). The vendor fix lives in
-    // asbiin/laravel-webauthn 6.0.0; bump tracked in #789. Once that lands,
-    // the 201 + persist + DELETE strengthening (and #786 wa.2's
-    // remove-modal coverage) come along for free. The wire shape IS the
-    // contract here; server-side acceptance is gated independently.
+    // The 201 + row + DELETE round-trip became possible across two
+    // dependency moves: #711 (Caddy sidecar — HTTPS origin so
+    // CheckOrigin passes) and #789 (asbiin/laravel-webauthn 6.0.0 —
+    // CredentialAttestationValidator return type aligned with
+    // webauthn-lib 5.3's CredentialRecord). Before #789 the request 500'd
+    // with a TypeError after CheckOrigin passed; this spec was limited to
+    // shape-only checks.
     const cdp = await context.newCDPSession(page);
     await cdp.send('WebAuthn.enable');
     const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
@@ -697,6 +695,8 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
         r.url().endsWith('/webauthn/keys/options') && r.request().method() === 'POST');
       const storeReq = page.waitForRequest((r) =>
         /\/webauthn\/keys$/.test(r.url()) && r.method() === 'POST');
+      const storeResp = page.waitForResponse((r) =>
+        /\/webauthn\/keys$/.test(r.url()) && r.request().method() === 'POST');
 
       await modal.getByRole('link', { name: 'Next' }).click();
 
@@ -738,10 +738,46 @@ test.describe('Monica v4 — dependency-upgrade smoke walkthrough', () => {
       const attBytes = decodeBase64UrlNoPadding(requestBody.response.attestationObject);
       const major = attBytes[0] >> 5;
       expect(major).toBe(5);
+
+      // Server accepts the registration: 201 + JSON envelope with the new
+      // WebauthnKey model. Response shape comes from asbiin/laravel-webauthn's
+      // RegisterSuccessResponse::jsonResponse: { result: <model>, callback }.
+      const storeResponse = await storeResp;
+      expect(storeResponse.status()).toBe(201);
+      const storeBody = await storeResponse.json();
+      const keyId = storeBody?.result?.id;
+      expect(typeof keyId).toBe('number');
+
+      // The Vue connector reactively appends the new key to its `currentkeys`
+      // list, so the row is visible without a fresh navigation.
+      const row = page.locator('li.table-row').filter({ hasText: keyName });
+      await expect(row).toBeVisible();
+
+      // Drive the remove-key modal (closes #786 wa.2 — the WA.2 thread
+      // deferred from #781). The modal is a separate <monica-modal> with
+      // title "Remove a key"; scope by that body copy so we don't collide
+      // with the still-mounted register modal.
+      await row.getByRole('link', { name: /^Delete$/i }).click();
+
+      const deleteModal = page.locator('.monica-modal__panel').filter({ hasText: 'Remove a key' }).first();
+      await expect(deleteModal).toBeVisible();
+
+      const deleteResp = page.waitForResponse((r) =>
+        /\/webauthn\/keys\/\d+$/.test(r.url()) && r.request().method() === 'DELETE');
+
+      await deleteModal.getByRole('link', { name: /^Delete$/i }).click();
+
+      const deleteResponse = await deleteResp;
+      // asbiin/laravel-webauthn's DestroyResponse::toResponse returns 204
+      // No Content for JSON callers.
+      expect(deleteResponse.status()).toBe(204);
+      expect(deleteResponse.url()).toMatch(new RegExp(`/webauthn/keys/${keyId}$`));
+
+      // Row gone — the splice on `currentkeys` removes it from the rendered
+      // list. (Single-key path, so the indexOf-undefined bug in
+      // WebauthnConnector.vue:357 doesn't bite here; flagged in #786 body.)
+      await expect(row).toHaveCount(0);
     } finally {
-      // Detach the virtual authenticator. (No DB row to clean up — the
-      // vendor TypeError described in the test comment 500s registration
-      // before the model is persisted.)
       await cdp.send('WebAuthn.removeVirtualAuthenticator', { authenticatorId });
       await cdp.detach();
     }


### PR DESCRIPTION
Closes #789. Closes #786.

## Summary

- Bump `asbiin/laravel-webauthn` `^5.0 → ^6.0`. The 6.0.0 release aligns `CredentialAttestationValidator`'s declared return type with `webauthn-lib` 5.3's `CredentialRecord` (replacing the deprecated `PublicKeyCredentialSource`). That's the entire breaking-change surface — five vendor source files swap one type for another, and the composer floor on `web-auth/webauthn-lib` moves from `^4.8 || ^5.2` to `^5.3`.
- Strengthen `tests/playwright/specs/dependency-upgrade-smoke.spec.ts` from "wire shape only" to the full `register → 201 → row visible → remove-modal → DELETE 204 → row gone` round-trip. Closes the WA.2 thread deferred from #781.

## Why this is Monica-safe despite the major-version bump

`grep -rn` across `app/` + `routes/` + `config/` found no caller of:
- `Webauthn::create()` facade
- `WebauthnRepository::create()`
- `CredentialRepository::getAllRegisteredKeys()` (protected anyway)
- `WebauthnKey::publicKeyCredentialSource` attribute (we read flat Eloquent columns via `App\Http\Resources\Settings\WebauthnKey`)
- Any direct type-hint on `PublicKeyCredentialSource`

The renamed type sits entirely behind the vendor's controller boundary. Monica's code path goes `HTTP route → asbiin's WebauthnKeyController → asbiin's internals (where the rename lives) → returns a `WebauthnKey` Eloquent model → our JsonResource serializes flat columns`. None of that surface changed.

Composer constraint floor: we're already on `web-auth/webauthn-lib` 5.3.4 (bumped to 5.3.5 as a side-effect of the update), so the `^5.3` floor on the vendor side doesn't ripple.

## Verification

| Check | Result |
| --- | --- |
| `vendor/bin/phpunit` (full) | **1748 tests / 13400 assertions OK** in 1m48s |
| `vendor/bin/phpstan analyse` | **No errors** |
| Playwright (full suite, HTTPS) | **88 passed** in 2.9m |
| End-to-end WebAuthn register + delete (strengthened smoke) | green — `POST /webauthn/keys` 201, row visible, `DELETE /webauthn/keys/{id}` 204, row gone |

## Incidental updates pulled in by `--with-dependencies`

All minor/patch (no other breaking semver):

- `web-token/jwt-library` 4.1.6 → 4.1.7
- `web-auth/webauthn-lib` 5.3.4 → 5.3.5
- `symfony/clock` v8.0.8 → v8.1.0
- `symfony/console` v7.4.11 → v7.4.13
- `symfony/string` v8.0.11 → v8.1.0
- `symfony/type-info` v8.0.9 → v8.1.0

No `spatie/ray` reintroduction; the `replace` block in `composer.json` continues to do its defense-in-depth job (verified by inspecting `composer.lock` for `spatie/ray`).

## Test plan

- [ ] `composer install` cleanly in CI.
- [ ] PHPUnit + PHPStan green in CI (already green locally).
- [ ] Playwright smoke green in CI (the strengthened spec is the new gate).
- [ ] Manual: in dev, register a security key on `/settings/security` via a real authenticator (or the CDP virtual one), confirm the row persists; click Delete on the row, confirm the modal opens, click Delete inside, confirm the row disappears.
