### PR TITLE
fix(vue3): close deferred $refs-after-unmount audit from #743

### DIFF
--- a/docs/review-rules/vue3-proxy-after-unmount.md
+++ b/docs/review-rules/vue3-proxy-after-unmount.md
@@ -1,52 +1,41 @@
 # Vue 3 review rule — don't touch the proxy after self-unmount
 
 > Closes #743. First exemplar: #742 (CreateGift two-microtask crash). Related: #771 → #773 (PAT modal `$refs.form` TypeError).
+>
+> **Status:** Flavour 1 (`$t` after unmount) is structurally resolved by #744 (vue-i18n composition-mode migration — `t` is closure-captured by `useI18n()` and survives instance teardown). Flavour 2 (`$refs.X.method()` after unmount) is the remaining live concern; the deferred sweep was done in [this PR] and its findings are folded into the audit table below.
 
-When a Vue component fires a method that triggers its own unmount — typical patterns are `this.close()`, `this.$emit('cancel')`, mutating a parent-controlled state prop that flips a `v-if` off — **everything else on that instance dies on the next microtask**: `this.$t`, `this.$refs`, `this.$emit('update', ...)`, `this.$nextTick`, and data reads via `this.someProp`. Anything past the unmount line in the same call stack is fine (still inside one microtask). Anything *after* a `then` / `await` boundary is not.
+When a Vue component fires a method that triggers its own unmount — typical patterns are `this.close()`, `this.$emit('cancel')`, mutating a parent-controlled state prop that flips a `v-if` off — **everything else on that instance dies on the next microtask**: `this.$refs`, `this.$emit('update', ...)`, `this.$nextTick`, and data reads via `this.someProp`. Anything past the unmount line in the same call stack is fine (still inside one microtask). Anything *after* a `then` / `await` boundary is not.
 
-This is the predictable consequence of how Vue 3 + vue-i18n@10 (legacy mode) install per-instance plugin bindings on `instance.ctx`, which Vue clears at unmount. Vue 2 + vue-i18n@8 put those bindings on `Vue.prototype`, so prototype-chain lookup still resolved after the instance was destroyed — code that worked for years started crashing on the cutover (#730). It is not in the Vue 3 migration guide, not in vue-i18n's docs, and only surfaces through linked issues: [vue-i18n#1440](https://github.com/kazupon/vue-i18n/issues/1440), [vue-i18n#184](https://github.com/kazupon/vue-i18n/issues/184).
+This is the predictable consequence of how Vue 3 installs per-instance state on `instance.ctx`, which Vue clears at unmount. The historical `$t` flavour (Flavour 1, below) had the same root cause via vue-i18n's legacy-mode `$t` binding on `instance.ctx` — code that worked for years on Vue 2 + vue-i18n@8 (where bindings sat on `Vue.prototype`) started crashing on the cutover (#730). Migrating to vue-i18n composition mode (#744) closed that subclass: `t` is now a setup-time closure, not a proxy property. The `$refs` flavour remains because Vue clears `instance.refs` at unmount and there is no equivalent escape hatch for components still using Options-API `this.$refs` (composition-API code can use `useTemplateRef()` to closure-capture; that's not on the ladder).
+
+For background, the original vue-i18n issues that surfaced the proxy-clear behavior: [vue-i18n#1440](https://github.com/kazupon/vue-i18n/issues/1440), [vue-i18n#184](https://github.com/kazupon/vue-i18n/issues/184).
 
 ## The rule
 
-> When a method calls `this.close()` / `$emit('cancel')` / anything else that triggers parent-side unmount, all subsequent work on the component instance — `$t`, `$emit('update')`, `$refs`, data reads, `$nextTick` — must happen in the **same** `.then` body (single microtask). If it spans `.then` blocks or crosses an `await`, capture i18n strings and per-instance plugin output to locals **before** the close call.
+> When a method calls `this.close()` / `$emit('cancel')` / anything else that triggers parent-side unmount, all subsequent work on the component instance — `$emit('update')`, `$refs`, data reads, `$nextTick` — must happen in the **same** `.then` body (single microtask). If it spans `.then` blocks or crosses an `await`, capture per-instance plugin output to locals **before** the close call. For `$refs.X.method()` reachable after sibling/slot unmount, use `$refs.X?.method()`.
 
 Equivalent rule for `async`/`await` code: don't `await` between a self-close and any `this.$x` access.
 
 ## Two flavours, same root cause
 
-### Flavour 1 — `$t` / vue-i18n legacy (the #742 crash)
+### Flavour 1 — `$t` / vue-i18n legacy (the #742 crash) — **RESOLVED by #744**
+
+Historical pattern; included here for reviewers reading older PRs / blame. Composition-mode `useI18n()` destructures `t` as a closure (`const { t } = useI18n()` in `setup()`), and the closure outlives the instance — so the original crash no longer reproduces:
 
 ```js
-// BROKEN — close() in .then #1, $t in .then #2 → unmount flush between them
+// HISTORICAL — legacy-mode vue-i18n. Crashed in #742 because vm.$t became
+// undefined after the unmount flushed between the two .then blocks.
 store() {
   const vm = this;
   axios.post(url, payload)
-    .then(r => {
-      vm.close();                                     // parent flips v-if → unmount scheduled
-      vm.$emit('update', r.data.data);                // still safe (same microtask)
-      return r;
-    })
-    .then(() => {
-      vm.$notify({ title: vm.$t('app.success') });    // CRASH: vm.$t is undefined post-unmount
-    });
+    .then(r => { vm.close(); vm.$emit('update', r.data.data); return r; })
+    .then(() => { vm.$notify({ title: vm.$t('app.success') }); });
 }
 ```
 
-```js
-// FIXED — capture before close, OR collapse into one .then body
-store() {
-  const vm = this;
-  const successTitle = vm.$t('app.success');          // capture i18n strings to locals first
-  axios.post(url, payload)
-    .then(r => {
-      vm.$emit('update', r.data.data);
-      vm.close();
-      vm.$notify({ title: successTitle });            // local, not vm.$t
-    });
-}
-```
+After #744, `$t` is gone from the codebase (`globalInjection: false`) and code uses `t` from a `setup()`-scoped destructure — closure-captured, survives unmount. The structural fix is in place; no rule needed for this flavour.
 
-### Flavour 2 — `$refs` after slot unmount (the #771 crash)
+### Flavour 2 — `$refs` after slot unmount (the #771 crash) — **LIVE**
 
 ```js
 // BROKEN — second modal's Close button fires closeModal() after the first modal's slot unmounted
@@ -76,9 +65,9 @@ A single `.then` callback runs as one synchronous block on a single microtask. V
 
 `globalProperties`-installed plugins survive the unmount because they're resolved via the proxy's fall-through to `appContext.config.globalProperties` — that map is app-scoped, not instance-scoped. Plugins that survive: `$notify` (from `@kyvg/vue3-notification`), most third-party plugins installed via `app.config.globalProperties.$x = ...`. Plugins that die: vue-i18n legacy `$t`, vuelidate-style instance state, anything installed via `Vue.mixin('beforeCreate', function() { this.$x = ... })` that writes to `this.$x`. **`$refs` always dies** at unmount.
 
-## Audit done as part of #742
+## Flavour-1 audit (done as part of #742) — historical
 
-Greped every `vm = this` capture across `resources/js/` — 11 sites in 7 files:
+Greped every `vm = this` capture across `resources/js/` at the time of #742 — 11 sites in 7 files:
 
 | File | Pattern | Vulnerable? |
 |------|---------|-------------|
@@ -91,20 +80,52 @@ Greped every `vm = this` capture across `resources/js/` — 11 sites in 7 files:
 | `people/ContactInformation.vue` | `_.each(data, fn)` with `vm.$t` inside (synchronous) | No |
 | `people/gifts/Gifts.vue` | computed property filter using `vm.activeTab` | No |
 
-The `$refs` flavour audit hasn't been done as a sweep — #771 was found via the #781 D.1 spec authoring. A future audit would grep `$refs\.\w+\.` (refs followed by method call) and check whether the call site could fire after a sibling unmount.
+Made moot by #744 — `$t` no longer exists in components.
+
+## Flavour-2 audit (deferred from #771, completed in [this PR])
+
+Greped `$refs\.\w+\.` across `resources/js/components/` — 28 method-call sites in 17 files. Classification:
+
+| File:line | Pattern | Vulnerable? | Action |
+|-----------|---------|-------------|--------|
+| `passport/PersonalAccessTokens.vue:234` | `$refs.form?.reset()` in `closeModal()` after sibling unmount | **Yes** | Already fixed (#771 → #773) |
+| `passport/Clients.vue:364` | `$refs.form.reset()` in `closeModal()` | No | Looks like the #771 shape, but the secret modal binds Close to a separate `closeSecretModal()` that never touches `$refs.form` — so the create-modal `closeModal` only fires while the create modal (and its form) is mounted. Documented in `tests/playwright/specs/oauth-client-crud.spec.ts:23-27`. |
+| `people/calls/PhoneCallList.vue:381` | `$parent.$refs.lastCalledAttribute.getLastCalled()` after axios `.then` | **Yes** | Add `?.` chain through parent/refs (this PR) |
+| `people/gifts/CreateGift.vue:426` | `$refs.upload.forceFileUpload()` in store() axios `.then` chain | **Yes** | Guard via local + early return (this PR) |
+| `people/gifts/CreateGift.vue:453` | `$refs.upload.showUploadZone()` in deletePhoto axios `.then` | **Yes** | Add `?.` (this PR) |
+| `partials/form/Date.vue:177` | `$refs.picker?.openMenu?.()` | (defensive) | Already defensive |
+| `people/photo/PhotoUpload.vue:146` | `this.$refs.file !== undefined ? this.$refs.file.files[0] : undefined` | (defensive) | Already defensive via undefined check |
+| `settings/Subscription.vue:260` | `$refs.form.submit()` in `setTimeout(…, 10)` | No | Page-level component, no unmount path between schedule and fire |
+| `settings/ContactFieldTypes.vue:384,394` | `setTimeout(() => vm.$refs.X.focus(), 10)` | No | Settings page, no unmount path |
+| `passport/PersonalAccessTokens.vue:246` | same setTimeout focus idiom | No | Same reasoning |
+| `passport/Clients.vue:253` | same setTimeout focus idiom | No | Same reasoning |
+| `people/Tags.vue:158` | `$nextTick(() => $refs.tags.focus())` after `editMode = true` | No | Self-toggle, same component |
+| `people/SetAvatar.vue:188,191,205` | `getCroppedCanvas()`, `uploadedImg.files` | No | Synchronous, within same click handler, clipper mounted while modal open |
+| `people/document/DocumentList.vue:297` | `$refs.file.files[0]` in change handler | No | Live during the input's own change event |
+| `people/gifts/CreateGift.vue:82,147` | inline template handlers, refs always-mounted via `v-show` or same `v-if` parent | No | Refs always live at the click moment |
+| `people/photo/PhotoList.vue:14,19` | inline handlers; `photo-upload ref="upload"` is unconditional | No | Always mounted |
+| `partials/SpecialDate.vue:241,246,251` | `$refs.X.focus()` in input handlers | No | Same-component native refs |
+| `partials/SpecialDeceased.vue:134` | `$refs.deaceasedday.focus()` | No | Same-component |
+| `partials/form/PInput.vue:123,124,127` | `$refs.input.checked` toggle | No | Self-instance native input ref |
+| `partials/form/Input.vue:162` | `$refs.input.focus()` | No | Self-instance |
+| `partials/form/Select.vue:167` | `$refs.select.focus()` | No | Self-instance |
+
+Five sites required fixes (one already done in #771, four in this PR). The rest are documented above as audited-safe so reviewers don't have to redo the analysis.
 
 ## Forcing function
 
-This whole class of bug goes away when we migrate vue-i18n from legacy mode to the Composition API (`useI18n()`), because `t` is then a setup-time closure that survives instance teardown. The `$refs` flavour goes away with `useTemplateRef()` for the same reason — closure-captured. Both are larger ladder rungs; until then, this rule stands.
+The `$refs` flavour goes away when components migrate to `useTemplateRef()` in `setup()` — closure-captured, survives instance teardown. That requires either `<script setup>` or composition-API rewrites, both explicitly out of scope per #702. Until then, this rule stands.
+
+The `$t` flavour is already gone — see Flavour 1 status note above.
 
 ## Reviewer checklist
 
 When reviewing a Vue SFC change, scan for:
 
-- [ ] `.then` chain with `close()` / `$emit('cancel')` in one block and any `$t` / `$emit('update')` / `$refs.X.method()` in a later block → flag.
-- [ ] `async fn() { ... ; this.close(); await ...; this.$t(...); }` → flag.
 - [ ] `$refs.X.method()` call inside a handler that *might* fire after a sibling modal/slot unmount → require `$refs.X?.method()` or hoist into the live-instance path.
-- [ ] `setTimeout(() => vm.$x, 10)` where `vm.$x` is `$t`/`$refs`/`$emit('update')` and the setTimeout could fire after unmount → flag (same root cause, different scheduler).
+- [ ] `$refs.X.method()` inside an axios `.then` / `await` whose component can be unmounted before the promise resolves → require `?.` or capture a local guard before the boundary.
+- [ ] `setTimeout(() => vm.$refs.X, ...)` where the timeout could fire after unmount → flag (same root cause, different scheduler).
+- [ ] `$parent.$refs.X.method()` — also chain through with `?.`; parents unmount too.
 
 ## References
 

--- a/docs/review-rules/vue3-proxy-after-unmount.md
+++ b/docs/review-rules/vue3-proxy-after-unmount.md
@@ -2,7 +2,7 @@
 
 > Closes #743. First exemplar: #742 (CreateGift two-microtask crash). Related: #771 → #773 (PAT modal `$refs.form` TypeError).
 >
-> **Status:** Flavour 1 (`$t` after unmount) is structurally resolved by #744 (vue-i18n composition-mode migration — `t` is closure-captured by `useI18n()` and survives instance teardown). Flavour 2 (`$refs.X.method()` after unmount) is the remaining live concern; the deferred sweep was done in [this PR] and its findings are folded into the audit table below.
+> **Status:** Flavour 1 (`$t` after unmount) is structurally resolved by #744 (vue-i18n composition-mode migration — `t` is closure-captured by `useI18n()` and survives instance teardown). Flavour 2 (`$refs.X.method()` after unmount) is the remaining live concern; the deferred sweep was done in #795 and its findings are folded into the audit table below.
 
 When a Vue component fires a method that triggers its own unmount — typical patterns are `this.close()`, `this.$emit('cancel')`, mutating a parent-controlled state prop that flips a `v-if` off — **everything else on that instance dies on the next microtask**: `this.$refs`, `this.$emit('update', ...)`, `this.$nextTick`, and data reads via `this.someProp`. Anything past the unmount line in the same call stack is fine (still inside one microtask). Anything *after* a `then` / `await` boundary is not.
 
@@ -82,7 +82,7 @@ Greped every `vm = this` capture across `resources/js/` at the time of #742 — 
 
 Made moot by #744 — `$t` no longer exists in components.
 
-## Flavour-2 audit (deferred from #771, completed in [this PR])
+## Flavour-2 audit (deferred from #771, completed in #795)
 
 Greped `$refs\.\w+\.` across `resources/js/components/` — 28 method-call sites in 17 files. Classification:
 

--- a/resources/js/components/people/calls/PhoneCallList.vue
+++ b/resources/js/components/people/calls/PhoneCallList.vue
@@ -378,7 +378,10 @@ export default {
     },
 
     updateLastCalled() {
-      this.$parent.$refs.lastCalledAttribute.getLastCalled();
+      // Called from axios .then handlers — if the parent (contact page) has
+      // unmounted between request and response, $parent or its refs are gone.
+      // Same root cause as #743: per-instance state is cleared at unmount.
+      this.$parent?.$refs?.lastCalledAttribute?.getLastCalled();
     },
 
     showEditBox(call) {

--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -423,7 +423,12 @@ export default {
 
     storePhoto(response) {
       const vm = this;
-      return this.$refs.upload.forceFileUpload()
+      // $refs.upload is under v-show, so usually live — but storePhoto runs
+      // inside store()'s axios .then chain, and if the modal closes before
+      // the save resolves the ref evaporates.
+      const upload = this.$refs.upload;
+      if (!upload) return Promise.resolve(response);
+      return upload.forceFileUpload()
         .then(photo => {
           if (photo !== undefined) {
             axios.put(`people/${this.hash}/gifts/${response.data.data.id}/photo/${photo.id}`);
@@ -450,7 +455,7 @@ export default {
         .then(response => {
           this.photos.splice(this.photos.indexOf(photo), 1);
           if (this.photos.length === 0) {
-            this.$refs.upload.showUploadZone();
+            this.$refs.upload?.showUploadZone();
           }
         });
     },


### PR DESCRIPTION
## Summary

Closes the deferred `$refs`-after-unmount sweep that was tracked as a "future audit" footnote in `docs/review-rules/vue3-proxy-after-unmount.md` (originally #743). Three live fixes + a full audit table folded into the review rule.

The other flavour the rule covered (`$t` after unmount) is structurally resolved by #744 — vue-i18n composition-mode migration made `t` a setup-time closure that survives instance teardown, so the original #742 crash class no longer reproduces. The rule is updated to reflect that.

## What's fixed

| File | Issue |
|---|---|
| `people/calls/PhoneCallList.vue:381` | `$parent.$refs.lastCalledAttribute.getLastCalled()` after axios `.then` — parent contact page can unmount on route change |
| `people/gifts/CreateGift.vue:426` | `$refs.upload.forceFileUpload()` inside `store()`'s axios `.then` chain — modal/component can be torn down before the save resolves |
| `people/gifts/CreateGift.vue:453` | `$refs.upload.showUploadZone()` inside `deletePhoto()`'s axios `.then` — same shape |

All three were unguarded `$refs.X.method()` calls reachable after an async boundary. Fixed with optional chaining (`?.`) or a local guard + early return where the method needs to return a promise (CreateGift `storePhoto`).

## What's documented

Full classification of all 28 `$refs.X.method()` callsites in `resources/js/components/` lives in the review rule. Notable non-fix: `passport/Clients.vue:364` looks like the same shape as the #771 PAT crash, but its secret modal binds Close to a separate `closeSecretModal()` handler — caught while sanity-checking against `tests/playwright/specs/oauth-client-crud.spec.ts:23-27`, which already documented this safety.

## Test plan

- [x] `yarn run lint` — 0 new errors/warnings on changed files (142 pre-existing warnings elsewhere unchanged)
- [x] `yarn run prod` — clean build in 4s
- [ ] CI green on this PR
- [ ] Optional manual smoke: edit a contact's phone call → save → confirm the "last called" attribute updates on the contact page; create a gift with a photo → confirm the upload path still works; delete the last photo on a gift → confirm the upload zone re-opens

## Why this isn't bigger

The structurally-clean fix is `useTemplateRef()` in `setup()` — closure-captured, immune to instance teardown. Both that and broader composition-API migration are explicitly out of scope per #702 ("composition-API rewrites are out of scope for the cutover"). Until that changes, the rule + defensive `?.` is the right tier.
