### PR TITLE
refactor: open modernization track + service-layer cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A community maintenance fork of Monica v4 (Laravel 12 + Vue 3.5 personal CRM). The default branch is `4.x`, pinned to the upstream v4.1.2 release (`32028ce`) plus a maintenance ladder of follow-on fixes (PHP 8.4, Laravel 12, Vue 3.5, Vite 8). See `README.md` for the full posture; the short version is: **stability is the feature, no new features, no rewrite, no UI redesign.**
+A community maintenance fork of Monica v4 (Laravel 12 + Vue 3.5 personal CRM). The default branch is `4.x`, pinned to the upstream v4.1.2 release (`32028ce`) plus a maintenance ladder of follow-on fixes (PHP 8.4, Laravel 12, Vue 3.5, Vite 8). See `README.md` for the full posture; the short version is: **no new features, no UI redesign, no full-SPA conversion — but internal modernization (Composition API, TypeScript on the frontend, dropping Bootstrap 4 + jQuery, service-layer cleanup) is explicitly in scope.**
 
 If `CLAUDE.local.md` and `.migration/` exist in your working tree, they hold fork-local context that isn't checked in — read them first when present. The triage workbench in `.migration/triage.db` is a SQLite mirror of the upstream issue tracker; it's where decisions about the imported backlog live before anything is applied to the fork on GitHub.
 
@@ -86,7 +86,7 @@ Standard Laravel + Vue monolith. Worth knowing before changing things:
 - `Contacts/`, `Settings/`, `Account/`, `Auth/`, `Settings/`, `DAV/` — server-rendered Blade views in `resources/views/`.
 - `DAV/` is the CardDAV/CalDAV surface via `sabre/dav` + `monicahq/laravel-sabre`.
 
-**Frontend is mixed-paradigm.** Most pages are Blade templates with islands of Vue 3 components mounted by `resources/js/app.js` (via `createApp(...)`). Components live in `resources/js/components/` and are still on the Options API — composition-API rewrites were explicitly out of scope for the cutover (#702) and remain so. **Do not introduce jQuery for new behaviour** (the existing jQuery is legacy); use Vue. New CSS should prefer Tachyons utility classes over new SASS — Bootstrap is being phased out.
+**Frontend is mixed-paradigm.** Most pages are Blade templates with islands of Vue 3 components mounted by `resources/js/app.js` (via `createApp(...)`). Components live in `resources/js/components/`. As of 2026-06 all 82 SFCs are still on the Options API — Composition API conversion was out of scope for the Vue 3 cutover (#702) but is now an active modernization track (see `## Fork-specific scope` below). New components or files being touched substantively should land in `<script setup lang="ts">`. **Do not introduce jQuery for new behaviour** (the existing jQuery is legacy Bootstrap-plugin glue and is on the removal list); use Vue. New CSS should prefer Tachyons utility classes over new SASS — Bootstrap 4 is being phased out.
 
 **Localization.** Source strings live in `resources/lang/en/*.php`. Crowdin owns every other locale — don't edit non-`en` files by hand. Strings used in Vue need `php artisan lang:generate` to be regenerated into JS, then `yarn run prod` to bundle them. PHP side uses `trans('file.key')`. Vue side uses `vue-i18n` in composition mode — destructure `t` from `useI18n()` in `setup()` and call `t('file.key')` (plural form: `t('file.key', namedParams, count)`). There is no template `$t` fallback — `globalInjection: false`. The legacy `$tc` helper is gone (dropped from vue-i18n 11's legacy mode and from composition mode entirely; use `t` with the count argument).
 
@@ -126,6 +126,7 @@ Anything not on the modernization ladder is out of scope. The ladder, in rough p
 
 1. Continued security patches against the current dependency graph (`composer audit` / `yarn audit` reduction)
 2. Triage of the imported issue and PR queue
+3. **Frontend modernization** (active): Options API → Composition API with TypeScript adoption on the .vue side; typing the shared `.js` modules in `resources/js/` first so their types flow into the eventual Vue rewrites; dropping Bootstrap 4 + jQuery in favour of Tachyons-only. Constraint: zero user-facing behaviour change.
 
 Already landed (kept here as context for older docs that may still list these as "things we plan to do"):
 
@@ -134,13 +135,13 @@ Already landed (kept here as context for older docs that may still list these as
 - Modern Node / build chain (Vite 8 + `@vitejs/plugin-vue 6`)
 - Vue 2.7 → Vue 3.5 cutover (#730) and post-cutover cleanups: vue-i18n composition-mode migration (#744 + #746/#755/#756/#757/#758), `vue-final-modal` `useModal()` composable (#724), Vitest harness (#759)
 
-Hard constraints carried in from the README and `CLAUDE.local.md`:
+Hard constraints:
 
-- **No new features.** Stability is the feature.
-- **No architectural refactors.** Match upstream's structure.
-- **No UI redesigns.**
+- **No new features.** User-facing functionality is frozen at the upstream v4.1.2 surface plus the bug fixes that have shipped in this fork. Internal refactors that don't change behaviour are fine.
+- **No UI redesigns.** Visual design and information architecture stay as upstream shipped them. Class swaps (Bootstrap → Tachyons) that produce visually-equivalent output are not UI redesigns.
+- **No full-SPA conversion.** The Blade-rendered pages with Vue-component islands architecture stays. Refactors inside that hybrid (Composition API, TypeScript, dropping Bootstrap/jQuery, service-layer cleanup) are explicitly in scope.
 
-If you're being asked to do something that doesn't fit one of those rungs, stop and confirm with the user before proceeding.
+If you're being asked to do something that doesn't fit those constraints, stop and confirm with the user before proceeding.
 
 ## Triage workbench
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,20 @@ successor work. Those existing v4 deployments still need:
 - working Docker images and build pipelines
 - responses to bug reports
 
-This fork exists to provide exactly that — **nothing more, nothing less**.
-The goal is to keep v4 alive, secure, and runnable for the people who
-already rely on it. No rewrite. No new vision. No competing roadmap.
+This fork exists to provide exactly that, while modernizing the codebase's
+internals enough to keep contributing to it pleasant. The goal is to keep
+v4 alive, secure, runnable, and maintainable for the people who already
+rely on it. No new features. No UI redesigns. No competing roadmap.
 
 ## What this fork is not
 
 - **Not a hostile fork.** We have no quarrel with upstream. We hold the
   Monica maintainers in the highest regard for nearly a decade of work
   that made any of this possible.
-- **Not a rewrite.** We are intentionally *not* redesigning the codebase.
-  Stability is the feature.
+- **Not a user-facing rewrite.** We are not redesigning the UI, adding
+  new features, or changing the data model. Internal modernization that
+  keeps user-facing behaviour identical (Composition API, TypeScript on
+  the frontend, dropping Bootstrap 4 + jQuery) is in scope.
 - **Not the official Monica.** The Monica name and brand belong to
   Monica HQ SAS. This is a community maintenance fork distributed under
   the original AGPL-3.0-or-later license.
@@ -43,6 +46,9 @@ In rough priority order, the things we plan to do:
    (`composer audit` and `yarn audit` reduction)
 2. Triage of the imported issue and PR queue, cherry-picking valuable
    community contributions that were never merged upstream
+3. Internal modernization of the frontend layer: Options API →
+   Composition API, TypeScript adoption, dropping Bootstrap 4 + jQuery
+   in favour of Tachyons. Constraint: zero user-facing behaviour change.
 
 Already landed in the modernization ladder:
 
@@ -58,8 +64,9 @@ Things we will not do:
 
 - New features beyond what is needed to keep existing functionality
   working on modern infrastructure
-- Architectural refactors
-- UI redesigns
+- UI redesigns or changes to user-facing behaviour
+- Full-SPA conversion — the Blade-rendered pages with Vue-component
+  islands architecture stays
 - Forking the name, the docs, the marketing site, or the hosted product
 
 For specific in/out decisions that aren't obvious from the code (e.g. which

--- a/app/Http/Controllers/Auth/Validate2faController.php
+++ b/app/Http/Controllers/Auth/Validate2faController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Auth;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Route;
-use PragmaRX\Google2FALaravel\Facade as Google2FA;
 
 class Validate2faController extends Controller
 {
@@ -25,11 +24,5 @@ class Validate2faController extends Controller
         }
 
         return redirect()->route('login');
-    }
-
-    public static function loginCallback()
-    {
-        app('pragmarx.google2fa')->setStateless(false);
-        Google2FA::login();
     }
 }

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -14,7 +14,6 @@ use App\Models\Contact\Contact;
 use App\Jobs\AddContactFromVCard;
 use App\Models\Account\ImportJob;
 use App\Models\Account\Invitation;
-use App\Services\User\EmailChange;
 use App\Exceptions\StripeException;
 use App\Http\Requests\ImportsRequest;
 use Illuminate\Http\RedirectResponse;
@@ -26,6 +25,7 @@ use App\Http\Requests\InvitationRequest;
 use App\Services\Contact\Tag\DestroyTag;
 use App\Services\Account\Settings\ResetAccount;
 use App\Services\Account\Settings\DestroyAccount;
+use App\Services\Account\Settings\UpdateUserSettings;
 use PragmaRX\Google2FALaravel\Facade as Google2FA;
 use App\Http\Resources\Contact\ContactShort as ContactResource;
 use App\Http\Resources\Settings\WebauthnKey\WebauthnKey as WebauthnKeyResource;
@@ -92,34 +92,21 @@ class SettingsController extends Controller
     {
         $user = $request->user();
 
-        $user->update(
-            $request->only([
-                'first_name',
-                'last_name',
-                'timezone',
-                'locale',
-                'currency_id',
-                'name_order',
-                'fluid_container',
-                'temperature_scale',
-            ])
-        );
-
-        if ($user->email !== $request->input('email')) {
-            app(EmailChange::class)->execute([
-                'account_id' => $user->account_id,
-                'email' => $request->input('email'),
-                'user_id' => $user->id,
-            ]);
-        }
-
-        if (! AccountHelper::hasLimitations($user->account) && $request->input('me_contact_id')) {
-            $user->me_contact_id = $request->input('me_contact_id');
-            $user->save();
-        }
-
-        $user->account->default_time_reminder_is_sent = $request->input('reminder_time');
-        $user->account->save();
+        app(UpdateUserSettings::class)->execute([
+            'account_id' => $user->account_id,
+            'user_id' => $user->id,
+            'first_name' => $request->input('first_name'),
+            'last_name' => $request->input('last_name'),
+            'email' => $request->input('email'),
+            'timezone' => $request->input('timezone'),
+            'locale' => $request->input('locale'),
+            'currency_id' => $request->input('currency_id'),
+            'name_order' => $request->input('name_order'),
+            'fluid_container' => $request->input('fluid_container'),
+            'temperature_scale' => $request->input('temperature_scale'),
+            'reminder_time' => $request->input('reminder_time'),
+            'me_contact_id' => $request->input('me_contact_id'),
+        ]);
 
         return redirect()->route('settings.index')
             ->with('status', trans('settings.settings_success', [], $request['locale']));

--- a/app/Listeners/LoginListener.php
+++ b/app/Listeners/LoginListener.php
@@ -7,7 +7,7 @@ use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Auth;
 use LaravelWebauthn\Facades\Webauthn;
 use LaravelWebauthn\Events\WebauthnLogin;
-use App\Http\Controllers\Auth\Validate2faController;
+use PragmaRX\Google2FALaravel\Facade as Google2FA;
 use PragmaRX\Google2FALaravel\Events\LoginSucceeded;
 use Illuminate\Contracts\Auth\Authenticatable as User;
 
@@ -93,7 +93,8 @@ class LoginListener
     private function registerGoogle2fa(User $user)
     {
         if (config('google2fa.enabled') && ! empty($user->google2fa_secret)) {
-            Validate2faController::loginCallback();
+            app('pragmarx.google2fa')->setStateless(false);
+            Google2FA::login();
         }
     }
 

--- a/app/Services/Account/Settings/UpdateUserSettings.php
+++ b/app/Services/Account/Settings/UpdateUserSettings.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\Account\Settings;
+
+use App\Helpers\AccountHelper;
+use App\Models\User\User;
+use App\Services\BaseService;
+use App\Services\User\EmailChange;
+use Illuminate\Validation\Rule;
+
+class UpdateUserSettings extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'account_id' => 'required|integer|exists:accounts,id',
+            'user_id' => 'required|integer',
+            'first_name' => 'required|max:255',
+            'last_name' => 'required|max:255',
+            'email' => 'required|email|max:255',
+            'timezone' => 'required|string',
+            'locale' => 'required|string',
+            'currency_id' => 'required|int|exists:currencies,id',
+            'name_order' => 'required|string',
+            'fluid_container' => 'required|bool',
+            'temperature_scale' => [
+                'required',
+                'string',
+                Rule::in(['fahrenheit', 'celsius']),
+            ],
+            'reminder_time' => 'required|integer|min:0|max:23',
+            'me_contact_id' => 'nullable|integer',
+        ];
+    }
+
+    /**
+     * Update user-level settings (profile, locale, currency, reminders) and
+     * the account's default reminder time. Delegates email changes to
+     * EmailChange so the double-opt-in flow stays in one place.
+     *
+     * @param  array  $data
+     * @return User
+     */
+    public function execute(array $data): User
+    {
+        $this->validate($data);
+
+        /** @var User */
+        $user = User::where('account_id', $data['account_id'])
+            ->findOrFail($data['user_id']);
+
+        $user->update([
+            'first_name' => $data['first_name'],
+            'last_name' => $data['last_name'],
+            'timezone' => $data['timezone'],
+            'locale' => $data['locale'],
+            'currency_id' => $data['currency_id'],
+            'name_order' => $data['name_order'],
+            'fluid_container' => $data['fluid_container'],
+            'temperature_scale' => $data['temperature_scale'],
+        ]);
+
+        if ($user->email !== $data['email']) {
+            app(EmailChange::class)->execute([
+                'account_id' => $user->account_id,
+                'email' => $data['email'],
+                'user_id' => $user->id,
+            ]);
+        }
+
+        if (! AccountHelper::hasLimitations($user->account) && ! empty($data['me_contact_id'])) {
+            $user->me_contact_id = $data['me_contact_id'];
+            $user->save();
+        }
+
+        $user->account->default_time_reminder_is_sent = $data['reminder_time'];
+        $user->account->save();
+
+        return $user;
+    }
+}

--- a/tests/Unit/Services/Account/Settings/UpdateUserSettingsTest.php
+++ b/tests/Unit/Services/Account/Settings/UpdateUserSettingsTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\Services\Account\Settings;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+use App\Models\User\User;
+use App\Models\Account\Account;
+use App\Models\Contact\Contact;
+use Illuminate\Validation\ValidationException;
+use App\Services\Account\Settings\UpdateUserSettings;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+class UpdateUserSettingsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_updates_user_settings()
+    {
+        NotificationFacade::fake();
+        config(['monica.requires_subscription' => false]);
+
+        $user = factory(User::class)->create([
+            'first_name' => 'Old',
+            'last_name' => 'Name',
+            'timezone' => 'UTC',
+            'locale' => 'en',
+            'name_order' => 'firstname_lastname',
+        ]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $request = $this->validRequest($user, [
+            'first_name' => 'New',
+            'last_name' => 'Person',
+            'timezone' => 'Europe/Berlin',
+            'me_contact_id' => $contact->id,
+            'reminder_time' => 9,
+        ]);
+
+        $result = app(UpdateUserSettings::class)->execute($request);
+
+        $this->assertInstanceOf(User::class, $result);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'first_name' => 'New',
+            'last_name' => 'Person',
+            'timezone' => 'Europe/Berlin',
+            'me_contact_id' => $contact->id,
+        ]);
+
+        $this->assertDatabaseHas('accounts', [
+            'id' => $user->account_id,
+            'default_time_reminder_is_sent' => 9,
+        ]);
+    }
+
+    #[Test]
+    public function it_fails_if_wrong_parameters_are_given()
+    {
+        $this->expectException(ValidationException::class);
+
+        app(UpdateUserSettings::class)->execute([
+            'first_name' => 'New',
+        ]);
+    }
+
+    #[Test]
+    public function it_throws_an_exception_if_user_is_not_linked_to_account()
+    {
+        $account = factory(Account::class)->create();
+        $user = factory(User::class)->create();
+
+        $request = $this->validRequest($user, [
+            'account_id' => $account->id,
+        ]);
+
+        $this->expectException(ModelNotFoundException::class);
+
+        app(UpdateUserSettings::class)->execute($request);
+    }
+
+    #[Test]
+    public function it_calls_email_change_when_email_differs()
+    {
+        NotificationFacade::fake();
+        config(['monica.signup_double_optin' => false]);
+
+        $user = factory(User::class)->create([
+            'email' => 'old@example.com',
+        ]);
+
+        $request = $this->validRequest($user, [
+            'email' => 'new@example.com',
+        ]);
+
+        app(UpdateUserSettings::class)->execute($request);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'email' => 'new@example.com',
+        ]);
+    }
+
+    #[Test]
+    public function it_does_not_update_me_contact_id_when_account_is_limited()
+    {
+        NotificationFacade::fake();
+        // Force AccountHelper::hasLimitations() to return true: subscription required,
+        // account is not subscribed, and not on free-paid-access plan (factory default).
+        config(['monica.requires_subscription' => true]);
+
+        $user = factory(User::class)->create([
+            'me_contact_id' => null,
+        ]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $request = $this->validRequest($user, [
+            'me_contact_id' => $contact->id,
+        ]);
+
+        app(UpdateUserSettings::class)->execute($request);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'me_contact_id' => null,
+        ]);
+    }
+
+    /**
+     * Build a fully-populated request payload, overridable per-test.
+     */
+    private function validRequest(User $user, array $overrides = []): array
+    {
+        return array_merge([
+            'account_id' => $user->account_id,
+            'user_id' => $user->id,
+            'first_name' => $user->first_name ?? 'First',
+            'last_name' => $user->last_name ?? 'Last',
+            'email' => $user->email,
+            'timezone' => $user->timezone ?? 'UTC',
+            'locale' => $user->locale ?? 'en',
+            'currency_id' => $user->currency_id,
+            'name_order' => $user->name_order ?? 'firstname_lastname',
+            'fluid_container' => true,
+            'temperature_scale' => 'celsius',
+            'reminder_time' => 8,
+            'me_contact_id' => null,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary

Opens the internal-modernization track for this fork. Two changes bundled:

1. **Posture update** (`README.md`, `CLAUDE.md`): drops the "no architectural refactors" constraint. New posture stays "no new features, no UI redesigns, no full-SPA conversion" but explicitly greenlights Composition API conversion, TypeScript on the frontend, Bootstrap 4 + jQuery removal, and service-layer cleanup.
2. **Service-layer cleanup** identified by the modernization audit:
   - `SettingsController::save()` — 30 lines of inline conditional logic (basic user update, conditional `EmailChange`, limited-account `me_contact_id` check, account default reminder) → extracted to `App\Services\Account\Settings\UpdateUserSettings` following the BaseService pattern. Controller is now a translator: delegate to service + redirect.
   - `LoginListener::registerGoogle2fa()` called `Validate2faController::loginCallback()` statically (a Listener → Controller dependency). The "callback" was 2 lines of `pragmarx/google2fa` facade work. The audit recommended extracting to a new Auth service, but the sibling `registerWebauthn()` in the same listener already calls `Webauthn::forceAuthenticate()` directly. Mirrored that pattern: inlined the 2 lines, dropped the Controller import. `loginCallback()` removed from the controller; `Validate2faController` is now just its HTTP handler.

Net code change: **−11 lines** across the modified files.

## Test plan

- [x] `docker exec monica-app-1 vendor/bin/phpunit --filter UpdateUserSettingsTest` — 5 tests, 7 assertions, OK
- [x] `docker exec monica-app-1 vendor/bin/phpunit --filter 'EmailChangeTest|SettingsTest'` (downstream regression) — 15 tests, 33 assertions, OK
- [x] `docker exec monica-app-1 vendor/bin/phpstan analyse` on the 5 touched files — no errors
- [ ] CI full suite green
- [ ] Manual smoke test against `/settings/save` — the route itself has no feature-test coverage; the new service unit test exercises the same logic but doesn't go through the HTTP route. Worth a one-pass click-through before merge.

## Risks & notes

- The `LoginListener` change diverges from the audit's literal recommendation ("extract to Auth service") in favour of matching the sibling `registerWebauthn()` facade-call pattern. Judgement call — happy to refactor into an explicit service if reviewers prefer.
- `UpdateUserSettings` re-implements the controller's exact branch order, including the pre-existing behaviour of skipping the `me_contact_id` update when the account is limited. No behavioural change intended; service unit test covers both branches.
- Service validation rules are stricter than `SettingsRequest` only in that `account_id` + `user_id` are required (they come from `$request->user()` in the controller). The `unique:users,email,…` clause from `SettingsRequest` is intentionally NOT duplicated on the service — uniqueness is enforced by the downstream `EmailChange` service's own `unique:users` rule, gated by the "email differs" guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
