### PR TITLE
refactor(eslint,test): vue3 preset + typed mountModal helper

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,9 +4,12 @@ import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
 
 export default [
-  // plugin-vue v9's `vue/recommended` resolved to vue2 rules; v10's `flat/recommended`
-  // is Vue 3-oriented. Use `flat/vue2-recommended` explicitly since we're on Vue 2.
-  ...pluginVue.configs['flat/vue2-recommended'],
+  // Vue 3 (#730 cutover). plugin-vue v10's `flat/recommended` is Vue 3-oriented;
+  // `flat/vue2-recommended` was the bridge preset during the migration and is
+  // now wrong for our codebase. Rules that fired only under the Vue 2 preset
+  // (or that we wanted to skip during the dep-upgrade sweep) are individually
+  // overridden in the rules block below.
+  ...pluginVue.configs['flat/recommended'],
   // Register @typescript-eslint as a plugin (no rules enabled) so that
   // existing `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
   // comments resolve. Without the plugin loaded, those rule names produce a

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -43,7 +43,7 @@
 
 
       <!-- How was your day -->
-      <journal-rate-day @hasRated="hasRated" />
+      <journal-rate-day @has-rated="hasRated" />
 
       <!-- Logs -->
       <div v-if="journalEntries.data" v-cy-name="'journal-entries-body'" v-cy-items="journalEntries.data.map(j => j.id)"
@@ -53,7 +53,7 @@
              v-cy-name="'entry-body-' + journalEntry.id" class="cf"
         >
           <journal-content-rate v-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Day'"
-                                :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry"
+                                :journal-entry="journalEntry" @delete-journal-entry="deleteJournalEntry"
           />
 
           <journal-content-activity v-else-if="journalEntry.journalable_type === 'App\\Models\\Account\\Activity'"
@@ -61,7 +61,7 @@
           />
 
           <journal-content-entry v-else-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Entry'"
-                                 :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry"
+                                 :journal-entry="journalEntry" @delete-journal-entry="deleteJournalEntry"
           />
         </div>
       </div>

--- a/resources/js/components/people/activity/CreateActivity.vue
+++ b/resources/js/components/people/activity/CreateActivity.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <!-- LOG AN ACTIVITY -->
+    <!-- Legacy Vue 2 idiom: <transition> wraps an always-rendered child so the
+         transition CSS never fires. Cleanup would alter UI behaviour (suddenly
+         animate on mount) — out of scope for the fork's "no UI changes" rule. -->
     <transition name="fade">
+      <!-- eslint-disable-next-line vue/require-toggle-inside-transition -->
       <div class="ba br3 mb3 pa3 b--black-40">
         <div class="dt dt--fixed pb3 mb3 mb0-ns bb b--gray-monica">
           <!-- SUMMARY -->
@@ -61,7 +65,7 @@
             :rows="4"
             :title="t('people.activities_summary')"
             :placeholder="t('people.conversation_add_content')"
-            @contentChange="updateDescription($event)"
+            @content-change="updateDescription($event)"
           />
           <p class="f6">
             {{ t('app.markdown_description') }} <a href="https://guides.github.com/features/mastering-markdown/" rel="noopener noreferrer" target="_blank">

--- a/resources/js/components/people/calls/PhoneCallList.vue
+++ b/resources/js/components/people/calls/PhoneCallList.vue
@@ -135,7 +135,7 @@
               :label="t('people.modal_call_comment')"
               :rows="4"
               iclass="br2 f5 w-100 ba b--black-40 pa2 outline-0"
-              @contentChange="updateEditCallContent($event)"
+              @content-change="updateEditCallContent($event)"
             />
             <p class="f6">
               {{ t('app.markdown_description') }}

--- a/resources/js/components/people/conversation/Conversation.vue
+++ b/resources/js/components/people/conversation/Conversation.vue
@@ -39,8 +39,8 @@
           :uid="message.uid"
           :participant-name="participantName"
           :display-trash="displayTrash"
-          @updateAuthor="updateAuthor($event, message)"
-          @deleteMessage="deleteMessage($event)"
+          @update-author="updateAuthor($event, message)"
+          @delete-message="deleteMessage($event)"
         />
       </div>
       <p class="tc mb0">

--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -7,7 +7,11 @@
 <template>
   <div>
     <!-- Add a gift -->
+    <!-- Legacy Vue 2 idiom: <transition> wraps an always-rendered child so the
+         transition CSS never fires. Cleanup would alter UI behaviour (suddenly
+         animate on mount) — out of scope for the fork's "no UI changes" rule. -->
     <transition name="fade">
+      <!-- eslint-disable-next-line vue/require-toggle-inside-transition -->
       <div class="ba br3 mb3 pa3 b--black-40">
         <div class="pb3 mb3 flex-ns b--gray-monica">
           <!-- STATUS -->

--- a/resources/js/components/people/lifeevent/CreateLifeEvent.vue
+++ b/resources/js/components/people/lifeevent/CreateLifeEvent.vue
@@ -119,7 +119,7 @@
           </p>
         </div>
 
-        <create-default-life-event @contentChange="updateLifeEventContent($event)" />
+        <create-default-life-event @content-change="updateLifeEventContent($event)" />
 
         <!-- YEARLY REMINDER -->
         <div class="ph4 pv3 mb3 mb0-ns bb b--gray-monica">

--- a/resources/js/components/people/lifeevent/LifeEventList.vue
+++ b/resources/js/components/people/lifeevent/LifeEventList.vue
@@ -491,8 +491,8 @@
                        :months="months"
                        :days="days"
                        :years="years"
-                       @updateLifeEventTimeline="updateLifeEventsList($event)"
-                       @dismissModal="showAdd = false"
+                       @update-life-event-timeline="updateLifeEventsList($event)"
+                       @dismiss-modal="showAdd = false"
     />
 
     <!-- LISTING OF LIFE EVENTS -->

--- a/resources/js/components/people/photo/PhotoList.vue
+++ b/resources/js/components/people/photo/PhotoList.vue
@@ -85,7 +85,12 @@
     </div>
 
     <!-- MODAL ZOOM PHOTO -->
+    <!-- Legacy Vue 2 idiom: v-if is on <transition> rather than the inner
+         element, so the transition CSS never fires (the wrapper itself
+         mounts/unmounts with showModal). Moving v-if onto .modal-mask would
+         make the modal fade in/out — that's a UI change, out of scope here. -->
     <transition v-if="showModal" name="modal">
+      <!-- eslint-disable-next-line vue/require-toggle-inside-transition -->
       <div class="modal-mask">
         <div class="modal-wrapper">
           <div class="modal-container">

--- a/resources/js/components/settings/genders/CreateModal.spec.ts
+++ b/resources/js/components/settings/genders/CreateModal.spec.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import CreateModal from './CreateModal.vue';
 
 const genderTypes = [{ id: 'M', name: 'Male', type: 'M' }, { id: 'F', name: 'Female', type: 'F' }];
-const defaultGenderType = { id: 'M', name: 'Male', type: 'M' };
+const defaultGenderType = { id: 'M', name: 'Male', type: 'M', isDefault: false };
 
 describe('genders/CreateModal', () => {
   it('initializes form.type from the defaultGenderType prop', () => {
-    const w = mountModal(CreateModal, { props: { modelValue: true, genderTypes, defaultGenderType } });
+    const w = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, genderTypes, defaultGenderType } });
     expect(w.vm.form.type).toBe('M');
   });
 
   it('store() POSTs to settings/personalization/genders, emits saved + update:modelValue=false', async () => {
-    const w = mountModal(CreateModal, { props: { modelValue: true, genderTypes, defaultGenderType } });
+    const w = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, genderTypes, defaultGenderType } });
     w.vm.form.name = 'Test gender';
     w.vm.form.type = 'F';
     w.vm.form.isDefault = true;
@@ -26,7 +27,7 @@ describe('genders/CreateModal', () => {
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved', () => {
-    const w = mountModal(CreateModal, { props: { modelValue: true, genderTypes, defaultGenderType } });
+    const w = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, genderTypes, defaultGenderType } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/genders/DeleteModal.spec.ts
+++ b/resources/js/components/settings/genders/DeleteModal.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import DeleteModal from './DeleteModal.vue';
 
 const allGenders = [
@@ -14,7 +15,7 @@ const isDefault = { id: 2, name: 'Woman', isDefault: true, numberOfContacts: 0 }
 
 describe('genders/DeleteModal', () => {
   it('initializes form from the gender prop and starts with empty errorMessage', () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: hasContacts, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: hasContacts, genders: allGenders } });
     expect(w.vm.form.id).toBe('1');
     expect(w.vm.form.name).toBe('Man');
     expect(w.vm.form.isDefault).toBe(false);
@@ -23,7 +24,7 @@ describe('genders/DeleteModal', () => {
   });
 
   it('trash() (no contacts, not default) DELETEs and emits saved + close', async () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: simpleDeletable, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: simpleDeletable, genders: allGenders } });
     await w.vm.trash();
     expect(axios.delete).toHaveBeenCalledWith('settings/personalization/genders/3');
     expect(w.emitted('saved')).toBeTruthy();
@@ -31,7 +32,7 @@ describe('genders/DeleteModal', () => {
   });
 
   it('trashAndReplace() DELETEs with replaceby and emits saved + close', async () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: hasContacts, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: hasContacts, genders: allGenders } });
     w.vm.form.newId = 2;
     await w.vm.trashAndReplace();
     expect(axios.delete).toHaveBeenCalledWith('settings/personalization/genders/1/replaceby/2');
@@ -41,7 +42,7 @@ describe('genders/DeleteModal', () => {
 
   it('trashAndReplace() with structured error sets errorMessage from response.data.message', async () => {
     (axios.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { data: { message: 'cannot delete' } } });
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: hasContacts, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: hasContacts, genders: allGenders } });
     w.vm.form.newId = 2;
     await w.vm.trashAndReplace();
     expect(w.vm.errorMessage).toBe('cannot delete');
@@ -50,7 +51,7 @@ describe('genders/DeleteModal', () => {
 
   it('trashAndReplace() with non-object error falls back to app.error_try_again', async () => {
     (axios.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { data: 'oops' } });
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: isDefault, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: isDefault, genders: allGenders } });
     w.vm.form.newId = 3;
     await w.vm.trashAndReplace();
     expect(w.vm.errorMessage).toBe('app.error_try_again');
@@ -58,7 +59,7 @@ describe('genders/DeleteModal', () => {
   });
 
   it('cancel() emits update:modelValue=false (no saved)', () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, gender: simpleDeletable, genders: allGenders } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, gender: simpleDeletable, genders: allGenders } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/genders/EditModal.spec.ts
+++ b/resources/js/components/settings/genders/EditModal.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import EditModal from './EditModal.vue';
 
 const genderTypes = [{ id: 'M', name: 'Male', type: 'M' }, { id: 'F', name: 'Female', type: 'F' }];
@@ -8,13 +9,13 @@ const bobGender = { id: 11, name: 'Bob', type: 'M', isDefault: true };
 
 describe('genders/EditModal', () => {
   it('initializes form from the gender prop (different rows → different state)', () => {
-    const a = mountModal(EditModal, { props: { modelValue: true, gender: aliceGender, genderTypes } });
+    const a = mount(EditModal, { ...modalMountOptions, props: { modelValue: true, gender: aliceGender, genderTypes } });
     expect(a.vm.form.id).toBe('7');
     expect(a.vm.form.name).toBe('Alice');
     expect(a.vm.form.type).toBe('F');
     expect(a.vm.form.isDefault).toBe(false);
 
-    const b = mountModal(EditModal, { props: { modelValue: true, gender: bobGender, genderTypes } });
+    const b = mount(EditModal, { ...modalMountOptions, props: { modelValue: true, gender: bobGender, genderTypes } });
     expect(b.vm.form.id).toBe('11');
     expect(b.vm.form.name).toBe('Bob');
     expect(b.vm.form.type).toBe('M');
@@ -22,7 +23,7 @@ describe('genders/EditModal', () => {
   });
 
   it('update() PUTs to settings/personalization/genders/{id}, emits saved + update:modelValue=false', async () => {
-    const w = mountModal(EditModal, { props: { modelValue: true, gender: aliceGender, genderTypes } });
+    const w = mount(EditModal, { ...modalMountOptions, props: { modelValue: true, gender: aliceGender, genderTypes } });
     w.vm.form.name = 'Alice II';
     await w.vm.update();
     expect(axios.put).toHaveBeenCalledWith(
@@ -34,7 +35,7 @@ describe('genders/EditModal', () => {
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved', () => {
-    const w = mountModal(EditModal, { props: { modelValue: true, gender: aliceGender, genderTypes } });
+    const w = mount(EditModal, { ...modalMountOptions, props: { modelValue: true, gender: aliceGender, genderTypes } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/genders/SetDefaultModal.spec.ts
+++ b/resources/js/components/settings/genders/SetDefaultModal.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import SetDefaultModal from './SetDefaultModal.vue';
 
 const genders = [
@@ -9,12 +10,12 @@ const genders = [
 
 describe('genders/SetDefaultModal', () => {
   it('initializes selectedId from the defaultId prop', () => {
-    const w = mountModal(SetDefaultModal, { props: { modelValue: true, genders, defaultId: 2 } });
+    const w = mount(SetDefaultModal, { ...modalMountOptions, props: { modelValue: true, genders, defaultId: 2 } });
     expect(w.vm.selectedId).toBe(2);
   });
 
   it('save() PUTs to settings/personalization/genders/default/{id}, emits saved + close', async () => {
-    const w = mountModal(SetDefaultModal, { props: { modelValue: true, genders, defaultId: 2 } });
+    const w = mount(SetDefaultModal, { ...modalMountOptions, props: { modelValue: true, genders, defaultId: 2 } });
     w.vm.selectedId = 1;
     await w.vm.save();
     expect(axios.put).toHaveBeenCalledWith('settings/personalization/genders/default/1');
@@ -23,7 +24,7 @@ describe('genders/SetDefaultModal', () => {
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved', () => {
-    const w = mountModal(SetDefaultModal, { props: { modelValue: true, genders, defaultId: 2 } });
+    const w = mount(SetDefaultModal, { ...modalMountOptions, props: { modelValue: true, genders, defaultId: 2 } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/life-event-types/CreateModal.spec.ts
+++ b/resources/js/components/settings/life-event-types/CreateModal.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import CreateModal from './CreateModal.vue';
 
 const familyCategory = { id: 4, default_life_event_category_key: 'family' };
@@ -7,16 +8,16 @@ const workCategory = { id: 7, default_life_event_category_key: 'work_education' 
 
 describe('life-event-types/CreateModal', () => {
   it('initializes form.life_event_category_id from the category prop (different categories → different state)', () => {
-    const a = mountModal(CreateModal, { props: { modelValue: true, category: familyCategory } });
+    const a = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, category: familyCategory } });
     expect(a.vm.form.life_event_category_id).toBe(4);
     expect(a.vm.form.name).toBe('');
 
-    const b = mountModal(CreateModal, { props: { modelValue: true, category: workCategory } });
+    const b = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, category: workCategory } });
     expect(b.vm.form.life_event_category_id).toBe(7);
   });
 
   it('store() POSTs to settings/personalization/lifeeventtypes, emits saved + update:modelValue=false', async () => {
-    const w = mountModal(CreateModal, { props: { modelValue: true, category: familyCategory } });
+    const w = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, category: familyCategory } });
     w.vm.form.name = 'New milestone';
     await w.vm.store();
     expect(axios.post).toHaveBeenCalledWith(
@@ -28,7 +29,7 @@ describe('life-event-types/CreateModal', () => {
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved', () => {
-    const w = mountModal(CreateModal, { props: { modelValue: true, category: familyCategory } });
+    const w = mount(CreateModal, { ...modalMountOptions, props: { modelValue: true, category: familyCategory } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/life-event-types/DeleteModal.spec.ts
+++ b/resources/js/components/settings/life-event-types/DeleteModal.spec.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import DeleteModal from './DeleteModal.vue';
 
 const aType = { id: 9, name: 'Anniversary' };
 
 describe('life-event-types/DeleteModal', () => {
   it('initializes form.id from the type prop and starts with empty errorMessage', () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, type: aType } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, type: aType } });
     expect(w.vm.form.id).toBe(9);
     expect(w.vm.errorMessage).toBe('');
   });
 
   it('destroy() DELETEs to settings/personalization/lifeeventtypes/{id}, emits saved + update:modelValue=false', async () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, type: aType } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, type: aType } });
     await w.vm.destroy();
     expect(axios.delete).toHaveBeenCalledWith('settings/personalization/lifeeventtypes/9');
     expect(w.emitted('saved')).toBeTruthy();
@@ -21,14 +22,14 @@ describe('life-event-types/DeleteModal', () => {
 
   it('destroy() with structured error sets errorMessage from response.data.message and does not emit saved', async () => {
     (axios.delete as ReturnType<typeof vi.fn>).mockRejectedValueOnce({ response: { data: { message: 'cannot delete' } } });
-    const w = mountModal(DeleteModal, { props: { modelValue: true, type: aType } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, type: aType } });
     await w.vm.destroy();
     expect(w.vm.errorMessage).toBe('cannot delete');
     expect(w.emitted('saved')).toBeFalsy();
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved or touch errorMessage', () => {
-    const w = mountModal(DeleteModal, { props: { modelValue: true, type: aType } });
+    const w = mount(DeleteModal, { ...modalMountOptions, props: { modelValue: true, type: aType } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/resources/js/components/settings/life-event-types/UpdateModal.spec.ts
+++ b/resources/js/components/settings/life-event-types/UpdateModal.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mountModal } from '../../../../../tests/js/helpers';
+import { mount } from '@vue/test-utils';
+import { modalMountOptions } from '../../../../../tests/js/helpers';
 import UpdateModal from './UpdateModal.vue';
 
 const customType = { id: 12, name: 'Anniversary', default_life_event_type_key: 'birthday' };
@@ -7,19 +8,19 @@ const builtinType = { id: 5, name: '', default_life_event_type_key: 'birthday' }
 
 describe('life-event-types/UpdateModal', () => {
   it('initializes form from the type and categoryId props (custom name)', () => {
-    const w = mountModal(UpdateModal, { props: { modelValue: true, type: customType, categoryId: 3 } });
+    const w = mount(UpdateModal, { ...modalMountOptions, props: { modelValue: true, type: customType, categoryId: 3 } });
     expect(w.vm.form.id).toBe(12);
     expect(w.vm.form.name).toBe('Anniversary');
     expect(w.vm.form.life_event_category_id).toBe(3);
   });
 
   it('falls back to the i18n sentence key when type.name is empty', () => {
-    const w = mountModal(UpdateModal, { props: { modelValue: true, type: builtinType, categoryId: 3 } });
+    const w = mount(UpdateModal, { ...modalMountOptions, props: { modelValue: true, type: builtinType, categoryId: 3 } });
     expect(w.vm.form.name).toBe('people.life_event_sentence_birthday');
   });
 
   it('update() PUTs to settings/personalization/lifeeventtypes/{id}, emits saved + update:modelValue=false', async () => {
-    const w = mountModal(UpdateModal, { props: { modelValue: true, type: customType, categoryId: 3 } });
+    const w = mount(UpdateModal, { ...modalMountOptions, props: { modelValue: true, type: customType, categoryId: 3 } });
     w.vm.form.name = 'Anniversary II';
     await w.vm.update();
     expect(axios.put).toHaveBeenCalledWith(
@@ -31,7 +32,7 @@ describe('life-event-types/UpdateModal', () => {
   });
 
   it('cancel() emits update:modelValue=false and does not emit saved', () => {
-    const w = mountModal(UpdateModal, { props: { modelValue: true, type: customType, categoryId: 3 } });
+    const w = mount(UpdateModal, { ...modalMountOptions, props: { modelValue: true, type: customType, categoryId: 3 } });
     w.vm.cancel();
     expect(w.emitted('update:modelValue')?.flat()).toContain(false);
     expect(w.emitted('saved')).toBeFalsy();

--- a/tests/js/helpers.ts
+++ b/tests/js/helpers.ts
@@ -1,6 +1,5 @@
-import { mount, type MountingOptions, type VueWrapper } from '@vue/test-utils';
+import { type MountingOptions } from '@vue/test-utils';
 import { vi } from 'vitest';
-import type { Component } from 'vue';
 
 // vue-i18n's useI18n() is called inside setup(). Stub it module-wide
 // in tests that don't need real translations.
@@ -15,30 +14,29 @@ vi.mock('vue-i18n', () => ({
 //   - form atom stubs avoid mounting their full templates.
 //   - useI18n's t() is stubbed to identity so assertions against keys work.
 //
-// Returns `VueWrapper<any>` so tests can poke at component-exposed state
-// (`w.vm.form.type`, `w.vm.store()`, etc.) without re-declaring each modal's
-// `defineExpose` shape at every call site.
-export function mountModal(
-  component: Component,
-  options: MountingOptions<Record<string, unknown>> = {},
-): VueWrapper<any> {
-  return mount(component, {
-    global: {
-      stubs: {
-        'monica-modal': {
-          template: '<div class="stub-monica-modal" :data-shown="modelValue"><slot /><slot name="button" /></div>',
-          props: ['modelValue', 'title', 'blocking'],
-          emits: ['update:modelValue'],
-        },
-        'form-input': true,
-        'form-select': true,
-        'form-toggle': true,
+// Exported as a plain options object — spread it into `mount(Component, ...)`
+// at the call site rather than calling a wrapper helper. That preserves
+// vue-test-utils' overload resolution, so `wrapper.vm` carries the SFC's
+// `defineExpose` types. A rename inside a modal's `defineExpose` then breaks
+// the spec at typecheck time instead of silently passing on `any`.
+//
+// If a spec needs to add to `global` (extra stubs, custom mocks), it must
+// either spread inside the global key or override the whole thing — there's
+// no deep-merge here, only object spread.
+export const modalMountOptions = {
+  global: {
+    stubs: {
+      'monica-modal': {
+        template: '<div class="stub-monica-modal" :data-shown="modelValue"><slot /><slot name="button" /></div>',
+        props: ['modelValue', 'title', 'blocking'],
+        emits: ['update:modelValue'],
       },
-      mocks: {
-        $t: (k: string) => k,
-      },
-      ...options.global,
+      'form-input': true,
+      'form-select': true,
+      'form-toggle': true,
     },
-    ...options,
-  });
-}
+    mocks: {
+      $t: (k: string) => k,
+    },
+  },
+} satisfies MountingOptions<Record<string, unknown>>;


### PR DESCRIPTION
## Summary

Two cleanup items observed during the lint-coverage work in #813.

### 1. ESLint preset: `flat/vue2-recommended` → `flat/recommended`

We've been on Vue 3 since #730. The lint config was still using plugin-vue's Vue 2 preset because the migration left it behind. Switching to `flat/recommended` surfaced:

- **10 hyphenation warnings** (`vue/v-on-event-hyphenation`) — `@camelCaseEvent` in template listeners. Vue 3 normalises both kebab and camel directions at parse time, so auto-fix is safe. Applied across `JournalList`, `Conversation`, `LifeEventList`, `CreateActivity`, `CreateLifeEvent`, `PhoneCallList`.
- **3 transition errors** (`vue/require-toggle-inside-transition`) — real Vue 2 → Vue 3 migration artefacts:
  - `CreateActivity.vue` and `CreateGift.vue` wrap an always-rendered child in `<transition>`, so the fade-in CSS never fires.
  - `PhotoList.vue` puts `v-if="showModal"` on `<transition>` itself instead of the child, so the modal pops in/out without the fade.

  Fixing any of these would alter user-facing UI behaviour (animations would suddenly start firing) — out of scope per the fork's "no UI changes" constraint. Suppressed per-site with `eslint-disable-next-line` + a rationale comment so the rule still fires for any *new* violations.

### 2. Typed `mountModal` helper

The previous `mountModal()` wrapper returned `VueWrapper<any>`, so a rename in any modal SFC's `defineExpose` would silently keep the spec passing. The 7 modal spec files were typecheck-blind to their components.

Split the helper:

- `tests/js/helpers.ts` now exports a plain `modalMountOptions` object (the same stubs + mocks config it had before).
- Each spec calls `mount(Component, { ...modalMountOptions, props: {...} })` directly. vue-test-utils' overload resolves against the actual SFC type, so `w.vm.form.type`, `w.vm.cancel()`, `w.vm.store()` etc. are now checked against the component's exposed shape.

This **immediately caught a real defect**: `defaultGenderType = { id: 'M', name: 'Male', type: 'M' }` in `genders/CreateModal.spec.ts` was missing the `isDefault: boolean` field that the SFC's `Gender` interface requires. The `any` return type from `mountModal` had been hiding the mismatch since #810 landed. Fixed alongside.

## History

Replaces #812 — that PR was auto-closed by GitHub when its base branch (`chore/lint-typescript-files`, the now-merged #813) was deleted. Same content, rebased onto fresh `4.x`.

## Test plan

- [x] `yarn lint` — clean (0 errors, 0 warnings)
- [x] `vue-tsc --noEmit` — exit 0
- [x] `yarn test:js` — 108 / 108 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
