### PR TITLE
fix(deps): bump phpseclib/phpseclib 3.0.52 → 3.0.55 (SSRF advisory)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5690,16 +5690,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
+            "version": "3.0.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db9744e6d47e742b1f974e965ad49bdd041105af",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af",
                 "shasum": ""
             },
             "require": {
@@ -5780,7 +5780,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.55"
             },
             "funding": [
                 {
@@ -5796,7 +5796,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-27T07:02:15+00:00"
+            "time": "2026-06-14T23:24:10+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",


### PR DESCRIPTION
## Summary

Bumps `phpseclib/phpseclib` from **3.0.52 → 3.0.55** to clear [GHSA-m557-wrgg-6rp4](https://github.com/advisories/GHSA-m557-wrgg-6rp4) (`PKSA-432p-hv1d-chf7`), an SSRF in X.509 certificate validation reported on 2026-06-16T15:03:58Z.

- **Affected range:** `>=3.0.0,<=3.0.53` (we were on 3.0.52)
- **Fixed in:** 3.0.54 (2026-06-14) and 3.0.55 (2026-06-15)
- **Transitive usage:** pulled by `laravel/passport` (OAuth client + JWT signing) and `laravel/socialite` (OAuth flows). Zero direct call sites in `app/`, `config/`, or `routes/`. Patch-release bump within 3.0.x — no API surface change.

## Why it's urgent

The advisory landed mid-day on 2026-06-16. The `Build Assets` CI job exits on `composer audit`, so every PR opened against `4.x` after that timestamp will fail CI on this unrelated issue. PR #819 (breadcrumb migration) is currently red for exactly this reason.

## Verification

- `composer audit --no-interaction --abandoned=ignore` → `No security vulnerability advisories found.` (locally, against the new lock)
- Lockfile diff: 6 inserts / 6 deletes, scoped to phpseclib only (no transitive churn)
- `composer why phpseclib/phpseclib` → only `laravel/passport` and `laravel/socialite` require it; both pin `^3.0` which 3.0.55 satisfies

## Test plan

- [ ] CI green (specifically `Build Assets` should now pass `composer audit`)
- [ ] Passport-gated `routes/api.php` smokes locally if anyone wants belt-and-braces (JWT issue/verify path is the realistic regression surface)
